### PR TITLE
Add null check to Companion when looking up serializer.

### DIFF
--- a/runtime/js/src/main/kotlin/kotlinx/serialization/Serialization.kt
+++ b/runtime/js/src/main/kotlin/kotlinx/serialization/Serialization.kt
@@ -19,7 +19,7 @@ package kotlinx.serialization
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
-actual fun <T: Any> KClass<T>.serializer(): KSerializer<T> = this.js.asDynamic().Companion.serializer() as? KSerializer<T>
+actual fun <T: Any> KClass<T>.serializer(): KSerializer<T> = this.js.asDynamic().Companion?.serializer() as? KSerializer<T>
         ?: throw SerializationException("Can't locate default serializer for class $this")
 
 actual fun String.toUtf8Bytes(): ByteArray {


### PR DESCRIPTION
This one-byte change eliminates the rather unhelpful error

`TypeError: get_js(...).Companion is undefined`

in favor of the intended

`uncaught exception: SerializationException: Can't locate default serializer for class`

error in the case when one tries to serialize an erased type.

Example triggering problem:

```
interface Foo
@Serializable
data class Bar(var baz: String): Foo

fun tryToSerialize(foo: Foo) = JSON.stringify(foo)

tryToSerialize(Bar("hello"))
```