### PR TITLE
wasm32 is added as a build target

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -29,7 +29,6 @@ def deployMode = property('native.deploy') == 'true'
 
 kotlin {
     infra {
-        target('wasm32')
         target('macosX64')
         target('linuxX64')
         if (deployMode) {
@@ -37,10 +36,9 @@ kotlin {
             target('iosArm64')
             target('iosArm32')
             target('iosX64')
+            target('wasm32')
         }
     }
-
-    wasm32 {}
 
     targets {
         fromPreset(presets.jvm, 'jvm') {
@@ -123,17 +121,6 @@ kotlin {
             dependencies {
                 api 'org.jetbrains.kotlin:kotlin-stdlib-js'
             }
-        }
-
-        wasm32Main{
-            dependsOn nativeMain
-            dependencies {
-                implementation kotlin("stdlib")
-            }
-        }
-
-        wasm32Test{
-            dependsOn nativeTest
         }
 
         jsTest {

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -29,6 +29,7 @@ def deployMode = property('native.deploy') == 'true'
 
 kotlin {
     infra {
+        target('wasm32')
         target('macosX64')
         target('linuxX64')
         if (deployMode) {
@@ -38,6 +39,8 @@ kotlin {
             target('iosX64')
         }
     }
+
+    wasm32 {}
 
     targets {
         fromPreset(presets.jvm, 'jvm') {
@@ -120,6 +123,17 @@ kotlin {
             dependencies {
                 api 'org.jetbrains.kotlin:kotlin-stdlib-js'
             }
+        }
+
+        wasm32Main{
+            dependsOn nativeMain
+            dependencies {
+                implementation kotlin("stdlib")
+            }
+        }
+
+        wasm32Test{
+            dependsOn nativeTest
         }
 
         jsTest {


### PR DESCRIPTION
Just to be able to use the serializer inside wasm32 projects,

```gradle
wasm32Main {
            dependencies {
                implementation kotlin("stdlib")
                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-wasm32:$kotlin_serialization"                  
            }
        }
```