### PR TITLE
Skip null fields in ProtoBuf serialization for CLASS type fields

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonOutput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonOutput.kt
@@ -166,7 +166,8 @@ private class JsonTreeMapOutput(json: Json, nodeConsumer: (JsonElement) -> Unit)
         return JsonObject(content)
     }
 
-    override fun shouldWriteElement(desc: SerialDescriptor, tag: String, index: Int): Boolean = true
+    override fun <T: Any?> shouldWriteElement(desc: SerialDescriptor, tag: String, index: Int, value: T): Boolean = true
+    override fun shouldWriteNullElement(desc: SerialDescriptor, tag: String, index: Int): Boolean = true
 }
 
 private class JsonTreeListOutput(json: Json, nodeConsumer: (JsonElement) -> Unit) :
@@ -174,7 +175,8 @@ private class JsonTreeListOutput(json: Json, nodeConsumer: (JsonElement) -> Unit
     private val array: ArrayList<JsonElement> = arrayListOf()
     override fun elementName(desc: SerialDescriptor, index: Int): String = index.toString()
 
-    override fun shouldWriteElement(desc: SerialDescriptor, tag: String, index: Int): Boolean = true
+    override fun <T: Any?> shouldWriteElement(desc: SerialDescriptor, tag: String, index: Int, value: T): Boolean = true
+    override fun shouldWriteNullElement(desc: SerialDescriptor, tag: String, index: Int): Boolean = true
 
     override fun putElement(key: String, element: JsonElement) {
         val idx = key.toInt()

--- a/runtime/commonMain/src/kotlinx/serialization/protobuf/ProtoBuf.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/protobuf/ProtoBuf.kt
@@ -40,6 +40,9 @@ class ProtoBuf(context: SerialModule = EmptyModule) : AbstractSerialFormat(conte
             else -> throw SerializationException("Primitives are not supported at top-level")
         }
 
+        override fun shouldWriteNullElement(desc: SerialDescriptor, tag: ProtoDesc, index: Int): Boolean =
+            desc.kind !is StructureKind.CLASS
+
         override fun encodeTaggedInt(tag: ProtoDesc, value: Int) = encoder.writeInt(value, tag.first, tag.second)
         override fun encodeTaggedByte(tag: ProtoDesc, value: Byte) = encoder.writeInt(value.toInt(), tag.first, tag.second)
         override fun encodeTaggedShort(tag: ProtoDesc, value: Short) = encoder.writeInt(value.toInt(), tag.first, tag.second)

--- a/runtime/commonTest/src/kotlinx/serialization/protobuf/ProtobufReaderTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/protobuf/ProtobufReaderTest.kt
@@ -59,4 +59,9 @@ class ProtobufReaderTest {
         if (isNative()) return // todo: support update on Native
         ProtoBuf.loads(TestIntWithList.serializer(), "500308960150045005") shouldBe TestIntWithList(150, listOf(3, 4, 5))
     }
+
+    @Test
+    fun readObjectWithNullableMissingFields() {
+        ProtoBuf.loads(TestInnerNullable.serializer(), "1a0308ab02") shouldBe t7
+    }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/protobuf/ProtobufWriterTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/protobuf/ProtobufWriterTest.kt
@@ -58,4 +58,9 @@ class ProtobufWriterTest {
     fun writeNumbers() {
         ProtoBuf.dumps(TestNumbers.serializer(), t6).toLowerCase() shouldBe "0d9488010010ffffffffffffffff7f"
     }
+
+    @Test
+    fun writeNullableFields() {
+        ProtoBuf.dumps(TestInnerNullable.serializer(), t7).toLowerCase() shouldBe "1a0308ab02"
+    }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/protobuf/SampleClasses.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/protobuf/SampleClasses.kt
@@ -33,6 +33,9 @@ data class TestString(@SerialId(2) val b: String)
 data class TestInner(@SerialId(3) val a: TestInt)
 
 @Serializable
+data class TestInnerNullable(@SerialId(3) val a: TestInt, @SerialId(4) val b: TestInt? = null)
+
+@Serializable
 data class TestComplex(@SerialId(42) val b: Int, @SerialId(2) val c: String)
 
 @Serializable
@@ -53,3 +56,4 @@ val t3e = TestString("")
 val t4 = TestInner(t1)
 val t5 = TestComplex(42, "testing")
 val t6 = TestNumbers(100500, Long.MAX_VALUE)
+val t7 = TestInnerNullable(t1, null)


### PR DESCRIPTION
Resubmission of https://github.com/Kotlin/kotlinx.serialization/pull/588

The issue blocks any real usage of kotlinx.serialization, as there is no way to serialize an optional field as of right now. I suggest this as an easy and mostly-compatible fix until a long-term solution is devised.

The solution here introduces separate `TaggedEncoder#shouldWriteNullElement` method, which can be overriden by different Encoders to provide custom null-handling behaviour. For this PR only ProtoBufEncoder overrides it to skip null CLASS type fields (as should be completely compatible with Proto spec).

Other encoders could also benefit from this, for example an extra setting could be added to JSON encoder to skip null fields altogether.