### PR TITLE
Fixes #78: Tagged - popping tags correctly

### DIFF
--- a/runtime/common/src/main/kotlin/kotlinx/serialization/Tagged.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/Tagged.kt
@@ -278,8 +278,8 @@ abstract class TaggedInput<T : Any?> : KInput() {
         val r = block()
         if (!flag) {
             popTag()
-            flag = false
         }
+        flag = false
         return r
     }
 

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/MapperTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/MapperTest.kt
@@ -9,7 +9,10 @@ class MapperTest {
     data class Data(val list: List<String>, val property: String)
 
     @Serializable
-    data class NullableData(val nullable: String?, val property: String)
+    data class Recursive(val data: Data, val property: String)
+
+    @Serializable
+    data class NullableData(val nullable: String?, val nullable2: String?, val property: String)
 
     @Test
     fun testListTagStack() {
@@ -23,13 +26,26 @@ class MapperTest {
     }
 
     @Test
+    fun testRecursiveBlockTag() {
+        val recursive = Recursive(Data(listOf("l1"), "property"), "string")
+
+        val map = Mapper.map(recursive)
+        val unmap = Mapper.unmap<Recursive>(map)
+
+        assertEquals(recursive.data.list, unmap.data.list)
+        assertEquals(recursive.data.property, unmap.data.property)
+        assertEquals(recursive.property, unmap.property)
+    }
+
+    @Test
     fun testNullableTagStack() {
-        val data = NullableData(null, "property")
+        val data = NullableData(null, null, "property")
 
         val map = Mapper.mapNullable(data)
         val unmap = Mapper.unmapNullable<NullableData>(map)
 
         assertEquals(data.nullable, unmap.nullable)
+        assertEquals(data.nullable2, unmap.nullable2)
         assertEquals(data.property, unmap.property)
     }
 }

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/MapperTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/MapperTest.kt
@@ -1,0 +1,35 @@
+package kotlinx.serialization
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MapperTest {
+
+    @Serializable
+    data class Data(val list: List<String>, val property: String)
+
+    @Serializable
+    data class NullableData(val nullable: String?, val property: String)
+
+    @Test
+    fun testListTagStack() {
+        val data = Data(listOf("element1"), "property")
+
+        val map = Mapper.map(data)
+        val unmap = Mapper.unmap<Data>(map)
+
+        assertEquals(data.list, unmap.list)
+        assertEquals(data.property, unmap.property)
+    }
+
+    @Test
+    fun testNullableTagStack() {
+        val data = NullableData(null, "property")
+
+        val map = Mapper.mapNullable(data)
+        val unmap = Mapper.unmapNullable<NullableData>(map)
+
+        assertEquals(data.nullable, unmap.nullable)
+        assertEquals(data.property, unmap.property)
+    }
+}


### PR DESCRIPTION
This fixes #78 

Flag has to be reset after each block correctly, as well when tag was already popped allowing block-end of collections to pop collection tag correctly