### PR TITLE
Make makeNullable extension, make NullableSerializer internal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,14 @@ buildscript {
     }
     ext.experimentalsEnabled = ["-progressive", "-Xuse-experimental=kotlin.Experimental",
                                 "-Xuse-experimental=kotlin.ExperimentalMultiplatform",
+                                "-Xuse-experimental=kotlinx.serialization.InternalSerializationApi"
     ]
 
     ext.experimentalsInTestEnabled = ["-progressive", "-Xuse-experimental=kotlin.Experimental",
                                       "-Xuse-experimental=kotlin.ExperimentalMultiplatform",
                                       "-Xuse-experimental=kotlinx.serialization.ImplicitReflectionSerializer",
-                                      "-Xuse-experimental=kotlinx.serialization.UnstableDefault"
+                                      "-Xuse-experimental=kotlinx.serialization.UnstableDefault",
+                                      "-Xuse-experimental=kotlinx.serialization.InternalSerializationApi"
     ]
 
     /*

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -144,6 +144,7 @@ kotlin {
     sourceSets.findAll({ it.name.contains("Test") }).forEach { srcSet ->
         srcSet.languageSettings {
             it.useExperimentalAnnotation("kotlinx.serialization.UnstableDefault")
+            it.useExperimentalAnnotation("kotlinx.serialization.InternalSerializationApi")
 
             if (srcSet.name.contains("jvm") || srcSet.name.contains("js")) {
                 it.useExperimentalAnnotation("kotlinx.serialization.ImplicitReflectionSerializer")

--- a/runtime/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -4,7 +4,7 @@
 
 package kotlinx.serialization
 
-import kotlin.reflect.KClass
+import kotlin.reflect.*
 
 /**
  * Instructs to use specific serializer for class, property or type argument.
@@ -99,3 +99,15 @@ public annotation class UseSerializers(vararg val serializerClasses: KClass<out 
  */
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 public annotation class Polymorphic
+
+
+/**
+ * Public API marked with this annotation is effectively **internal**, which means
+ * it should not be used outside of `kotlinx.serialization`.
+ * Signature, semantics, source and binary compatibilities are not guaranteed for this API
+ * and will be changed without any warnings or migration aids.
+ * If you cannot avoid using internal API to solve your problem, please report your use-case to serialization's issue tracker.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Experimental(level = Experimental.Level.ERROR)
+public annotation class InternalSerializationApi

--- a/runtime/commonMain/src/kotlinx/serialization/SerializerResolving.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SerializerResolving.kt
@@ -78,5 +78,5 @@ public fun serializer(type: KType): KSerializer<Any?> {
     }
 
     val result = serializerByKTypeImpl(type)
-    return if (type.isMarkedNullable) makeNullable(result) else result as KSerializer<Any?>
+    return if (type.isMarkedNullable) result.nullable else result as KSerializer<Any?>
 }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
@@ -1,39 +1,42 @@
 /*
  * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-
 package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
-import kotlin.reflect.KClass
 
-fun <T : Any> makeNullable(actualSerializer: KSerializer<T>): KSerializer<T?> = NullableSerializer(actualSerializer)
 
-class NullableSerializer<T : Any>(public val actualSerializer: KSerializer<T>) : KSerializer<T?> {
-    private class SerialDescriptorForNullable(val original: SerialDescriptor): SerialDescriptor by original {
-        override val isNullable: Boolean
-            get() = true
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (other !is SerialDescriptorForNullable) return false
-
-            if (original != other.original) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            return original.hashCode() * 31
-        }
+/**
+ * Returns a nullable serializer for the given serializer of non-null type.
+ */
+public val <T : Any> KSerializer<T>.nullable: KSerializer<T?>
+    get() {
+        @Suppress("UNCHECKED_CAST")
+        return if (descriptor.isNullable) (this as KSerializer<T?>) else NullableSerializer(this)
     }
 
