### PR TITLE
Private class serialization support for JVM

### DIFF
--- a/runtime/jvm/src/main/kotlin/kotlinx/serialization/Serialization.kt
+++ b/runtime/jvm/src/main/kotlin/kotlinx/serialization/Serialization.kt
@@ -35,7 +35,7 @@ actual fun <T: Any, E: T?> ArrayList<E>.toNativeArray(eClass: KClass<T>): Array<
 
 internal fun <T> Class<T>.invokeSerializerGetter(vararg args: KSerializer<Any>): KSerializer<T>? {
     val companion: Any = try {
-        this.getField("Companion").get(null)
+        this.getField("Companion").apply { isAccessible = true }.get(null)
     } catch (e: NoSuchFieldException) {
         return null
     }

--- a/runtime/jvm/src/test/kotlin/kotlinx/serialization/privateclasstest/PrivateDataOutOfKotlinXSerializationPackageTest.kt
+++ b/runtime/jvm/src/test/kotlin/kotlinx/serialization/privateclasstest/PrivateDataOutOfKotlinXSerializationPackageTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.serialization.privateclasstest
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializeFlatTest.Inp
+import kotlinx.serialization.SerializeFlatTest.Out
+import kotlinx.serialization.serializer
+import org.junit.Test
+
+// Serializable data class with private visibility that lays out of serialization library package
+
+@Serializable
+private data class DataPrivate(
+        val value1: String,
+        val value2: Int
+) {
+    companion object
+}
+
+class PrivateClassOutOfSerializationLibraryPackageTest {
+
+    @Test
+    fun testDataPrivate() {
+        val out = Out("privateclasstest.DataPrivate")
+        out.write(DataPrivate::class.serializer(), DataPrivate("s1", 42))
+        out.done()
+
+        val inp = Inp("privateclasstest.DataPrivate")
+        val data = inp.read(DataPrivate::class.serializer())
+        inp.done()
+        assert(data.value1 == "s1" && data.value2 == 42)
+    }
+}


### PR DESCRIPTION
Add support for @Serializable classes that are private and live out of kotlinx.serialization package. In such case the Companion field is not visible and must be set accessible before use.
If not an exception is thrown:

``` 
java.lang.IllegalAccessException: Class kotlinx.serialization.SerializationKt can not access a member of class kotlinx.serialization.privateclasstest.DataPrivate with modifiers "public static final"
        at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:102)
        at java.lang.reflect.AccessibleObject.slowCheckMemberAccess(AccessibleObject.java:296)
        at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:288)
        at java.lang.reflect.Field.get(Field.java:390)
        at kotlinx.serialization.SerializationKt.invokeSerializerGetter(Serialization.kt:38)
        at kotlinx.serialization.SerializationKt.serializer(Serialization.kt:22)
        at kotlinx.serialization.privateclasstest.PrivateClassOutOfSerializationLibraryPackageTest.testDataPrivate(PrivateDataOutOfKotlinXSerializationPackageTest.kt:40)
```