### PR TITLE
Add YAML parser to list of supported formats

### DIFF
--- a/formats/README.md
+++ b/formats/README.md
@@ -16,3 +16,12 @@ Allows deserialization of `Config` object from popular [lightbend/config](https:
 into Kotlin objects.
 You can learn about "Human-Optimized Config Object Notation" or HOCON from library's [readme](https://github.com/lightbend/config#using-hocon-the-json-superset).
 
+## Other community-supported formats
+
+### YAML
+
+* GitHub repo: [charleskorn/kaml](https://github.com/charleskorn/kaml)
+* Artifact ID: `com.charleskorn.kaml:kaml`
+* Platform: JVM only
+
+Allows deserialization of objects from [YAML](http://yaml.org).


### PR DESCRIPTION
I've started work on a (very, very basic) YAML parser that works with this library - [kaml](https://github.com/charleskorn/kaml).

It's still very limited (only supports deserialisation at the moment), and is very rough (it works, but I've taken some shortcuts that will hurt performance, error messages might not be great etc.).

I'm not sure if this file is the best place to mention it, so I'm open to suggestions / requests to add this somewhere else (or not add it at all).