### PR TITLE
Reorder Json parameters for consistency

### DIFF
--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/Json.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/Json.kt
@@ -98,7 +98,7 @@ public class Json(
      * Serializes [value] into an equivalent [JsonElement] using provided [serializer].
      * @throws [JsonException] subclass in case of serialization error.
      */
-    public fun <T> toJson(value: T, serializer: SerializationStrategy<T>): JsonElement {
+    public fun <T> toJson(serializer: SerializationStrategy<T>, value: T): JsonElement {
         return writeJson(value, serializer)
     }
 
@@ -108,7 +108,7 @@ public class Json(
      */
     @ImplicitReflectionSerializer
     public inline fun <reified T : Any> toJson(value: T): JsonElement {
-        return toJson(value, context.getOrDefault(T::class))
+        return toJson(context.getOrDefault(T::class), value)
     }
 
     /**
@@ -135,7 +135,7 @@ public class Json(
      * Deserializes [json] element into a corresponding object of type [T] using provided [deserializer].
      * @throws [JsonException] subclass in case of serialization error.
      */
-    public fun <T> fromJson(json: JsonElement, deserializer: DeserializationStrategy<T>): T {
+    public fun <T> fromJson(deserializer: DeserializationStrategy<T>, json: JsonElement): T {
         return readJson(json, deserializer)
     }
 
@@ -144,7 +144,7 @@ public class Json(
      * @throws [JsonException] subclass in case of serialization error.
      */
     @ImplicitReflectionSerializer
-    public inline fun <reified T : Any> fromJson(tree: JsonElement): T = fromJson(tree, context.getOrDefault(T::class))
+    public inline fun <reified T : Any> fromJson(tree: JsonElement): T = fromJson(context.getOrDefault(T::class), tree)
 
     companion object : StringFormat {
         val plain = Json()

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonTreeMapper.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonTreeMapper.kt
@@ -15,8 +15,8 @@ class JsonTreeMapper(val encodeDefaults: Boolean = true) : AbstractSerialFormat(
 
     @Deprecated(level = DeprecationLevel.WARNING, message = "Use Json.fromJson instead", replaceWith = ReplaceWith("Json.plain.fromJson(obj, deserializer)"))
     fun <T> readTree(obj: JsonElement, deserializer: DeserializationStrategy<T>): T =
-        Json.plain.fromJson(obj, deserializer)
+        Json.plain.fromJson(deserializer, obj)
 
     @Deprecated(level = DeprecationLevel.WARNING, message = "Use Json.toJson instead", replaceWith = ReplaceWith("Json.plain.toJson(obj, serializer)"))
-    fun <T> writeTree(obj: T, serializer: SerializationStrategy<T>): JsonElement = Json.plain.toJson(obj, serializer)
+    fun <T> writeTree(obj: T, serializer: SerializationStrategy<T>): JsonElement = Json.plain.toJson(serializer, obj)
 }

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonTreeAndMapperTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonTreeAndMapperTest.kt
@@ -37,14 +37,14 @@ object EitherSerializer : KSerializer<DummyEither> {
             ?: throw SerializationException("Expected JsonObject")
         if ("error" in tree) return DummyEither.Left(tree.getPrimitive("error").content)
 
-        return DummyEither.Right(input.json.fromJson(tree, Payload.serializer()))
+        return DummyEither.Right(input.json.fromJson(Payload.serializer(), tree))
     }
 
     override fun serialize(encoder: Encoder, obj: DummyEither) {
         val output = encoder as? JsonOutput ?: throw SerializationException("This class can be saved only by Json")
         val tree = when (obj) {
             is DummyEither.Left -> JsonObject(mapOf("error" to JsonLiteral(obj.errorMsg)))
-            is DummyEither.Right -> output.json.toJson(obj.data, Payload.serializer())
+            is DummyEither.Right -> output.json.toJson(Payload.serializer(), obj.data)
         }
 
         output.encodeJson(tree)

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonTreeTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonTreeTest.kt
@@ -62,7 +62,7 @@ class JsonTreeTest : JsonTestBase() {
     @Test
     fun testReadTreeSimple() {
         val tree = prepare("{a: 42}")
-        val parsed = json.fromJson(tree, Data.serializer())
+        val parsed = json.fromJson(Data.serializer(), tree)
         assertEquals(Data(42), parsed)
     }
 
@@ -128,10 +128,10 @@ class JsonTreeTest : JsonTestBase() {
 
     private inline fun <reified T: Any> writeAndTest(obj: T, printDiagnostics: Boolean = false): Pair<JsonElement, T> {
         val serial = T::class.serializer()
-        val tree = Json().toJson(obj, serial)
+        val tree = Json().toJson(serial, obj)
         val str = tree.toString()
         if (printDiagnostics) println(str)
-        val restored = json.fromJson(json.parseJson(str), serial)
+        val restored = json.fromJson(serial, json.parseJson(str))
         assertEquals(obj, restored)
         return tree to restored
     }


### PR DESCRIPTION
I noticed that the new methods `toJson` and `fromJson` had a different parameter order than `stringify` and `parse` (Which have the serializer first, and the value in second)

Having the same parameter order for similar method signatures can reduce cognitive load and improve developer experience in my opinion.

