### PR TITLE
Make the baseclass of the polymorphic serializer public.

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
@@ -78,7 +78,7 @@ public object PolymorphicClassDescriptor : SerialClassDescImpl("kotlin.Any") {
  * @see SerializersModule
  * @see SerializersModuleBuilder.polymorphic
  */
-public class PolymorphicSerializer<T : Any>(private val baseClass: KClass<T>) : KSerializer<Any> {
+public class PolymorphicSerializer<T : Any>(public val baseClass: KClass<T>) : KSerializer<Any> {
     public override val descriptor: SerialDescriptor = PolymorphicClassDescriptor
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
This allow formats to look up all candidates in the `SerialContext` for the given serializer. Likely this information is more useful in the PolymorphicDescriptor, but similar information is also needed for other container types (lists, NullableSerializer etc.). In most cases is is probably better to provide the serializer rather than the descriptor.