### PR TITLE
Fix the library to not create a stack overflow exception when creating a MissingDescriptorException.

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/internal/SerialClassDescImpl.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/SerialClassDescImpl.kt
@@ -110,5 +110,5 @@ open class SerialClassDescImpl @JvmOverloads constructor(
     }
 
     private class MissingDescriptorException(index: Int, origin: SerialDescriptor) :
-        SerializationException("Element descriptor at index $index has not been found in $origin")
+        SerializationException("Element descriptor at index $index has not been found in ${origin.name}")
 }

--- a/runtime/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
@@ -17,11 +17,13 @@
 package kotlinx.serialization.features
 
 import kotlinx.serialization.*
+import kotlinx.serialization.internal.SerialClassDescImpl
 import kotlinx.serialization.modules.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class PolymorphismTest {
 
@@ -62,5 +64,18 @@ class PolymorphismTest {
         val obj = PolyDerived("b")
         val s = json.stringify(PolymorphicSerializer(PolyDerived::class), obj)
         assertEquals("[kotlinx.serialization.features.PolyDerived,{id:1,s:b}]", s)
+    }
+
+    @Test
+    fun testElementDescriptors() {
+        val serializer = PolymorphicSerializer(PolyDerived::class)
+        try {
+            serializer.descriptor.getElementDescriptor(1)
+            fail ("Exception expected")
+        } catch (e: Exception) {
+            if (e !is SerializationException) {
+                fail ("Exception is not a serialization exception, but $e")
+            }
+        }
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
@@ -17,13 +17,12 @@
 package kotlinx.serialization.features
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.SerialClassDescImpl
 import kotlinx.serialization.modules.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
+import kotlin.test.assertFailsWith
 
 class PolymorphismTest {
 
@@ -69,13 +68,8 @@ class PolymorphismTest {
     @Test
     fun testElementDescriptors() {
         val serializer = PolymorphicSerializer(PolyDerived::class)
-        try {
+        assertFailsWith(SerializationException::class) {
             serializer.descriptor.getElementDescriptor(1)
-            fail ("Exception expected")
-        } catch (e: Exception) {
-            if (e !is SerializationException) {
-                fail ("Exception is not a serialization exception, but $e")
-            }
         }
     }
 }


### PR DESCRIPTION
Unfortunately MissingDescriptorException uses the toString of the descriptor. This by default lists all component descriptors. Obviously that creates a stack overflow. This patch adds a simple test that triggers the error, and a fix that uses the name of the violating descriptor rather than the toString. It may be possible to use toString (or to simulate it), but that would introduce significantly more complexity.