### PR TITLE
Deprecate unaryPlus for Json array builder in favor of `add`.

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("RedundantVisibilityModifier")
@@ -34,6 +34,7 @@ public class JsonArrayBuilder internal constructor() {
     /**
      * Adds [this] value to the current [JsonArray] as [JsonPrimitive].
      */
+    @Deprecated("Deprecated due to ambiguity", ReplaceWith("add(this)"), DeprecationLevel.ERROR)
     public operator fun String?.unaryPlus() {
         content.add(JsonPrimitive(this))
     }
@@ -41,6 +42,7 @@ public class JsonArrayBuilder internal constructor() {
     /**
      * Adds [this] value to the current [JsonArray] as [JsonPrimitive].
      */
+    @Deprecated("Deprecated due to ambiguity", ReplaceWith("add(this)"), DeprecationLevel.ERROR)
     public operator fun Number?.unaryPlus() {
         content.add(JsonPrimitive(this))
     }
@@ -48,6 +50,7 @@ public class JsonArrayBuilder internal constructor() {
     /**
      * Adds [this] value to the current [JsonArray] as [JsonPrimitive].
      */
+    @Deprecated("Deprecated due to ambiguity", ReplaceWith("add(this)"), DeprecationLevel.ERROR)
     public operator fun Boolean?.unaryPlus() {
         content.add(JsonPrimitive(this))
     }
@@ -55,8 +58,37 @@ public class JsonArrayBuilder internal constructor() {
     /**
      * Adds [this] value to the current [JsonArray].
      */
+    @Deprecated("Deprecated due to ambiguity", ReplaceWith("add(this)"), DeprecationLevel.ERROR)
     public operator fun JsonElement.unaryPlus() {
         this@JsonArrayBuilder.content.add(this)
+    }
+
+    /**
+     * Adds [string] value to the current [JsonArray] as [JsonPrimitive].
+     */
+    public fun add(string: String?) {
+        content.add(JsonPrimitive(string))
+    }
+
+    /**
+     * Adds [number] value to the current [JsonArray] as [JsonPrimitive].
+     */
+    public fun add(number: Number?) {
+        content.add(JsonPrimitive(number))
+    }
+
+    /**
+     * Adds [bool] value to the current [JsonArray] as [JsonPrimitive].
+     */
+    public fun add(bool: Boolean?) {
+        content.add(JsonPrimitive(bool))
+    }
+
+    /**
+     * Adds [element] to the current [JsonArray].
+     */
+    public fun add(element: JsonElement) {
+        this@JsonArrayBuilder.content.add(element)
     }
 }
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonArraySerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonArraySerializerTest.kt
@@ -42,15 +42,15 @@ class JsonArraySerializerTest : JsonTestBase() {
 
     private fun prebuiltJson(): JsonArray {
         return jsonArray {
-            +JsonLiteral(1)
-            +JsonNull
-            +jsonArray {
-                +JsonLiteral("nested literal")
-            }
-            +jsonArray { }
-            +json {
+            add(1)
+            add(JsonNull)
+            add(jsonArray {
+                add("nested literal")
+            })
+            add(jsonArray { })
+            add(json {
                 "key" to "value"
-            }
+            })
         }
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonSerializerInGenericsTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonSerializerInGenericsTest.kt
@@ -27,7 +27,7 @@ class JsonSerializerInGenericsTest : JsonTestBase() {
 
     private fun create(): NonTrivialClass {
         return NonTrivialClass(
-            arrayListOf(JsonPrimitive(42), jsonArray { +json { "key" to "value" } }, null),
+            arrayListOf(JsonPrimitive(42), jsonArray { add(json { "key" to "value" }) }, null),
             null,
             mapOf("key1" to mapOf("nested" to json {
                 "first" to "second"


### PR DESCRIPTION
Mainly because of #418

There are three ways for it:

1. Do nothing.
2. Deprecate `unaryPlus` only for `Number` (and probably other primitives)
3. Deprecate all overloads, including one with `JsonElement`.

This PR implements 3), but I suggest considering 2) as a resolution, because using `add` everywhere seems verbose and overhead-ish to me (see diff of `JsonArraySerializersTest`). However, this will lead to inconsistency: `JsonElement` would be added via `unaryPlus` and other primitives via `add`. WDYT, @qwwdfsad ?