### PR TITLE
Improved performanse of JSON.stringify

### DIFF
--- a/benchmark/src/main/java/com/example/buffers/Buffers.kt
+++ b/benchmark/src/main/java/com/example/buffers/Buffers.kt
@@ -28,6 +28,10 @@ class OkioEngine(private val buf: Buffer = Buffer()) : BufferEngine<BufferedSink
         buf.writeUtf8(v)
     }
 
+    override fun print(v: Byte) {
+        buf.writeByte(v.toInt())
+    }
+
     override fun print(v: Short) {
         buf.writeShort(v.toInt())
     }
@@ -52,7 +56,7 @@ class KxioEngine(private val builder: BytePacketBuilder = BytePacketBuilder()) :
     }
 
     override fun append(obj: Any) {
-        builder.writeStringUtf8(obj.toString())
+        builder.append(obj.toString())
     }
 
     override fun print(v: Char) {
@@ -60,7 +64,11 @@ class KxioEngine(private val builder: BytePacketBuilder = BytePacketBuilder()) :
     }
 
     override fun print(v: String) {
-        builder.writeStringUtf8(v)
+        builder.append(v)
+    }
+
+    override fun print(v: Byte) {
+        builder.writeByte(v)
     }
 
     override fun print(v: Short) {

--- a/benchmark/src/main/java/com/example/buffers/Buffers.kt
+++ b/benchmark/src/main/java/com/example/buffers/Buffers.kt
@@ -32,6 +32,10 @@ class OkioEngine(private val buf: Buffer = Buffer()) : BufferEngine<BufferedSink
         buf.writeShort(v.toInt())
     }
 
+    override fun print(v: Byte) {
+        buf.writeByte(v.toInt())
+    }
+
     override fun print(v: Int) {
         buf.writeInt(v)
     }

--- a/benchmark/src/main/java/com/example/buffers/Buffers.kt
+++ b/benchmark/src/main/java/com/example/buffers/Buffers.kt
@@ -32,10 +32,6 @@ class OkioEngine(private val buf: Buffer = Buffer()) : BufferEngine<BufferedSink
         buf.writeShort(v.toInt())
     }
 
-    override fun print(v: Byte) {
-        buf.writeByte(v.toInt())
-    }
-
     override fun print(v: Int) {
         buf.writeInt(v)
     }

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
@@ -186,7 +186,7 @@ data class JSON(
         fun print(v: Boolean) = engine.print(v)
 
         fun printQuoted(value: String): Unit = with(engine) {
-            print(STRING)
+            print(STRING.toByte())
             var lastPos = 0
             val length = value.length
             for (i in 0 until length) {
@@ -200,7 +200,7 @@ data class JSON(
                 lastPos = i + 1
             }
             append(value, lastPos, length)
-            print(STRING)
+            print(STRING.toByte())
         }
     }
 

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSON.kt
@@ -197,7 +197,7 @@ data class JSON(
         fun print(v: Boolean) = engine.print(v)
 
         fun printQuoted(value: String): Unit = with(engine) {
-            print(STRING.toByte())
+            print(STRING)
             var lastPos = 0
             val length = value.length
             for (i in 0 until length) {
@@ -211,7 +211,7 @@ data class JSON(
                 lastPos = i + 1
             }
             append(value, lastPos, length)
-            print(STRING.toByte())
+            print(STRING)
         }
     }
 

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSONBuffers.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JSONBuffers.kt
@@ -38,6 +38,10 @@ class StringEngine(private val sb: StringBuilder) : BufferEngine<String> {
         sb.append(obj)
     }
 
+    override fun print(v: String) {
+        sb.append(v)
+    }
+
     override fun result(): String {
         return sb.toString()
     }

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/JSONTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/JSONTest.kt
@@ -36,6 +36,11 @@ class JSONTest {
     }
 
     @Test
+    fun testSerializeQuotedJSON() {
+        assertEquals("""{"a":10,"e":false,"c":"Hello"}""", JSON.stringify(TransientTests.Data(10, 100)))
+    }
+
+    @Test
     fun strictJSONCanNotSkipValues() {
         assertFailsWith(SerializationException::class) {
             JSON.parse<OptionalTests.Data>("{strangeField: 100500, a:0}")


### PR DESCRIPTION
After all changes kotlinx.serializaion is consistently faster than moshi on serizalization benchmarks.
The most of performance gain is due to `printQuoted` vectorization.

Results on linux box:
```
Benchmark                                 Mode  Cnt    Score   Error  Units
SpeedTest.kserializer_toJson_okioBuffer  thrpt   20  860.521 ± 5.467  ops/s
SpeedTest.moshi_streaming_toJson_buffer  thrpt   20  845.783 ± 3.169  ops/s
```