### PR TITLE
Bump gradle version to be compatible with 4.8+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 
-library.version=0.6.0
+library.version=0.6.1
 kotlin.version=1.2.51
 kotlin.version.snapshot=1.2.60-eap-44
 plugin.version=0.6.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,6 +16,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The gradle metadata format changed in gradle 4.8 to version 0.4. This
allows using this lib with gradle 4.8+ with
`enableFeaturePreview('GRADLE_METADATA')`.