### PR TITLE
Optimize the Writer.write(String) case.

### DIFF
--- a/runtime/js/src/main/kotlin/kotlinx/io/Writers.kt
+++ b/runtime/js/src/main/kotlin/kotlinx/io/Writers.kt
@@ -21,7 +21,10 @@ actual abstract class Writer protected actual constructor() {
         write(charArrayOf(ch.toChar()), 0, 1)
     }
     actual open fun write(str: String) {
-        write(str.toList().toCharArray(), 0, str.length)
+        val buf = CharArray(str.length)
+        for (i in str.indices)
+            buf[i] = str[i]
+        write(buf, 0, buf.size)
     }
     actual abstract fun write(src: CharArray, off: Int, len: Int)
     actual abstract fun flush()

--- a/runtime/native/src/main/kotlin/kotlinx/io/Writers.kt
+++ b/runtime/native/src/main/kotlin/kotlinx/io/Writers.kt
@@ -22,7 +22,10 @@ actual abstract class Writer protected actual constructor() {
     }
 
     actual open fun write(str: String) {
-        write(str.toList().toCharArray(), 0, str.length)
+        val buf = CharArray(str.length)
+        for (i in str.indices)
+            buf[i] = str[i]
+        write(buf, 0, buf.size)
     }
 
     actual abstract fun write(src: CharArray, off: Int, len: Int)


### PR DESCRIPTION
The old implementation called .toList().toCharArray() which created an
intermediate representation with extra overhead. Instead, simply copy
the representation into a char array directly.