### PR TITLE
Delegates `equals`, `hashCode` of `JsonObject` and `JsonArray`.

### DIFF
--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonElement.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonElement.kt
@@ -283,6 +283,10 @@ public data class JsonObject(val content: Map<String, JsonElement>) : JsonElemen
             transform = {(k, v) -> """"$k": $v"""}
         )
     }
+
+    public override fun equals(other: Any?): Boolean = content.equals(other)
+
+    public override fun hashCode(): Int = content.hashCode()
 }
 
 @Serializable(JsonArraySerializer::class)
@@ -339,6 +343,10 @@ public data class JsonArray(val content: List<JsonElement>) : JsonElement(), Lis
     public inline fun <reified J : JsonElement> getAsOrNull(index: Int): J? = content.getOrNull(index) as? J
 
     public override fun toString() = content.joinToString(prefix = "[", postfix = "]")
+
+    public override fun equals(other: Any?): Boolean = content.equals(other)
+
+    public override fun hashCode(): Int = content.hashCode()
 }
 
 @PublishedApi

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -103,4 +103,37 @@ class JsonTreeTest {
         assertFailsWith<IllegalStateException> { n.boolean }
         assertEquals(null, n.booleanOrNull)
     }
+
+    @Test
+    fun testThatJsonArraysCompareWithLists() {
+        val jsonArray: List<JsonElement> = JsonArray(listOf(JsonLiteral(3), JsonLiteral(4)))
+        val arrayList: List<JsonElement> = ArrayList(listOf(JsonLiteral(3), JsonLiteral(4)))
+        val otherArrayList: List<JsonElement> = ArrayList(listOf(JsonLiteral(3), JsonLiteral(5)))
+
+        assertEquals(jsonArray, arrayList)
+        assertEquals(arrayList, jsonArray)
+        assertEquals(jsonArray.hashCode(), arrayList.hashCode())
+        assertNotEquals(jsonArray, otherArrayList)
+    }
+
+    @Test
+    fun testThatJsonObjectsCompareWithMaps() {
+        val jsonObject: Map<String, JsonElement> = JsonObject(mapOf(
+                "three" to JsonLiteral(3),
+                "four" to JsonLiteral(4)
+        ))
+        val hashMap: Map<String, JsonElement> = HashMap(mapOf(
+                "three" to JsonLiteral(3),
+                "four" to JsonLiteral(4)
+        ))
+        val otherHashMap: Map<String, JsonElement> = HashMap(mapOf(
+                "three" to JsonLiteral(3),
+                "four" to JsonLiteral(5)
+        ))
+
+        assertEquals(jsonObject, hashMap)
+        assertEquals(hashMap, jsonObject)
+        assertEquals(jsonObject.hashCode(), hashMap.hashCode())
+        assertNotEquals(jsonObject, otherHashMap)
+    }
 }


### PR DESCRIPTION
Fixes issue #301.