-    override val descriptor: SerialDescriptor = SerialDescriptorForNullable(actualSerializer.descriptor)
+@Deprecated(
+    message = "Deprecated in the favor of extension",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("actualSerializer.nullable)")
+)
+fun <T : Any> makeNullable(actualSerializer: KSerializer<T>): KSerializer<T?> {
+    return NullableSerializer(actualSerializer)
+}
+
+/**
+ * Use [KSerializer.nullable][nullable] instead.
+ * @suppress internal API
+ */
+@InternalSerializationApi
+public class NullableSerializer<T : Any>(private val serializer: KSerializer<T>) : KSerializer<T?> {
+
+    override val descriptor: SerialDescriptor = SerialDescriptorForNullable(serializer.descriptor)
 
     override fun serialize(encoder: Encoder, obj: T?) {
         if (obj != null) {
             encoder.encodeNotNullMark()
-            encoder.encodeSerializableValue(actualSerializer, obj)
+            encoder.encodeSerializableValue(serializer, obj)
         }
         else {
             encoder.encodeNull()
@@ -41,14 +44,30 @@ class NullableSerializer<T : Any>(public val actualSerializer: KSerializer<T>) :
     }
 
     override fun deserialize(decoder: Decoder): T? {
-        return if (decoder.decodeNotNullMark()) decoder.decodeSerializableValue(actualSerializer) else decoder.decodeNull()
+        return if (decoder.decodeNotNullMark()) decoder.decodeSerializableValue(serializer) else decoder.decodeNull()
     }
 
     override fun patch(decoder: Decoder, old: T?): T? {
         return when {
             old == null -> deserialize(decoder)
-            decoder.decodeNotNullMark() -> decoder.updateSerializableValue(actualSerializer, old)
+            decoder.decodeNotNullMark() -> decoder.updateSerializableValue(serializer, old)
             else -> decoder.decodeNull().let { old }
+        }
+    }
+
+    private class SerialDescriptorForNullable(private val original: SerialDescriptor): SerialDescriptor by original {
+        override val isNullable: Boolean
+            get() = true
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is SerialDescriptorForNullable) return false
+            if (original != other.original) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return original.hashCode() * 31
         }
     }
 }

--- a/runtime/commonMain/src/kotlinx/serialization/modules/StandardSubtypesOfAny.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/StandardSubtypesOfAny.kt
@@ -11,44 +11,32 @@ import kotlin.reflect.KClass
 internal object StandardSubtypesOfAny {
     private val map: Map<KClass<*>, KSerializer<*>> = mapOf(
         List::class to ArrayListSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            )
+            PolymorphicSerializer(Any::class).nullable
         ),
         LinkedHashSet::class to LinkedHashSetSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            )
+            PolymorphicSerializer(Any::class).nullable
         ),
         HashSet::class to HashSetSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            )
+            PolymorphicSerializer(Any::class).nullable
         ),
         Set::class to LinkedHashSetSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            )
+            PolymorphicSerializer(Any::class).nullable
         ),
         LinkedHashMap::class to LinkedHashMapSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            ), makeNullable(PolymorphicSerializer(Any::class))
+            PolymorphicSerializer(Any::class).nullable,
+            PolymorphicSerializer(Any::class).nullable
         ),
         HashMap::class to HashMapSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            ), makeNullable(PolymorphicSerializer(Any::class))
+            PolymorphicSerializer(Any::class).nullable,
+            PolymorphicSerializer(Any::class).nullable
         ),
         Map::class to LinkedHashMapSerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            ), makeNullable(PolymorphicSerializer(Any::class))
+            PolymorphicSerializer(Any::class).nullable,
+            PolymorphicSerializer(Any::class).nullable
         ),
         Map.Entry::class to MapEntrySerializer(
-            makeNullable(
-                PolymorphicSerializer(Any::class)
-            ), makeNullable(PolymorphicSerializer(Any::class))
+            PolymorphicSerializer(Any::class).nullable,
+            PolymorphicSerializer(Any::class).nullable
         ),
         String::class to StringSerializer,
         Char::class to CharSerializer,

--- a/runtime/commonTest/src/kotlinx/serialization/cbor/CborRootLevelNullsTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/cbor/CborRootLevelNullsTest.kt
@@ -15,7 +15,7 @@ class CborRootLevelNullsTest {
     @Test
     fun testNull() {
         val obj: Simple? = null
-        val content = (Cbor as BinaryFormat).dump(makeNullable(Simple.serializer()), obj)
+        val content = (Cbor as BinaryFormat).dump(Simple.serializer().nullable, obj)
         assertTrue(content.contentEquals(byteArrayOf(0xf6.toByte())))
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonRootLevelNullTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonRootLevelNullTest.kt
@@ -17,13 +17,13 @@ class JsonRootLevelNullTest : JsonTestBase() {
     fun testNullableStringify() {
         // Top-level nulls in tagged encoder is not yet supported, no parametrized test
         val obj: Simple? = null
-        val json = strict.stringify(makeNullable(Simple.serializer()), obj)
+        val json = strict.stringify(Simple.serializer().nullable, obj)
         assertEquals("null", json)
     }
 
     @Test
     fun testNullableParse() = parametrizedTest { useStreaming ->
-        val result = strict.parse(makeNullable(Simple.serializer()), "null", useStreaming)
+        val result = strict.parse(Simple.serializer().nullable, "null", useStreaming)
         assertNull(result)
     }
 }


### PR DESCRIPTION
    * Extension is more expressive, readable and is aligned with Kotlin conventions
    * NullableSerializer is an implementation detail and should not be exposed