### PR TITLE
Default polymorphic serializer for unregistered types

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleBuilders.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleBuilders.kt
@@ -73,6 +73,19 @@ public class SerializersModuleBuilder internal constructor(@JvmField internal va
     }
 
     /**
+     * Adds [defaultSerializer] as the default serializer in the scope of [baseClass] for polymorphic serialization.
+     * It will be used in case a type that is not registered is found.
+     * Throws [SerializationException] if a module already has a default serializer in the scope of [baseClass].
+     * To overwrite an already registered serializer, [SerialModule.overwriteWith] can be used.
+     */
+    override fun <Base : Any> polymorphicDefault(
+        baseClass: KClass<Base>,
+        defaultSerializer: KSerializer<Base>
+    ) {
+       impl.registerPolymorphicDefaultSerializer(baseClass, defaultSerializer)
+    }
+
+    /**
      * Copies contents of [other] module into current builder.
      */
     public fun include(other: SerialModule) {

--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleCollector.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleCollector.kt
@@ -28,6 +28,14 @@ public interface SerialModuleCollector {
         actualClass: KClass<Sub>,
         actualSerializer: KSerializer<Sub>
     )
+
+    /**
+     * Accepts a default serializer, associated with [baseClass] for polymorphic serialization.
+     */
+    public fun <Base : Any> polymorphicDefault(
+        baseClass: KClass<Base>,
+        defaultSerializer: KSerializer<Base>
+    )
 }
 
 /**

--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleExtensions.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleExtensions.kt
@@ -61,5 +61,12 @@ public infix fun SerialModule.overwriteWith(other: SerialModule): SerialModule =
         ) {
             impl.registerPolymorphicSerializer(baseClass, actualClass, actualSerializer, allowOverwrite = true)
         }
+
+        override fun <Base : Any> polymorphicDefault(
+                baseClass: KClass<Base>,
+                defaultSerializer: KSerializer<Base>
+        ) {
+            impl.registerPolymorphicDefaultSerializer(baseClass, defaultSerializer, allowOverwrite = true)
+        }
     })
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPolymorphicDefaultDeserializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPolymorphicDefaultDeserializerTest.kt
@@ -1,0 +1,42 @@
+package kotlinx.serialization.json.polymorphic
+
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.SerialClassDescImpl
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+import kotlin.test.*
+
+class JsonPolymorphicDefaultDeserializerTest : JsonTestBase() {
+
+    private val defaultSerializer: KSerializer<InnerBase> = object : KSerializer<InnerBase> {
+        override fun serialize(encoder: Encoder, obj: InnerBase) {
+            encoder.beginStructure(descriptor).endStructure(descriptor)
+        }
+
+        override fun deserialize(decoder: Decoder): InnerBase = InnerImpl2(42)
+
+        override val descriptor: SerialDescriptor = SerialClassDescImpl("NotExisting")
+    }
+
+    private val json = Json {
+        unquoted = true
+        serialModule = SerializersModule {
+            polymorphic<InnerBase> {
+                addSubclass(InnerImpl.serializer())
+                setDefaultSerializer(defaultSerializer)
+            }
+        }
+    }
+
+    @Test
+    fun testPolymorphicDefaultSerialization() {
+        assertEquals("{type:NotExisting}", json.stringify(PolymorphicSerializer(InnerBase::class), InnerImpl2(42), true))
+    }
+
+    @Test
+    fun testPolymorphicDefaultDeserialization() {
+        val string = "{type:kotlinx.serialization.json.polymorphic.NotExistingInnerImpl}"
+        assertEquals(InnerImpl2(42), json.parse(PolymorphicSerializer(InnerBase::class), string, true))
+    }
+
+}

--- a/runtime/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
@@ -140,6 +140,29 @@ class ModuleBuildersTest {
     }
 
     @Test
+    fun testPolymorphicDefaultDSL() {
+        val defaultSerializer = object : KSerializer<PolyBase> {
+            override fun serialize(encoder: Encoder, obj: PolyBase) = TODO()
+            override fun deserialize(decoder: Decoder): PolyBase = TODO()
+            override val descriptor: SerialDescriptor
+                get() = TODO()
+        }
+
+        val module = SerializersModule {
+            polymorphic<PolyBase> {
+                addSubclass(PolyDerived.serializer())
+                setDefaultSerializer(defaultSerializer)
+            }
+        }
+
+        val base = PolyBase(10)
+        val derived = PolyDerived("foo")
+
+        assertEquals(defaultSerializer, module.getPolymorphic(PolyBase::class, base))
+        assertEquals(PolyDerived.serializer(), module.getPolymorphic(PolyBase::class, derived))
+    }
+
+    @Test
     fun testOverwriteSerializer() {
         val moduleA = SerializersModule {
             contextual(A::class, ASerializer)


### PR DESCRIPTION
Allows to configure a default serializer that will be used in serialization/deserialization when a subtype that is not registered is found.