### PR TITLE
JsonLiteral retains type of literal

### DIFF
--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonElementSerializer.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/JsonElementSerializer.kt
@@ -54,7 +54,7 @@ public object JsonPrimitiveSerializer : KSerializer<JsonPrimitive> {
         return if (obj is JsonNull) {
             JsonNullSerializer.serialize(encoder, JsonNull)
         } else {
-            JsonLiteralSerializer.serialize(encoder, obj as JsonLiteral)
+            JsonLiteralSerializer.serialize(encoder, obj as JsonLiteral<*>)
         }
     }
 
@@ -99,11 +99,11 @@ public object JsonNullSerializer : KSerializer<JsonNull> {
  * It can only be used by with [Json] format an its input ([JsonInput] and [JsonOutput]).
  */
 @Serializer(forClass = JsonLiteral::class)
-public object JsonLiteralSerializer : KSerializer<JsonLiteral> {
+public object JsonLiteralSerializer : KSerializer<JsonLiteral<*>> {
 
     override val descriptor: SerialDescriptor get() = JsonLiteralDescriptor
 
-    override fun serialize(encoder: Encoder, obj: JsonLiteral) {
+    override fun serialize(encoder: Encoder, obj: JsonLiteral<*>) {
         verify(encoder)
         if (obj.isString) {
             return encoder.encodeString(obj.content)
@@ -127,7 +127,7 @@ public object JsonLiteralSerializer : KSerializer<JsonLiteral> {
         encoder.encodeString(obj.content)
     }
 
-    override fun deserialize(decoder: Decoder): JsonLiteral {
+    override fun deserialize(decoder: Decoder): JsonLiteral<*> {
         verify(decoder)
         return JsonLiteral(decoder.decodeString())
     }

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/JsonParser.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/JsonParser.kt
@@ -26,11 +26,6 @@ internal class JsonParser(private val reader: JsonReader) {
         return JsonObject(result)
     }
 
-    private fun readValue(isString: Boolean): JsonElement {
-        val str = reader.takeString()
-        return JsonLiteral(str, isString)
-    }
-
     private fun readArray(): JsonElement {
         reader.requireTokenClass(TC_BEGIN_LIST) { "Expected start of array" }
         reader.nextToken()
@@ -47,12 +42,13 @@ internal class JsonParser(private val reader: JsonReader) {
     }
 
     fun read(): JsonElement {
-        if (!reader.canBeginValue) fail(reader.currentPosition, "Can't begin reading value from here")
+        if (!reader.canBeginValue) fail(reader.currentPosition, "Can't begin reading value from here") // TODO: Redundant?
         val tc = reader.tokenClass
         return when (tc) {
             TC_NULL -> JsonNull.also { reader.nextToken() }
-            TC_STRING -> readValue(isString = true)
-            TC_OTHER -> readValue(isString = false)
+            TC_STRING -> JsonLiteral.JsonStringLiteral(reader.takeString())
+            TC_NUMBER -> JsonLiteral.JsonNumberLiteral(reader.takeNumber())
+            TC_BOOL -> JsonLiteral.JsonBooleanLiteral(reader.takeBoolean())
             TC_BEGIN_OBJ -> readObject()
             TC_BEGIN_LIST -> readArray()
             else -> fail(reader.currentPosition, "Can't begin reading element")

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/StreamingJsonInput.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/StreamingJsonInput.kt
@@ -16,7 +16,7 @@ internal class StreamingJsonInput internal constructor(override val  json: Json,
         context = json.context
     }
 
-    public override fun decodeJson(): JsonElement = JsonParser(reader).read()
+    override fun decodeJson(): JsonElement = JsonParser(reader).read()
 
     override val updateMode: UpdateMode
         get() = json.updateMode
@@ -47,12 +47,6 @@ internal class StreamingJsonInput internal constructor(override val  json: Json,
 
     override fun decodeNotNullMark(): Boolean {
         return reader.tokenClass != TC_NULL
-    }
-
-    override fun decodeNull(): Nothing? {
-        reader.requireTokenClass(TC_NULL) { "Expected 'null' literal" }
-        reader.nextToken()
-        return null
     }
 
     override fun decodeElementIndex(desc: SerialDescriptor): Int {
@@ -92,13 +86,18 @@ internal class StreamingJsonInput internal constructor(override val  json: Json,
         }
     }
 
-    override fun decodeBoolean(): Boolean = reader.takeString().run { if (json.strictMode) toBooleanStrict() else toBoolean() }
-    override fun decodeByte(): Byte = reader.takeString().toByte()
-    override fun decodeShort(): Short = reader.takeString().toShort()
-    override fun decodeInt(): Int = reader.takeString().toInt()
-    override fun decodeLong(): Long = reader.takeString().toLong()
-    override fun decodeFloat(): Float = reader.takeString().toFloat()
-    override fun decodeDouble(): Double = reader.takeString().toDouble()
+    override fun decodeNull(): Nothing? = reader.takeNull()
+    override fun decodeBoolean(): Boolean = if (json.strictMode) {
+            reader.takeBoolean()
+        } else {
+            reader.takeNonStrictBoolean() // TODO: Undocumented behaviour
+        }
+    override fun decodeByte(): Byte = reader.takeNumber().toByte()
+    override fun decodeShort(): Short = reader.takeNumber().toShort()
+    override fun decodeInt(): Int = reader.takeNumber().toInt()
+    override fun decodeLong(): Long = reader.takeNumber().toLong()
+    override fun decodeFloat(): Float = reader.takeNumber().toFloat()
+    override fun decodeDouble(): Double = reader.takeNumber().toDouble()
     override fun decodeChar(): Char = reader.takeString().single()
     override fun decodeString(): String = reader.takeString()
     override fun decodeEnum(enumDescription: EnumDescriptor): Int = enumDescription.getElementIndex(reader.takeString())

--- a/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/TreeJsonOutput.kt
+++ b/runtime/common/src/main/kotlin/kotlinx/serialization/json/internal/TreeJsonOutput.kt
@@ -117,7 +117,7 @@ private class JsonTreeMapOutput(json: Json, nodeConsumer: (JsonElement) -> Unit)
     override fun putElement(key: String, element: JsonElement) {
         val idx = key.toInt()
         if (idx % 2 == 0) { // writing key
-            check(element is JsonLiteral) { "Expected JsonLiteral, but has $element" }
+            check(element is JsonLiteral<*>) { "Expected JsonLiteral, but has $element" }
             tag = element.content
         } else {
             content[tag] = element

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonParserFuzzerTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/JsonParserFuzzerTest.kt
@@ -24,7 +24,7 @@ class JsonParserFuzzerTest {
     fun testQuotedBrace() {
         val tree = parse("""{x: "{"}""")
         assertTrue("x" in tree)
-        assertEquals("{", tree.getAs<JsonLiteral>("x").content)
+        assertEquals("{", tree.getAs<JsonLiteral<*>>("x").content)
     }
 
     private fun parse(input: String) = Json.plain.parseJson(input).jsonObject
@@ -33,7 +33,7 @@ class JsonParserFuzzerTest {
     fun testEmptyKey() {
         val tree = parse("""{"":"","":""}""")
         assertTrue("" in tree)
-        assertEquals("", tree.getAs<JsonLiteral>("").content)
+        assertEquals("", tree.getAs<JsonLiteral<*>>("").content)
     }
 
     @Test

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -140,4 +140,30 @@ class JsonTreeTest {
         assertNotEquals(jsonObject, otherHashMap)
         assertNotEquals(jsonObject, otherJsonObject)
     }
+
+    @Test
+    fun testThatJsonLiteralsAreDistinguishable() {
+        val input = """{
+                "numberString": "10", "number": 10,
+                "boolString": "true", "boolInt": 1, "bool": true,
+                "nullString": "null", "null": null
+            }""".trimMargin()
+        val parsed = parse(input) as JsonObject
+
+        with(parsed) {
+            fun getLiteral(key: String) : JsonLiteral =
+                get(key) as JsonLiteral
+
+            assertNotEquals(getLiteral("numberString"), getLiteral("number"))
+            assertNotEquals(getLiteral("boolString"), getLiteral("bool"))
+            assertNotEquals(getLiteral("boolInt"), getLiteral("bool"))
+            assertNotEquals(getLiteral("boolInt"), getLiteral("boolString"))
+            assertNotEquals(get("nullString"), get("null"))
+
+            assertNotEquals(getLiteral("numberString").body, getLiteral("number").body)
+            assertNotEquals(getLiteral("boolString").body, getLiteral("bool").body)
+            assertNotEquals(getLiteral("boolInt").body, getLiteral("bool").body)
+            assertNotEquals(getLiteral("boolInt").body, getLiteral("boolString").body)
+        }
+    }
 }

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -151,13 +151,13 @@ class JsonTreeTest {
         val parsed = parse(input) as JsonObject
 
         with(parsed) {
-            fun getLiteral(key: String) : JsonLiteral =
-                get(key) as JsonLiteral
+            fun getLiteral(key: String) : JsonLiteral<*> =
+                get(key) as JsonLiteral<*>
 
-            assertNotEquals(getLiteral("numberString"), getLiteral("number"))
-            assertNotEquals(getLiteral("boolString"), getLiteral("bool"))
-            assertNotEquals(getLiteral("boolInt"), getLiteral("bool"))
-            assertNotEquals(getLiteral("boolInt"), getLiteral("boolString"))
+            assertNotEquals(get("numberString"), get("number"))
+            assertNotEquals(get("boolString"), get("bool"))
+            assertNotEquals(get("boolInt"), get("bool"))
+            assertNotEquals(get("boolInt"), get("boolString"))
             assertNotEquals(get("nullString"), get("null"))
 
             assertNotEquals(getLiteral("numberString").body, getLiteral("number").body)

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -142,15 +142,68 @@ class JsonTreeTest {
     }
 
     @Test
+    fun testThatLiteralsAreDetected() {
+        val input = """{
+                "number1": 10,
+                "number2": -3,
+                "number3": 0.7,
+                "number4": 9999999999,
+                "bool1": true,
+                "bool2": false,
+                "string": "abc",
+                "null": null
+            }""".trimMargin()
+
+        with(parse(input) as JsonObject) {
+            get("number1").let {
+                assertTrue(it is JsonLiteral.JsonNumberLiteral)
+                assertEquals(it.body, 10)
+            }
+            get("number2").let {
+                assertTrue(it is JsonLiteral.JsonNumberLiteral)
+                assertEquals(it.body, -3)
+            }
+            get("number3").let {
+                assertTrue(it is JsonLiteral.JsonNumberLiteral)
+                assertEquals(it.body, 0.7)
+            }
+            get("number4").let {
+                assertTrue(it is JsonLiteral.JsonNumberLiteral)
+                assertEquals(it.body, 9999999999L)
+            }
+            get("bool1").let {
+                assertTrue(it is JsonLiteral.JsonBooleanLiteral)
+                assertEquals(it.body, true)
+            }
+            get("bool2").let {
+                assertTrue(it is JsonLiteral.JsonBooleanLiteral)
+                assertEquals(it.body, false)
+            }
+            get("string").let {
+                assertTrue(it is JsonLiteral.JsonStringLiteral)
+                assertEquals(it.body, "abc")
+            }
+            assertTrue(get("null") is JsonNull)
+        }
+    }
+
+    @Test @Ignore // Not yet supported, cf [JsonReader.takeNumber]
+    fun testNumberLiteralsWithExponent() {
+        val input = "[1e3, 1000e-3, 1.75E2, 1e0]"
+
+        assertEquals(listOf<Number>(1000, 1.0, 175.0, 1).map { JsonLiteral.JsonNumberLiteral(it) } as List<JsonElement>,
+                     parse(input) as JsonArray)
+    }
+
+    @Test
     fun testThatJsonLiteralsAreDistinguishable() {
         val input = """{
                 "numberString": "10", "number": 10,
                 "boolString": "true", "boolInt": 1, "bool": true,
                 "nullString": "null", "null": null
             }""".trimMargin()
-        val parsed = parse(input) as JsonObject
 
-        with(parsed) {
+        with(parse(input) as JsonObject) {
             fun getLiteral(key: String) : JsonLiteral<*> =
                 get(key) as JsonLiteral<*>
 

--- a/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/Primitives.kt
+++ b/runtime/common/src/test/kotlin/kotlinx/serialization/json/serializers/Primitives.kt
@@ -17,7 +17,7 @@ data class JsonPrimitiveWrapper(val primitive: JsonPrimitive)
 data class JsonNullWrapper(val element: JsonNull)
 
 @Serializable
-data class JsonLiteralWrapper(val literal: JsonLiteral)
+data class JsonLiteralWrapper(val literal: JsonLiteral<*>)
 
 @Serializable
 data class JsonObjectWrapper(val element: JsonObject)


### PR DESCRIPTION
Here's a proposal for a `JsonLiteral` that knows which type of value the original JSON had (cf. #303).

I tried not to break its interface; users of the class need to add the wildcard type parameter `<*>`.

Does making `JsonLiteral` generic have consequences beyond what the tests cover? Can't say I have an overview over the actual object serialization parts of the library.

I can see potential changes to the interface but I'm not sure how far to go in an experimental library, so I stayed conservative.
On concrete thing: `JsonNull` could be a `JsonLiteral` now, couldn't it?