### PR TITLE
Improved performance of JSON.parse/stringify

### DIFF
--- a/runtime/common/src/main/kotlin/kotlinx/serialization/internal/CommonStrings.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/internal/CommonStrings.kt
@@ -16,4 +16,10 @@
 
 package kotlinx.serialization.internal
 
-expect fun CharArray.contentToString(length: Int): String
+/**
+ * Creates a string by concatenating given chars.
+ * Can be more efficient than `joinToString` on some platforms.
+ *
+ * charArrayOf('a','b','c').createString(2) = "ab"
+ */
+expect fun CharArray.createString(length: Int): String

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/internal/CommonStrings.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/internal/CommonStrings.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.serialization.internal
+
+expect fun CharArray.contentToString(length: Int): String

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
@@ -16,12 +16,10 @@
 
 package kotlinx.serialization.json
 
-import kotlinx.io.PrintWriter
-import kotlinx.io.Reader
-import kotlinx.io.StringReader
-import kotlinx.io.StringWriter
+import kotlinx.io.*
 import kotlinx.serialization.*
-import kotlin.reflect.KClass
+import kotlinx.serialization.internal.*
+import kotlin.reflect.*
 
 data class JSON(
         private val unquoted: Boolean = false,
@@ -31,7 +29,6 @@ data class JSON(
         val updateMode: UpdateMode = UpdateMode.OVERWRITE,
         val context: SerialContext? = null
 ) {
-
     fun <T> stringify(saver: KSerialSaver<T>, obj: T): String {
         val sw = StringWriter()
         val output = JsonOutput(Mode.OBJ, Composer(sw))
@@ -42,10 +39,10 @@ data class JSON(
     inline fun <reified T : Any> stringify(obj: T): String = stringify(context.klassSerializer(T::class), obj)
 
     fun <T> parse(loader: KSerialLoader<T>, str: String): T {
-        val parser = Parser(StringReader(str))
+        val parser = Parser(str)
         val input = JsonInput(Mode.OBJ, parser)
         val result = input.read(loader)
-        check(parser.curTc == TC_EOF) { "Shall parse complete string"}
+        check(parser.tc == TC_EOF) { "Shall parse complete string"}
         return result
     }
 
@@ -61,149 +58,9 @@ data class JSON(
         val unquoted = JSON(unquoted = true)
         val indented = JSON(indented = true)
         val nonstrict = JSON(nonstrict = true)
-
-        //================================= implementation =================================
-
-        // special strings
-        private const val NULL = "null"
-
-        // special chars
-        private const val COMMA = ','
-        private const val COLON = ':'
-        private const val BEGIN_OBJ = '{'
-        private const val END_OBJ = '}'
-        private const val BEGIN_LIST = '['
-        private const val END_LIST = ']'
-        private const val STRING = '"'
-        private const val STRING_ESC = '\\'
-
-        private const val INVALID = 0.toChar()
-        private const val UNICODE_ESC = 'u'
-
-        // token classes
-        private const val TC_OTHER: Byte = 0
-        private const val TC_EOF: Byte = 1
-        private const val TC_INVALID: Byte = 2
-        private const val TC_WS: Byte = 3
-        private const val TC_COMMA: Byte = 4
-        private const val TC_COLON: Byte = 5
-        private const val TC_BEGIN_OBJ: Byte = 6
-        private const val TC_END_OBJ: Byte = 7
-        private const val TC_BEGIN_LIST: Byte = 8
-        private const val TC_END_LIST: Byte = 9
-        private const val TC_STRING: Byte = 10
-        private const val TC_STRING_ESC: Byte = 11
-        private const val TC_NULL: Byte = 12
-
-        // mapping from chars to token classes
-        private const val CTC_MAX = 0x7e
-        private const val CTC_OFS = 1
-
-        private val C2TC = ByteArray(CTC_MAX + CTC_OFS)
-
-        fun initC2TC(c : Int, cl: Byte) { C2TC[c + CTC_OFS] = cl }
-        fun initC2TC(c: Char, cl: Byte) {
-            initC2TC(c.toInt(), cl)
-        }
-
-        fun c2tc(c: Int): Byte = if (c < CTC_MAX) C2TC[c + CTC_OFS] else TC_OTHER
-
-        init {
-            initC2TC(-1, TC_EOF)
-            for (i in 0..0x20)
-                initC2TC(i, TC_INVALID)
-            initC2TC(0x09, TC_WS)
-            initC2TC(0x0a, TC_WS)
-            initC2TC(0x0d, TC_WS)
-            initC2TC(0x20, TC_WS)
-            initC2TC(COMMA, TC_COMMA)
-            initC2TC(COLON, TC_COLON)
-            initC2TC(BEGIN_OBJ, TC_BEGIN_OBJ)
-            initC2TC(END_OBJ, TC_END_OBJ)
-            initC2TC(BEGIN_LIST, TC_BEGIN_LIST)
-            initC2TC(END_LIST, TC_END_LIST)
-            initC2TC(STRING, TC_STRING)
-            initC2TC(STRING_ESC, TC_STRING_ESC)
-        }
-
-        private fun mustBeQuoted(str: String): Boolean = str.any { c2tc(it.toInt()) != TC_OTHER } || str == NULL
-
-        // mapping from chars to their escape chars and back
-        private const val C2ESC_MAX = 0x5d
-        private const val ESC2C_MAX = 0x75
-
-        private val C2ESC = ByteArray(C2ESC_MAX)
-        private val ESC2C = ByteArray(ESC2C_MAX)
-
-        fun initC2ESC(c: Int, esc: Char) {
-            C2ESC[c] = esc.toByte()
-            if (esc != UNICODE_ESC) ESC2C[esc.toInt()] = c.toByte()
-        }
-
-        fun initC2ESC(c: Char, esc: Char) {
-            initC2ESC(c.toInt(), esc)
-        }
-
-        fun c2esc(c: Char): Char = if (c.toInt() < C2ESC_MAX) C2ESC[c.toInt()].toChar() else INVALID
-        fun esc2c(c: Int): Char = if (c < ESC2C_MAX) ESC2C[c].toChar() else INVALID
-
-        init {
-            for (i in 0x00..0x1f)
-                initC2ESC(i, UNICODE_ESC)
-            initC2ESC(0x08, 'b')
-            initC2ESC(0x09, 't')
-            initC2ESC(0x0a, 'n')
-            initC2ESC(0x0c, 'f')
-            initC2ESC(0x0d, 'r')
-            initC2ESC('/', '/')
-            initC2ESC(STRING, STRING)
-            initC2ESC(STRING_ESC, STRING_ESC)
-        }
-
-        fun hex(i: Int) : Char {
-            val d = i and 0xf
-            return if (d < 10) (d + '0'.toInt()).toChar()
-            else (d - 10 + 'a'.toInt()).toChar()
-        }
-
-        private fun switchMode(mode: Mode, desc: KSerialClassDesc, typeParams: Array<out KSerializer<*>>): Mode =
-                when (desc.kind) {
-                    KSerialClassKind.POLYMORPHIC -> Mode.POLY
-                    KSerialClassKind.LIST, KSerialClassKind.SET -> Mode.LIST
-                    KSerialClassKind.MAP -> {
-                        val keyKind = typeParams[0].serialClassDesc.kind
-                        if (keyKind == KSerialClassKind.PRIMITIVE || keyKind == KSerialClassKind.ENUM)
-                            Mode.MAP
-                        else Mode.LIST
-                    }
-                    KSerialClassKind.ENTRY -> if (mode == Mode.MAP) Mode.ENTRY else Mode.OBJ
-                    else -> Mode.OBJ
-                }
-
-
-        private fun require(condition: Boolean, pos: Int, msg: () -> String ) {
-            if (!condition)
-                fail(pos, msg())
-        }
-
-        private fun fail(pos: Int, msg: String): Nothing {
-            throw IllegalArgumentException("JSON at $pos: $msg")
-        }
-    }
-
-    private enum class Mode(val begin: Char, val end: Char) {
-        OBJ(BEGIN_OBJ, END_OBJ),
-        LIST(BEGIN_LIST, END_LIST),
-        MAP(BEGIN_OBJ, END_OBJ),
-        POLY(BEGIN_LIST, END_LIST),
-        ENTRY(INVALID, INVALID);
-
-        val beginTc: Byte = c2tc(begin.toInt())
-        val endTc: Byte = c2tc(end.toInt())
     }
 
     private inner class JsonOutput(val mode: Mode, val w: Composer) : ElementValueOutput() {
-
         init {
             context = this@JSON.context
         }
@@ -294,10 +151,10 @@ data class JSON(
                         w.print(STRING_ESC)
                         w.print(UNICODE_ESC)
                         val code = c.toInt()
-                        w.print(hex(code shr 12))
-                        w.print(hex(code shr 8))
-                        w.print(hex(code shr 4))
-                        w.print(hex(code))
+                        w.print(toHexChar(code shr 12))
+                        w.print(toHexChar(code shr 8))
+                        w.print(toHexChar(code shr 4))
+                        w.print(toHexChar(code))
                     }
                     else -> {
                         w.print(STRING_ESC)
@@ -346,7 +203,7 @@ data class JSON(
         override fun readBegin(desc: KSerialClassDesc, vararg typeParams: KSerializer<*>): KInput {
             val newMode = switchMode(mode, desc, typeParams)
             if (newMode.begin != INVALID) {
-                require(p.curTc == newMode.beginTc, p.tokenPos) { "Expected '${newMode.begin}, kind: ${desc.kind}'" }
+                require(p.tc == newMode.beginTc, p.tokenPos) { "Expected '${newMode.begin}, kind: ${desc.kind}'" }
                 p.nextToken()
             }
             return when (newMode) {
@@ -358,62 +215,56 @@ data class JSON(
 
         override fun readEnd(desc: KSerialClassDesc) {
             if (mode.end != INVALID) {
-                require(p.curTc == mode.endTc, p.tokenPos) { "Expected '${mode.end}'" }
+                require(p.tc == mode.endTc, p.tokenPos) { "Expected '${mode.end}'" }
                 p.nextToken()
             }
         }
 
         override fun readNotNullMark(): Boolean {
-            return p.curTc != TC_NULL
+            return p.tc != TC_NULL
         }
 
         override fun readNullValue(): Nothing? {
-            require(p.curTc == TC_NULL, p.tokenPos) { "Expected 'null' literal" }
+            require(p.tc == TC_NULL, p.tokenPos) { "Expected 'null' literal" }
             p.nextToken()
             return null
         }
 
         override fun readElement(desc: KSerialClassDesc): Int {
-//            println(p.state())
             while (true) {
-                if (p.curTc == TC_COMMA) p.nextToken()
+                if (p.tc == TC_COMMA) p.nextToken()
                 when (mode) {
                     Mode.LIST, Mode.MAP -> {
-                        if (!p.canBeginValue)
-                            return READ_DONE
-                        return ++curIndex
+                        return if (!p.canBeginValue) READ_DONE else ++curIndex
                     }
                     Mode.POLY -> {
-                        when (entryIndex++) {
-                            0 -> return 0
-                            1 -> {
-                                return 1
-                            }
+                        return when (entryIndex++) {
+                            0 -> 0
+                            1 -> 1
                             else -> {
                                 entryIndex = 0
-                                return READ_DONE
+                                READ_DONE
                             }
                         }
                     }
                     Mode.ENTRY -> {
-                        when (entryIndex++) {
-                            0 -> return 0
+                        return when (entryIndex++) {
+                            0 -> 0
                             1 -> {
-                                require(p.curTc == TC_COLON, p.tokenPos) { "Expected ':'" }
+                                require(p.tc == TC_COLON, p.tokenPos) { "Expected ':'" }
                                 p.nextToken()
-                                return 1
+                                1
                             }
                             else -> {
                                 entryIndex = 0
-                                return READ_DONE
+                                READ_DONE
                             }
                         }
                     }
                     else -> {
-                        if (!p.canBeginValue)
-                            return READ_DONE
+                        if (!p.canBeginValue) return READ_DONE
                         val key = p.takeStr()
-                        require(p.curTc == TC_COLON, p.tokenPos) { "Expected ':'" }
+                        require(p.tc == TC_COLON, p.tokenPos) { "Expected ':'" }
                         p.nextToken()
                         val ind = desc.getElementIndex(key)
                         if (ind != UNKNOWN_NAME)
@@ -440,134 +291,164 @@ data class JSON(
         override fun <T : Enum<T>> readEnumValue(enumClass: KClass<T>): T = enumFromName(enumClass, p.takeStr())
     }
 
-    private class Parser(val r: Reader) {
-        // updated by nextChar
-        var charPos: Int = 0
-        var curChar: Int = -1
+    private class Parser(val source: String) {
+        var curPos: Int = 0 // position in source
+
         // updated by nextToken
         var tokenPos: Int = 0
-        var curTc: Byte = TC_EOF
-        var curStr: String? = null
-        var sb = StringBuilder()
+        var tc: Byte = TC_EOF
+
+        // update by nextString/nextLiteral
+        var offset = -1 // when offset >= 0 string is in source, otherwise in buf
+        var length = 0 // length of string
+        var buf = CharArray(16) // only used for strings with escapes
 
         init {
-            nextChar()
             nextToken()
         }
 
-        val canBeginValue: Boolean get() = when (curTc) {
+        val canBeginValue: Boolean get() = when (tc) {
             TC_BEGIN_LIST, TC_BEGIN_OBJ, TC_OTHER, TC_STRING, TC_NULL -> true
             else -> false
         }
 
         fun takeStr(): String {
-            val prevStr = curStr ?: fail(tokenPos, "Expected string or non-null literal")
+            if (tc != TC_OTHER && tc != TC_STRING) fail(tokenPos, "Expected string or non-null literal")
+            val prevStr = if (offset < 0)
+                buf.contentToString(length) else
+                source.substring(offset, offset + length)
             nextToken()
             return prevStr
         }
 
+        fun append(ch: Char) {
+            if (length >= buf.size) buf = buf.copyOf(2 * buf.size)
+            buf[length++] = ch
+        }
+
+        // initializes buf usage upon the first encountered escaped char
+        fun appendRange(source: String, fromIndex: Int, toIndex: Int) {
+            val addLen = toIndex - fromIndex
+            val oldLen = length
+            val newLen = oldLen + addLen
+            if (newLen > buf.size) buf = buf.copyOf(newLen.coerceAtLeast(2 * buf.size))
+            for (i in 0 until addLen) buf[oldLen + i] = source[fromIndex + i]
+            length += addLen
+        }
+
         fun nextToken() {
+            val source = source
+            var curPos = curPos
             while(true) {
-                tokenPos = charPos
-                curTc = c2tc(curChar)
-                when (curTc) {
-                    TC_WS -> nextChar() // skip whitespace
+                if (curPos >= source.length) {
+                    tokenPos = curPos
+                    tc = TC_EOF
+                    return
+                }
+                val ch = source[curPos]
+                val tc = c2tc(ch)
+                when (tc) {
+                    TC_WS -> curPos++ // skip whitespace
                     TC_OTHER -> {
-                        nextLiteral()
+                        nextLiteral(source, curPos)
                         return
                     }
                     TC_STRING -> {
-                        nextString()
+                        nextString(source, curPos)
                         return
                     }
                     else -> {
-                        nextChar()
-                        curStr = null
+                        tokenPos = curPos
+                        this.tc = tc
+                        this.curPos = curPos + 1
                         return
                     }
                 }
             }
         }
 
-        private fun nextChar() {
-            curChar = r.read()
-            charPos++
-        }
-
-        private fun nextLiteral() {
-            sb = StringBuilder()
+        fun nextLiteral(source: String, startPos: Int) {
+            tokenPos = startPos
+            offset = startPos
+            var curPos = startPos
             while(true) {
-                sb.append(curChar.toChar())
-                nextChar()
-                if (c2tc(curChar) != TC_OTHER) break
+                curPos++
+                if (curPos >= source.length || c2tc(source[curPos]) != TC_OTHER) break
             }
-            if (NULL == sb.toString()) {
-                curStr = null
-                curTc = TC_NULL
-            } else {
-                curStr = sb.toString()
-                curTc = TC_OTHER
-            }
+            this.curPos = curPos
+            length = curPos - offset
+            tc = if (rangeEquals(source, offset, length, NULL)) TC_NULL else TC_OTHER
         }
 
-        private fun nextString() {
-            sb = StringBuilder()
+        fun nextString(source: String, startPos: Int) {
+            tokenPos = startPos
+            length = 0 // in buffer
+            var curPos = startPos + 1
+            var lastPos = curPos
             parse@ while(true) {
-                nextChar()
-                when (c2tc(curChar)) {
-                    TC_EOF -> fail(charPos, "Unexpected end in string")
-                    TC_STRING -> {
-                        nextChar()
-                        break@parse
+                if (curPos >= source.length) fail(curPos, "Unexpected end in string")
+                when (source[curPos]) {
+                    STRING -> break@parse
+                    STRING_ESC -> {
+                        appendRange(source, lastPos, curPos)
+                        val newPos = appendEsc(source, curPos + 1)
+                        curPos = newPos
+                        lastPos = newPos
                     }
-                    TC_STRING_ESC -> {
-                        nextChar()
-                        require(curChar >= 0, charPos) { "Unexpected end after escape char" }
-                        if (curChar == UNICODE_ESC.toInt()) {
-                            sb.append(((hex() shl 12) + (hex() shl 8) + (hex() shl 4) + hex()).toChar())
-                        } else {
-                            val c = esc2c(curChar)
-                            require(c != INVALID, charPos) { "Invalid escaped char '${curChar.toChar()}'" }
-                            sb.append(c)
-                        }
-                    }
-                    else -> sb.append(curChar.toChar())
+                    else -> curPos++
                 }
             }
-            curStr = sb.toString()
-            curTc = TC_STRING
-        }
-
-        private fun hex(): Int {
-            nextChar()
-            require(curChar >= 0, charPos) { "Unexpected end in unicode escape " }
-            return when (curChar.toChar()) {
-                in '0'..'9' -> curChar - '0'.toInt()
-                in 'a'..'f' -> curChar - 'a'.toInt() + 10
-                in 'A'..'F' -> curChar - 'A'.toInt() + 10
-                else -> throw fail(charPos, "Invalid hex char '${curChar.toChar()}' in unicode escape")
+            if (lastPos == startPos + 1) {
+                // there was no escaped chars
+                this.offset = lastPos
+                this.length = curPos - lastPos
+            } else {
+                // some escaped chars were there
+                appendRange(source, lastPos, curPos)
+                this.offset = -1
             }
+            this.curPos = curPos + 1
+            tc = TC_STRING
         }
 
-        internal fun state(): String {
-            return "Parser(charPos=$charPos, curChar=$curChar, tokenPos=$tokenPos, curTc=$curTc, curStr=$curStr)"
+        fun appendEsc(source: String, startPos: Int): Int {
+            var curPos = startPos
+            require(curPos < source.length, curPos) { "Unexpected end after escape char" }
+            val curChar = source[curPos++]
+            if (curChar == UNICODE_ESC) {
+                curPos = appendHex(source, curPos)
+            } else {
+                val c = esc2c(curChar.toInt())
+                require(c != INVALID, curPos) { "Invalid escaped char '$curChar'" }
+                append(c)
+            }
+            return curPos
         }
 
-        internal fun skipElement() {
-            if (curTc != TC_BEGIN_OBJ && curTc != TC_BEGIN_LIST) {
+        fun appendHex(source: String, startPos: Int): Int {
+            var curPos = startPos
+            append(((fromHexChar(source, curPos++) shl 12) +
+                (fromHexChar(source, curPos++) shl 8) +
+                (fromHexChar(source, curPos++) shl 4) +
+                fromHexChar(source, curPos++)).toChar())
+            return curPos
+        }
+
+        fun skipElement() {
+            if (tc != TC_BEGIN_OBJ && tc != TC_BEGIN_LIST) {
                 nextToken()
                 return
             }
             val tokenStack = mutableListOf<Byte>()
             do {
-                when (curTc) {
-                    TC_BEGIN_LIST, TC_BEGIN_OBJ -> tokenStack.add(curTc)
+                when (tc) {
+                    TC_BEGIN_LIST, TC_BEGIN_OBJ -> tokenStack.add(tc)
                     TC_END_LIST -> {
-                        if (tokenStack.last() != TC_BEGIN_LIST) throw SerializationException("Invalid JSON at $charPos: found ] instead of }")
+                        if (tokenStack.last() != TC_BEGIN_LIST) throw SerializationException("Invalid JSON at $curPos: found ] instead of }")
                         tokenStack.removeAt(tokenStack.size - 1)
                     }
                     TC_END_OBJ -> {
-                        if (tokenStack.last() != TC_BEGIN_OBJ) throw SerializationException("Invalid JSON at $charPos: found } instead of ]")
+                        if (tokenStack.last() != TC_BEGIN_OBJ) throw SerializationException("Invalid JSON at $curPos: found } instead of ]")
                         tokenStack.removeAt(tokenStack.size - 1)
                     }
                 }
@@ -575,4 +456,158 @@ data class JSON(
             } while (tokenStack.isNotEmpty())
         }
     }
+}
+
+// ----------- JSON utilities -----------
+
+private enum class Mode(val begin: Char, val end: Char) {
+    OBJ(BEGIN_OBJ, END_OBJ),
+    LIST(BEGIN_LIST, END_LIST),
+    MAP(BEGIN_OBJ, END_OBJ),
+    POLY(BEGIN_LIST, END_LIST),
+    ENTRY(INVALID, INVALID);
+
+    val beginTc: Byte = c2tc(begin)
+    val endTc: Byte = c2tc(end)
+}
+
+private fun switchMode(mode: Mode, desc: KSerialClassDesc, typeParams: Array<out KSerializer<*>>): Mode =
+    when (desc.kind) {
+        KSerialClassKind.POLYMORPHIC -> Mode.POLY
+        KSerialClassKind.LIST, KSerialClassKind.SET -> Mode.LIST
+        KSerialClassKind.MAP -> {
+            val keyKind = typeParams[0].serialClassDesc.kind
+            if (keyKind == KSerialClassKind.PRIMITIVE || keyKind == KSerialClassKind.ENUM)
+                Mode.MAP
+            else Mode.LIST
+        }
+        KSerialClassKind.ENTRY -> if (mode == Mode.MAP) Mode.ENTRY else Mode.OBJ
+        else -> Mode.OBJ
+    }
+
+
+private fun require(condition: Boolean, pos: Int, msg: () -> String ) {
+    if (!condition)
+        fail(pos, msg())
+}
+
+private fun fail(pos: Int, msg: String): Nothing {
+    throw IllegalArgumentException("JSON at $pos: $msg")
+}
+
+// special strings
+private const val NULL = "null"
+
+// special chars
+private const val COMMA = ','
+private const val COLON = ':'
+private const val BEGIN_OBJ = '{'
+private const val END_OBJ = '}'
+private const val BEGIN_LIST = '['
+private const val END_LIST = ']'
+private const val STRING = '"'
+private const val STRING_ESC = '\\'
+
+private const val INVALID = 0.toChar()
+private const val UNICODE_ESC = 'u'
+
+// token classes
+private const val TC_OTHER: Byte = 0
+private const val TC_STRING: Byte = 1
+private const val TC_STRING_ESC: Byte = 2
+private const val TC_WS: Byte = 3
+private const val TC_COMMA: Byte = 4
+private const val TC_COLON: Byte = 5
+private const val TC_BEGIN_OBJ: Byte = 6
+private const val TC_END_OBJ: Byte = 7
+private const val TC_BEGIN_LIST: Byte = 8
+private const val TC_END_LIST: Byte = 9
+private const val TC_NULL: Byte = 10
+private const val TC_INVALID: Byte = 11
+private const val TC_EOF: Byte = 12
+
+// mapping from chars to token classes
+private const val CTC_MAX = 0x7e
+
+private val C2TC = ByteArray(CTC_MAX).apply {
+    for (i in 0..0x20)
+        initC2TC(i, TC_INVALID)
+    initC2TC(0x09, TC_WS)
+    initC2TC(0x0a, TC_WS)
+    initC2TC(0x0d, TC_WS)
+    initC2TC(0x20, TC_WS)
+    initC2TC(COMMA, TC_COMMA)
+    initC2TC(COLON, TC_COLON)
+    initC2TC(BEGIN_OBJ, TC_BEGIN_OBJ)
+    initC2TC(END_OBJ, TC_END_OBJ)
+    initC2TC(BEGIN_LIST, TC_BEGIN_LIST)
+    initC2TC(END_LIST, TC_END_LIST)
+    initC2TC(STRING, TC_STRING)
+    initC2TC(STRING_ESC, TC_STRING_ESC)
+}
+
+private fun ByteArray.initC2TC(c : Int, cl: Byte) { this[c] = cl }
+
+private fun ByteArray.initC2TC(c: Char, cl: Byte) {
+    initC2TC(c.toInt(), cl)
+}
+
+private fun c2tc(c: Char) = if (c.toInt() < CTC_MAX) C2TC[c.toInt()] else TC_OTHER
+
+private fun mustBeQuoted(str: String): Boolean = str.any { c2tc(it) != TC_OTHER } || str == NULL
+
+// mapping from chars to their escape chars and back
+private const val C2ESC_MAX = 0x5d
+private const val ESC2C_MAX = 0x75
+
+private val ESC2C = ByteArray(ESC2C_MAX)
+
+private val C2ESC = ByteArray(C2ESC_MAX).apply {
+    for (i in 0x00..0x1f)
+        initC2ESC(i, UNICODE_ESC)
+    initC2ESC(0x08, 'b')
+    initC2ESC(0x09, 't')
+    initC2ESC(0x0a, 'n')
+    initC2ESC(0x0c, 'f')
+    initC2ESC(0x0d, 'r')
+    initC2ESC('/', '/')
+    initC2ESC(STRING, STRING)
+    initC2ESC(STRING_ESC, STRING_ESC)
+}
+
+private fun ByteArray.initC2ESC(c: Int, esc: Char) {
+    this[c] = esc.toByte()
+    if (esc != UNICODE_ESC) ESC2C[esc.toInt()] = c.toByte()
+}
+
+private fun ByteArray.initC2ESC(c: Char, esc: Char) {
+    initC2ESC(c.toInt(), esc)
+}
+
+private fun c2esc(c: Char): Char = if (c.toInt() < C2ESC_MAX) C2ESC[c.toInt()].toChar() else INVALID
+
+private fun esc2c(c: Int): Char = if (c < ESC2C_MAX) ESC2C[c].toChar() else INVALID
+
+private fun toHexChar(i: Int) : Char {
+    val d = i and 0xf
+    return if (d < 10) (d + '0'.toInt()).toChar()
+    else (d - 10 + 'a'.toInt()).toChar()
+}
+
+private fun fromHexChar(source: String, curPos: Int): Int {
+    require(curPos < source.length, curPos) { "Unexpected end in unicode escape" }
+    val curChar = source[curPos]
+    return when (curChar) {
+        in '0'..'9' -> curChar.toInt() - '0'.toInt()
+        in 'a'..'f' -> curChar.toInt() - 'a'.toInt() + 10
+        in 'A'..'F' -> curChar.toInt() - 'A'.toInt() + 10
+        else -> throw fail(curPos, "Invalid toHexChar char '$curChar' in unicode escape")
+    }
+}
+
+private fun rangeEquals(source: String, start: Int, length: Int, str: String): Boolean {
+    val n = str.length
+    if (length != n) return false
+    for (i in 0 until n) if (source[start + i] != str[i]) return false
+    return true
 }

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
@@ -335,7 +335,7 @@ data class JSON(
         fun takeStr(): String {
             if (tc != TC_OTHER && tc != TC_STRING) fail(tokenPos, "Expected string or non-null literal")
             val prevStr = if (offset < 0)
-                buf.contentToString(length) else
+                buf.createString(length) else
                 source.substring(offset, offset + length)
             nextToken()
             return prevStr

--- a/runtime/js/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
+++ b/runtime/js/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.serialization.internal
+
+actual fun CharArray.contentToString(length: Int): String =
+    copyOf(length).contentToString()

--- a/runtime/js/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
+++ b/runtime/js/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
@@ -16,5 +16,5 @@
 
 package kotlinx.serialization.internal
 
-actual fun CharArray.contentToString(length: Int): String =
-    copyOf(length).contentToString()
+actual fun CharArray.createString(length: Int): String =
+    joinToString(separator = "", limit = length, truncated = "")

--- a/runtime/js/src/test/kotlin/kotlinx/serialization/StringTest.kt
+++ b/runtime/js/src/test/kotlin/kotlinx/serialization/StringTest.kt
@@ -17,6 +17,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.internal.HexConverter
+import kotlinx.serialization.internal.createString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -34,5 +35,12 @@ class StringTest {
     fun fromUtf8() {
         val s = stringFromUtf8Bytes(HexConverter.parseHexBinary(hex))
         assertEquals(str, s)
+    }
+
+    @Test
+    fun testCreateString() {
+        val charArr = charArrayOf('a', 'b', 'c', 'd')
+        val content = charArr.createString(2)
+        assertEquals("ab", content)
     }
 }

--- a/runtime/jvm/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
+++ b/runtime/jvm/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
@@ -16,5 +16,5 @@
 
 package kotlinx.serialization.internal
 
-actual fun CharArray.contentToString(length: Int): String =
+actual fun CharArray.createString(length: Int): String =
     String(this, 0, length)

--- a/runtime/jvm/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
+++ b/runtime/jvm/src/main/kotlin/kotlinx/serialization/internal/Strings.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.serialization.internal
+
+actual fun CharArray.contentToString(length: Int): String =
+    String(this, 0, length)


### PR DESCRIPTION
The most of performance gain is due to moving move of parse state into
local variables instead of fields for the duration of nextToken call and
getting rid of Reader class (now source string is directly parsed).
All the other refactorings (making constants fully static by moving
them to top level and avoiding extra copy of chars for strings that
do not use escapes) have minor effects on parsing of big JSON strings
but could be benefitial in other cases.