### PR TITLE
Fix ProGuard rules docs for serialization 0.4.1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ to add this to your `proguard-rules.pro`:
     *** Companion;
 }
 -keepclasseswithmembers class com.yourcompany.yourpackage.** { # <-- change package name to your app's
-    kotlinx.serialization.KSerializer serializer();
+    kotlinx.serialization.KSerializer serializer(...);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ to add this to your `proguard-rules.pro`:
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.SerializationKt
 -keep,includedescriptorclasses class com.yourcompany.yourpackage.**$$serializer { *; } # <-- change package name to your app's
+-keepclassmembers class com.yourcompany.yourpackage.** { # <-- change package name to your app's
+    *** Companion;
+}
+-keepclasseswithmembers class com.yourcompany.yourpackage.** { # <-- change package name to your app's
+    kotlinx.serialization.KSerializer serializer();
+}
 ```
 
 You may also want to keep all custom serializers you've defined.


### PR DESCRIPTION
Kotlin Serialization 0.4.1 version on JVM assumes that the @Serializable class has a field with name `Companion` that has a method with name `serializer` (see [Serialization.kt](../tree/v0.4.1/runtime/jvm/src/main/kotlin/kotlinx/serialization/Serialization.kt)). To keep these and its names another ProGuard rules must be applied.