### PR TITLE
Change JsonObject so it would comply to a Map interface

### DIFF
--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonElement.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonElement.kt
@@ -201,6 +201,9 @@ public object JsonNull : JsonPrimitive() {
 
 /**
  * Class representing JSON object, consisting of name-value pairs, where value is arbitrary [JsonElement]
+ *
+ * Since this class also implements [Map] interface, you can use
+ * traditional methods like [Map.get] or [Map.getValue] to obtain Json elements.
  */
 @Serializable(JsonObjectSerializer::class)
 public data class JsonObject(val content: Map<String, JsonElement>) : JsonElement(), Map<String, JsonElement> by content {
@@ -208,23 +211,12 @@ public data class JsonObject(val content: Map<String, JsonElement>) : JsonElemen
     override val jsonObject: JsonObject = this
 
     /**
-     * Returns [JsonElement] associated with given [key]
-     * @throws NoSuchElementException if element is not present
-     */
-    public override fun get(key: String): JsonElement = content[key] ?: throw NoSuchElementException("Element $key is missing")
-
-    /**
-     * Returns [JsonElement] associated with given [key] or `null` if element is not present
-     */
-    public fun getOrNull(key: String): JsonElement? = content[key]
-
-    /**
      * Returns [JsonPrimitive] associated with given [key]
      *
      * @throws NoSuchElementException if element is not present
      * @throws JsonElementTypeMismatchException if element is present, but has invalid type
      */
-    public fun getPrimitive(key: String): JsonPrimitive = get(key) as? JsonPrimitive
+    public fun getPrimitive(key: String): JsonPrimitive = getValue(key) as? JsonPrimitive
             ?: unexpectedJson(key, "JsonPrimitive")
 
     /**
@@ -233,7 +225,7 @@ public data class JsonObject(val content: Map<String, JsonElement>) : JsonElemen
      * @throws NoSuchElementException if element is not present
      * @throws JsonElementTypeMismatchException if element is present, but has invalid type
      */
-    public fun getObject(key: String): JsonObject = get(key) as? JsonObject
+    public fun getObject(key: String): JsonObject = getValue(key) as? JsonObject
             ?: unexpectedJson(key, "JsonObject")
 
     /**
@@ -242,7 +234,7 @@ public data class JsonObject(val content: Map<String, JsonElement>) : JsonElemen
      * @throws NoSuchElementException if element is not present
      * @throws JsonElementTypeMismatchException if element is present, but has invalid type
      */
-    public fun getArray(key: String): JsonArray = get(key) as? JsonArray
+    public fun getArray(key: String): JsonArray = getValue(key) as? JsonArray
             ?: unexpectedJson(key, "JsonArray")
 
     /**
@@ -276,7 +268,7 @@ public data class JsonObject(val content: Map<String, JsonElement>) : JsonElemen
      * Returns [J] associated with given [key] or `null` if element
      * is not present or has different type
      */
-    public inline fun <reified J : JsonElement> lookup(key: String): J? = content[key] as? J
+    public inline fun <reified J : JsonElement> getAsOrNull(key: String): J? = content[key] as? J
 
     public override fun toString(): String {
         return content.entries.joinToString(
@@ -287,11 +279,17 @@ public data class JsonObject(val content: Map<String, JsonElement>) : JsonElemen
         )
     }
 
-    public override fun equals(other: Any?): Boolean = content.equals(other)
+    public override fun equals(other: Any?): Boolean = content == other
 
     public override fun hashCode(): Int = content.hashCode()
 }
 
+/**
+ * Class representing JSON array, consisting of indexed values, where value is arbitrary [JsonElement]
+ *
+ * Since this class also implements [List] interface, you can use
+ * traditional methods like [List.get] or [List.getOrNull] to obtain Json elements.
+ */
 @Serializable(JsonArraySerializer::class)
 public data class JsonArray(val content: List<JsonElement>) : JsonElement(), List<JsonElement> by content {
 
@@ -299,6 +297,7 @@ public data class JsonArray(val content: List<JsonElement>) : JsonElement(), Lis
 
     /**
      * Returns [index]-th element of an array as [JsonPrimitive]
+     * @throws IndexOutOfBoundsException if there is no element with given index
      * @throws JsonElementTypeMismatchException if element has invalid type
      */
     public fun getPrimitive(index: Int) = content[index] as? JsonPrimitive
@@ -306,6 +305,7 @@ public data class JsonArray(val content: List<JsonElement>) : JsonElement(), Lis
 
     /**
      * Returns [index]-th element of an array as [JsonObject]
+     * @throws IndexOutOfBoundsException if there is no element with given index
      * @throws JsonElementTypeMismatchException if element has invalid type
      */
     public fun getObject(index: Int) = content[index] as? JsonObject
@@ -313,6 +313,7 @@ public data class JsonArray(val content: List<JsonElement>) : JsonElement(), Lis
 
     /**
      * Returns [index]-th element of an array as [JsonArray]
+     * @throws IndexOutOfBoundsException if there is no element with given index
      * @throws JsonElementTypeMismatchException if element has invalid type
      */
     public fun getArray(index: Int) = content[index] as? JsonArray
@@ -347,7 +348,7 @@ public data class JsonArray(val content: List<JsonElement>) : JsonElement(), Lis
 
     public override fun toString() = content.joinToString(prefix = "[", postfix = "]", separator = ",")
 
-    public override fun equals(other: Any?): Boolean = content.equals(other)
+    public override fun equals(other: Any?): Boolean = content == other
 
     public override fun hashCode(): Int = content.hashCode()
 }

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -149,7 +149,7 @@ private class JsonTreeMapInput(json: Json, override val obj: JsonObject) : JsonT
     }
 
     override fun currentElement(tag: String): JsonElement {
-        return if (position % 2 == 0) JsonLiteral(tag) else obj[tag]
+        return if (position % 2 == 0) JsonLiteral(tag) else obj.getValue(tag)
     }
 
     override fun endStructure(desc: SerialDescriptor) {

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonInputOutputRecursiveTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonInputOutputRecursiveTest.kt
@@ -205,7 +205,7 @@ class JsonInputOutputRecursiveTest : JsonTestBase() {
                     ?: throw SerializationException("This class can be loaded only by JSON")
             val tree = jsonReader.decodeJson() as? JsonObject
                     ?: throw SerializationException("Expected JSON object")
-            val typeName = tree[typeAttribute].primitive.content
+            val typeName = tree.getValue(typeAttribute).primitive.content
             val objTree = JsonObject(tree.content - typeAttribute)
             return when (typeName) {
                 typeNameA -> decoder.json.fromJson(DummyRecursive.A.serializer(), objTree)

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/parser/examples/User.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/parser/examples/User.kt
@@ -19,10 +19,10 @@ object UserAddressParser : JsonParser<UserAddress>() {
     }
 
     override fun read(json: JsonObject): UserAddress {
-        val country = json["country"].content
-        val city = json["city"].contentOrNull
-        val zipCode = json["zipCode"].intOrNull
-        val metadata = json["metadata"].jsonArray.map { it.content }
+        val country = json.getValue("country").content
+        val city = json["city"]?.contentOrNull
+        val zipCode = json["zipCode"]?.intOrNull
+        val metadata = json.getValue("metadata").jsonArray.map { it.content }
         return UserAddress(country, city, zipCode, metadata)
     }
 }
@@ -37,10 +37,10 @@ object UserPropertiesParser : JsonParser<UserProperties>() {
     }
 
     override fun read(json: JsonObject): UserProperties {
-        val flag = json["flag"].boolean
-        val int = json["int"].int
-        val double = json["double"].double
-        val nullableFlag = json["nullableFlag"].booleanOrNull
+        val flag = json.getValue("flag").boolean
+        val int = json.getValue("int").int
+        val double = json.getValue("double").double
+        val nullableFlag = json["nullableFlag"]?.booleanOrNull
         return UserProperties(flag, int, double, nullableFlag)
     }
 }
@@ -54,10 +54,10 @@ object UserParser : JsonParser<User>() {
     }
 
     override fun read(json: JsonObject): User {
-        val id = json["id"].int
-        val name = json["name"].content
-        val address = UserAddressParser.read(json["address"])
-        val bag = UserPropertiesParser.read(json["bag"].jsonObject)
+        val id = json.getValue("id").int
+        val name = json.getValue("name").content
+        val address = UserAddressParser.read(json.getValue("address"))
+        val bag = UserPropertiesParser.read(json.getValue("bag").jsonObject)
         return User(id, name, address, bag)
     }
 }

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -125,6 +125,10 @@ class JsonTreeTest {
                 "three" to JsonLiteral(3),
                 "four" to JsonLiteral(4)
         ))
+        val otherJsonObject: Map<String, JsonElement> = JsonObject(mapOf(
+            "three" to JsonLiteral(3),
+            "five" to JsonLiteral(5)
+        ))
         val otherHashMap: Map<String, JsonElement> = HashMap(mapOf(
                 "three" to JsonLiteral(3),
                 "four" to JsonLiteral(5)
@@ -134,5 +138,6 @@ class JsonTreeTest {
         assertEquals(hashMap, jsonObject)
         assertEquals(jsonObject.hashCode(), hashMap.hashCode())
         assertNotEquals(jsonObject, otherHashMap)
+        assertNotEquals(jsonObject, otherJsonObject)
     }
 }


### PR DESCRIPTION
`.get` should return null for a missing key

Incompatibility with standard Map contract may bring a lot of problems, e.g. broken equals.

Fixes #358