### PR TITLE
Support for multiple alternative names during JSON parsing

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/PlatformUtils.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/PlatformUtils.kt
@@ -4,8 +4,9 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.internal.builtinSerializerOrNull
-import kotlin.reflect.KClass
+import kotlinx.serialization.internal.*
+import kotlin.native.concurrent.*
+import kotlin.reflect.*
 
 /**
  * Retrieves a [KSerializer] for the given [KClass].
@@ -56,4 +57,9 @@ internal expect fun Any.isInstanceOf(kclass: KClass<*>): Boolean
  */
 internal expect fun <T : Any> KClass<T>.simpleName(): String?
 
-internal expect fun <K, V> createMapForCache(initialCapacity: Int = 8): MutableMap<K, V>
+/**
+ * Creates a ConcurrentHashMap on JVM and regular HashMap on other platforms.
+ * To make actual use of cache in Kotlin/Native, mark a top-level object with this map
+ * as a @[ThreadLocal].
+ */
+internal expect fun <K, V> createMapForCache(initialCapacity: Int): MutableMap<K, V>

--- a/runtime/commonMain/src/kotlinx/serialization/PlatformUtils.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/PlatformUtils.kt
@@ -55,3 +55,5 @@ internal expect fun Any.isInstanceOf(kclass: KClass<*>): Boolean
  * On JVM, it uses `java.lang.Class.getSimpleName()` (therefore does not work for local classes and other edge cases).
  */
 internal expect fun <T : Any> KClass<T>.simpleName(): String?
+
+internal expect fun <K, V> createMapForCache(initialCapacity: Int = 8): MutableMap<K, V>

--- a/runtime/commonMain/src/kotlinx/serialization/SchemaCache.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SchemaCache.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+private typealias DescriptorData<T> = MutableMap<DescriptorSchemaCache.Key<T>, T>
+
+/**
+ * A type-safe map for storing custom information (such as format schema), associated with [SerialDescriptor].
+ *
+ * This map is not thread safe. For thread safety and performance reasons, it is advised to pass it via stack (e.g. in function parameters)
+ */
+public class DescriptorSchemaCache {
+    private val map: MutableMap<SerialDescriptor, DescriptorData<Any>> = hashMapOf()
+
+    public operator fun <T : Any> set(descriptor: SerialDescriptor, key: Key<T>, value: T): Unit {
+        map.getOrPut(descriptor, ::hashMapOf)[key as Key<Any>] = value as Any
+    }
+
+    public fun <T : Any> getOrPut(descriptor: SerialDescriptor, key: Key<T>, defaultValue: () -> T): T {
+        get(descriptor, key)?.let { return it }
+        val value = defaultValue()
+        set(descriptor, key, value)
+        return value
+    }
+
+    public operator fun <T : Any> get(descriptor: SerialDescriptor, key: Key<T>): T? {
+        return map[descriptor]?.get(key as Key<Any>) as? T
+    }
+
+    /**
+     * A key for associating user data of type [T] with a given [SerialDescriptor].
+     */
+    public class Key<T : Any> {}
+}

--- a/runtime/commonMain/src/kotlinx/serialization/SchemaCache.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SchemaCache.kt
@@ -4,15 +4,18 @@
 
 package kotlinx.serialization
 
+import kotlin.native.concurrent.*
+
 private typealias DescriptorData<T> = MutableMap<DescriptorSchemaCache.Key<T>, T>
 
 /**
  * A type-safe map for storing custom information (such as format schema), associated with [SerialDescriptor].
  *
- * This map is not thread safe. For thread safety and performance reasons, it is advised to pass it via stack (e.g. in function parameters)
+ * This cache uses ConcurrentHashMap on JVM and regular maps on other platforms.
+ * To be able to work with it from multiple threads in Kotlin/Native, use @[ThreadLocal] in appropriate places.
  */
 internal class DescriptorSchemaCache {
-    private val map: MutableMap<SerialDescriptor, DescriptorData<Any>> = createMapForCache()
+    private val map: MutableMap<SerialDescriptor, DescriptorData<Any>> = createMapForCache(1)
 
     @Suppress("UNCHECKED_CAST")
     public operator fun <T : Any> set(descriptor: SerialDescriptor, key: Key<T>, value: T) {

--- a/runtime/commonMain/src/kotlinx/serialization/SchemaCache.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SchemaCache.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization
@@ -11,10 +11,11 @@ private typealias DescriptorData<T> = MutableMap<DescriptorSchemaCache.Key<T>, T
  *
  * This map is not thread safe. For thread safety and performance reasons, it is advised to pass it via stack (e.g. in function parameters)
  */
-public class DescriptorSchemaCache {
-    private val map: MutableMap<SerialDescriptor, DescriptorData<Any>> = hashMapOf()
+internal class DescriptorSchemaCache {
+    private val map: MutableMap<SerialDescriptor, DescriptorData<Any>> = createMapForCache()
 
-    public operator fun <T : Any> set(descriptor: SerialDescriptor, key: Key<T>, value: T): Unit {
+    @Suppress("UNCHECKED_CAST")
+    public operator fun <T : Any> set(descriptor: SerialDescriptor, key: Key<T>, value: T) {
         map.getOrPut(descriptor, ::hashMapOf)[key as Key<Any>] = value as Any
     }
 
@@ -25,6 +26,7 @@ public class DescriptorSchemaCache {
         return value
     }
 
+    @Suppress("UNCHECKED_CAST")
     public operator fun <T : Any> get(descriptor: SerialDescriptor, key: Key<T>): T? {
         return map[descriptor]?.get(key as Key<Any>) as? T
     }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/SerialClassDescImpl.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/SerialClassDescImpl.kt
@@ -115,7 +115,7 @@ public open class SerialClassDescImpl(
     }
 
     override fun toString(): String {
-        return indices.entries.joinToString(", ", "$serialName(", ")") { it.key + ": " + getElementDescriptor(it.value).serialName }
+        return (0 until elementsCount).joinToString(prefix = "$serialName(", postfix = ")") { getElementName(it) + ": " + getElementDescriptor(it).serialName }
     }
 }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -203,6 +203,7 @@ public class JsonBuilder {
     public var indent: String = "    "
     public var useArrayPolymorphism: Boolean = false
     public var classDiscriminator: String = "type"
+    public var supportAlternativeNames: Boolean = false
     public var serialModule: SerialModule = EmptyModule
 
     public fun buildConfiguration(): JsonConfiguration =
@@ -214,7 +215,8 @@ public class JsonBuilder {
             prettyPrint,
             indent,
             useArrayPolymorphism,
-            classDiscriminator
+            classDiscriminator,
+            supportAlternativeNames
         )
 
     public fun buildModule(): SerialModule = serialModule

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -126,7 +126,7 @@ public constructor(
      */
     public override fun <T> parse(deserializer: DeserializationStrategy<T>, string: String): T {
         val reader = JsonReader(string)
-        val input = StreamingJsonInput(this, WriteMode.OBJ, reader)
+        val input = StreamingJsonInput(this, WriteMode.OBJ, reader, DescriptorSchemaCache())
         val result = input.decode(deserializer)
         if (!reader.isDone) { error("Reader has not consumed the whole input: $reader") }
         return result

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonAlternativeNames.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonAlternativeNames.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlinx.serialization.*
+
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+public annotation class JsonAlternativeNames(val names: Array<String>)
+
+internal val JsonAlternativeNamesKey = DescriptorSchemaCache.Key<Map<String, Int>>()
+
+internal fun SerialDescriptor.buildAlternativeNamesMap(): Map<String, Int> {
+    fun MutableMap<String, Int>.putOrThrow(name: String, index: Int) {
+        check(name !in this) {
+            "Suggested name '$name' for property ${getElementName(index)} is already one of the names for property " +
+                    "${getElementName(getValue(name))} in ${this@buildAlternativeNamesMap}"
+        }
+        this[name] = index
+    }
+
+    val builder = mutableMapOf<String, Int>()
+    for (i in 0 until this.elementsCount) {
+        builder.putOrThrow(getElementName(i), i)
+        this.findAnnotation<JsonAlternativeNames>(i)?.names?.forEach { name ->
+            builder.putOrThrow(name, i)
+        }
+    }
+    return builder
+}

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonAlternativeNames.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonAlternativeNames.kt
@@ -15,7 +15,7 @@ internal val JsonAlternativeNamesKey = DescriptorSchemaCache.Key<Map<String, Int
 internal fun SerialDescriptor.buildAlternativeNamesMap(): Map<String, Int> {
     fun MutableMap<String, Int>.putOrThrow(name: String, index: Int) {
         check(name !in this) {
-            "Suggested name '$name' for property ${getElementName(index)} is already one of the names for property " +
+            "The suggested name '$name' for property ${getElementName(index)} is already one of the names for property " +
                     "${getElementName(getValue(name))} in ${this@buildAlternativeNamesMap}"
         }
         this[name] = index

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -79,7 +79,8 @@ public data class JsonConfiguration @UnstableDefault constructor(
             prettyPrint = false,
             indent = defaultIndent,
             useArrayPolymorphism = false,
-            classDiscriminator = defaultDiscriminator
+            classDiscriminator = defaultDiscriminator,
+            supportAlternateNames = false
         )
     }
 }

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -35,6 +35,7 @@ public data class JsonConfiguration @UnstableDefault constructor(
     @JvmField internal val indent: String = defaultIndent,
     @JvmField internal val useArrayPolymorphism: Boolean = false,
     @JvmField internal val classDiscriminator: String = defaultDiscriminator,
+    @JvmField internal val supportAlternateNames: Boolean = false,
     @Deprecated(message = "Custom update modes are not fully supported", level = DeprecationLevel.WARNING)
     @JvmField internal val updateMode: UpdateMode = UpdateMode.OVERWRITE) {
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -35,7 +35,7 @@ public data class JsonConfiguration @UnstableDefault constructor(
     @JvmField internal val indent: String = defaultIndent,
     @JvmField internal val useArrayPolymorphism: Boolean = false,
     @JvmField internal val classDiscriminator: String = defaultDiscriminator,
-    @JvmField internal val supportAlternateNames: Boolean = false,
+    @JvmField internal val supportAlternativeNames: Boolean = false,
     @Deprecated(message = "Custom update modes are not fully supported", level = DeprecationLevel.WARNING)
     @JvmField internal val updateMode: UpdateMode = UpdateMode.OVERWRITE) {
 
@@ -80,7 +80,7 @@ public data class JsonConfiguration @UnstableDefault constructor(
             indent = defaultIndent,
             useArrayPolymorphism = false,
             classDiscriminator = defaultDiscriminator,
-            supportAlternateNames = false
+            supportAlternativeNames = false
         )
     }
 }

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -6,8 +6,7 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.UpdateMode
-import kotlin.jvm.JvmField
-import kotlin.jvm.JvmStatic
+import kotlin.jvm.*
 
 /**
  * The class responsible for JSON-specific customizable behaviour in [Json] format.
@@ -22,6 +21,7 @@ import kotlin.jvm.JvmStatic
  * * [indent] specifies indent string to use with [prettyPrint] mode.
  * * [useArrayPolymorphism] switches polymorphic serialization to the default array format.
  * * [classDiscriminator] name of the class descriptor property in polymorphic serialization.
+ * * [useAlternativeNames] enables support of [JsonNames] annotation.
  *
  * This class is marked with [UnstableDefault]: its semantics may be changes in the next releases, e.g.
  * additional flag may be introduced or default parameter values may be changed.

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.json
@@ -35,9 +35,10 @@ public data class JsonConfiguration @UnstableDefault constructor(
     @JvmField internal val indent: String = defaultIndent,
     @JvmField internal val useArrayPolymorphism: Boolean = false,
     @JvmField internal val classDiscriminator: String = defaultDiscriminator,
-    @JvmField internal val supportAlternativeNames: Boolean = false,
+    @JvmField internal val useAlternativeNames: Boolean = false,
     @Deprecated(message = "Custom update modes are not fully supported", level = DeprecationLevel.WARNING)
-    @JvmField internal val updateMode: UpdateMode = UpdateMode.OVERWRITE) {
+    @JvmField internal val updateMode: UpdateMode = UpdateMode.OVERWRITE
+) {
 
     init {
         if (useArrayPolymorphism) require(classDiscriminator == defaultDiscriminator) {
@@ -80,7 +81,7 @@ public data class JsonConfiguration @UnstableDefault constructor(
             indent = defaultIndent,
             useArrayPolymorphism = false,
             classDiscriminator = defaultDiscriminator,
-            supportAlternativeNames = false
+            useAlternativeNames = false
         )
     }
 }

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonNames.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonNames.kt
@@ -1,14 +1,23 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
 
+/**
+ * Specifies an array of names those can be treated as alternative possible names
+ * for the property during JSON parsing. Unlike [SerialName], does not affect JSON
+ * writing in any way.
+ *
+ * To make actual use of this annotation, one should create [Json] instance
+ * from [JsonConfiguration] with [JsonConfiguration.useAlternativeNames] flag
+ * set to true.
+ */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)
-public annotation class JsonAlternativeNames(val names: Array<String>)
+public annotation class JsonNames(val names: Array<String>)
 
 internal val JsonAlternativeNamesKey = DescriptorSchemaCache.Key<Map<String, Int>>()
 
@@ -21,10 +30,10 @@ internal fun SerialDescriptor.buildAlternativeNamesMap(): Map<String, Int> {
         this[name] = index
     }
 
-    val builder = mutableMapOf<String, Int>()
-    for (i in 0 until this.elementsCount) {
+    val builder = createMapForCache<String, Int>(elementsCount)
+    for (i in 0 until elementsCount) {
         builder.putOrThrow(getElementName(i), i)
-        this.findAnnotation<JsonAlternativeNames>(i)?.names?.forEach { name ->
+        findAnnotation<JsonNames>(i)?.names?.forEach { name ->
             builder.putOrThrow(name, i)
         }
     }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
@@ -107,7 +107,7 @@ internal class StreamingJsonInput internal constructor(
     }
 
     private fun SerialDescriptor.getJsonElementIndex(key: String): Int {
-        if (!json.configuration.supportAlternateNames) return this.getElementIndex(key)
+        if (!json.configuration.supportAlternativeNames) return this.getElementIndex(key)
         val alternativeNamesMap = schemaCache.getOrPut(this, JsonAlternativeNamesKey, this::buildAlternativeNamesMap)
         return alternativeNamesMap[key] ?: CompositeDecoder.UNKNOWN_NAME
     }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
@@ -15,8 +15,7 @@ import kotlin.jvm.JvmField
 internal class StreamingJsonInput internal constructor(
     public override val json: Json,
     private val mode: WriteMode,
-    @JvmField internal val reader: JsonReader,
-    @JvmField private val schemaCache: DescriptorSchemaCache
+    @JvmField internal val reader: JsonReader
 ) : JsonInput, ElementValueDecoder() {
 
     public override val context: SerialModule = json.context
@@ -43,11 +42,10 @@ internal class StreamingJsonInput internal constructor(
             WriteMode.LIST, WriteMode.MAP, WriteMode.POLY_OBJ -> StreamingJsonInput(
                 json,
                 newMode,
-                reader,
-                schemaCache
+                reader
             ) // need fresh cur index
             else -> if (mode == newMode) this else
-                StreamingJsonInput(json, newMode, reader, schemaCache) // todo: reuse instance per mode
+                StreamingJsonInput(json, newMode, reader) // todo: reuse instance per mode
         }
     }
 
@@ -107,8 +105,9 @@ internal class StreamingJsonInput internal constructor(
     }
 
     private fun SerialDescriptor.getJsonElementIndex(key: String): Int {
-        if (!json.configuration.supportAlternativeNames) return this.getElementIndex(key)
-        val alternativeNamesMap = schemaCache.getOrPut(this, JsonAlternativeNamesKey, this::buildAlternativeNamesMap)
+        if (!json.configuration.useAlternativeNames) return this.getElementIndex(key)
+        val alternativeNamesMap =
+            json.schemaCache.getOrPut(this, JsonAlternativeNamesKey, this::buildAlternativeNamesMap)
         return alternativeNamesMap[key] ?: CompositeDecoder.UNKNOWN_NAME
     }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
@@ -106,10 +106,9 @@ internal class StreamingJsonInput internal constructor(
     }
 
     private fun SerialDescriptor.getJsonElementIndex(key: String): Int {
-        val elementIndex = this.getElementIndex(key)
-        if (elementIndex != UNKNOWN_NAME || !json.configuration.useAlternativeNames) {
-            return elementIndex
-        }
+        if (!json.configuration.useAlternativeNames) return this.getElementIndex(key)
+        // it is possible also to return result of .getElementIndex right away for optimization purposes,
+        // if it is not an UNKNOWN_NAME. However, it blocks ability to detect collisions between the primary name and alternate.
         val alternativeNamesMap =
             json.schemaCache.getOrPut(this, JsonAlternativeNamesKey, this::buildAlternativeNamesMap)
         return alternativeNamesMap[key] ?: UNKNOWN_NAME

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -126,7 +126,7 @@ private open class JsonTreeInput(json: Json, override val obj: JsonObject, schem
 
     override fun elementName(desc: SerialDescriptor, index: Int): String {
         val mainName = desc.getElementName(index)
-        if (!configuration.supportAlternateNames) return mainName
+        if (!configuration.supportAlternativeNames) return mainName
         val alternativeNamesMap = schemaCache.getOrPut(desc, JsonAlternativeNamesKey, desc::buildAlternativeNamesMap)
         val nameInObject = obj.keys.find { it == mainName || alternativeNamesMap[it] == index }
         return nameInObject ?: mainName

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -8,8 +8,8 @@ package kotlinx.serialization.json.internal
 
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
-import kotlinx.serialization.modules.SerialModule
-import kotlin.jvm.JvmField
+import kotlinx.serialization.modules.*
+import kotlin.jvm.*
 
 internal fun <T> Json.readJson(element: JsonElement, deserializer: DeserializationStrategy<T>): T {
     val input = when (element) {
@@ -125,7 +125,9 @@ private open class JsonTreeInput(json: Json, override val obj: JsonObject) :
 
     override fun elementName(desc: SerialDescriptor, index: Int): String {
         val mainName = desc.getElementName(index)
-        if (mainName in obj.keys || !configuration.useAlternativeNames) return mainName
+        if (!configuration.useAlternativeNames) return mainName
+        // it is possible also to return mainName right away for optimization purposes, if it is contained in obj.keys.
+        // However, it blocks ability to detect collisions between the primary name and alternate.
         val alternativeNamesMap =
             json.schemaCache.getOrPut(desc, JsonAlternativeNamesKey, desc::buildAlternativeNamesMap)
         val nameInObject = obj.keys.find { it == mainName || alternativeNamesMap[it] == index }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -13,16 +13,17 @@ import kotlin.jvm.*
 
 internal fun <T> Json.readJson(element: JsonElement, deserializer: DeserializationStrategy<T>): T {
     val input = when (element) {
-        is JsonObject -> JsonTreeInput(this, element)
-        is JsonArray -> JsonTreeListInput(this, element)
-        is JsonLiteral, JsonNull -> JsonPrimitiveInput(this, element as JsonPrimitive)
+        is JsonObject -> JsonTreeInput(this, element, DescriptorSchemaCache())
+        is JsonArray -> JsonTreeListInput(this, element, DescriptorSchemaCache())
+        is JsonLiteral, JsonNull -> JsonPrimitiveInput(this, element as JsonPrimitive, DescriptorSchemaCache())
     }
     return input.decode(deserializer)
 }
 
 private sealed class AbstractJsonTreeInput(
     override val json: Json,
-    open val obj: JsonElement
+    open val obj: JsonElement,
+    protected val schemaCache: DescriptorSchemaCache
 ) : NamedValueDecoder(), JsonInput {
 
     override val context: SerialModule
@@ -48,13 +49,13 @@ private sealed class AbstractJsonTreeInput(
     override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
         val currentObject = currentObject()
         return when (desc.kind) {
-            StructureKind.LIST, is PolymorphicKind -> JsonTreeListInput(json, cast(currentObject))
+            StructureKind.LIST, is PolymorphicKind -> JsonTreeListInput(json, cast(currentObject), schemaCache)
             StructureKind.MAP -> json.selectMapMode(
                 desc,
-                { JsonTreeMapInput(json, cast(currentObject)) },
-                { JsonTreeListInput(json, cast(currentObject)) }
+                { JsonTreeMapInput(json, cast(currentObject), schemaCache) },
+                { JsonTreeListInput(json, cast(currentObject), schemaCache) }
             )
-            else -> JsonTreeInput(json, cast(currentObject))
+            else -> JsonTreeInput(json, cast(currentObject), schemaCache)
         }
     }
 
@@ -94,7 +95,8 @@ private sealed class AbstractJsonTreeInput(
     override fun decodeTaggedString(tag: String) = getValue(tag).content
 }
 
-private class JsonPrimitiveInput(json: Json, override val obj: JsonPrimitive) : AbstractJsonTreeInput(json, obj) {
+private class JsonPrimitiveInput(json: Json, override val obj: JsonPrimitive, schemaCache: DescriptorSchemaCache) :
+    AbstractJsonTreeInput(json, obj, schemaCache) {
 
     init {
         pushTag(PRIMITIVE_TAG)
@@ -108,7 +110,8 @@ private class JsonPrimitiveInput(json: Json, override val obj: JsonPrimitive) : 
     }
 }
 
-private open class JsonTreeInput(json: Json, override val obj: JsonObject) : AbstractJsonTreeInput(json, obj) {
+private open class JsonTreeInput(json: Json, override val obj: JsonObject, schemaCache: DescriptorSchemaCache) :
+    AbstractJsonTreeInput(json, obj, schemaCache) {
     private var position = 0
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
@@ -119,6 +122,14 @@ private open class JsonTreeInput(json: Json, override val obj: JsonObject) : Abs
             }
         }
         return CompositeDecoder.READ_DONE
+    }
+
+    override fun elementName(desc: SerialDescriptor, index: Int): String {
+        val mainName = desc.getElementName(index)
+        if (!configuration.supportAlternateNames) return mainName
+        val alternativeNamesMap = schemaCache.getOrPut(desc, JsonAlternativeNamesKey, desc::buildAlternativeNamesMap)
+        val nameInObject = obj.keys.find { it == mainName || alternativeNamesMap[it] == index }
+        return nameInObject ?: mainName
     }
 
     override fun currentElement(tag: String): JsonElement = obj.getValue(tag)
@@ -138,7 +149,8 @@ private open class JsonTreeInput(json: Json, override val obj: JsonObject) : Abs
     }
 }
 
-private class JsonTreeMapInput(json: Json, override val obj: JsonObject) : JsonTreeInput(json, obj) {
+private class JsonTreeMapInput(json: Json, override val obj: JsonObject, schemaCache: DescriptorSchemaCache) :
+    JsonTreeInput(json, obj, schemaCache) {
     private val keys = obj.keys.toList()
     private val size: Int = keys.size * 2
     private var position = -1
@@ -165,7 +177,8 @@ private class JsonTreeMapInput(json: Json, override val obj: JsonObject) : JsonT
     }
 }
 
-private class JsonTreeListInput(json: Json, override val obj: JsonArray) : AbstractJsonTreeInput(json, obj) {
+private class JsonTreeListInput(json: Json, override val obj: JsonArray, schemaCache: DescriptorSchemaCache) :
+    AbstractJsonTreeInput(json, obj, schemaCache) {
     private val size = obj.content.size
     private var currentIndex = -1
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -125,7 +125,7 @@ private open class JsonTreeInput(json: Json, override val obj: JsonObject) :
 
     override fun elementName(desc: SerialDescriptor, index: Int): String {
         val mainName = desc.getElementName(index)
-        if (!configuration.useAlternativeNames) return mainName
+        if (mainName in obj.keys || !configuration.useAlternativeNames) return mainName
         val alternativeNamesMap =
             json.schemaCache.getOrPut(desc, JsonAlternativeNamesKey, desc::buildAlternativeNamesMap)
         val nameInObject = obj.keys.find { it == mainName || alternativeNamesMap[it] == index }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
@@ -23,7 +23,7 @@ data class WithDuplicateNames2(@JsonAlternativeNames(arrayOf("foo", "_foo")) val
 class JsonAlternativeNamesTest : JsonTestBase() {
     private val inputString1 = """{"foo":"foo"}"""
     private val inputString2 = """{"_foo":"foo"}"""
-    private val json = Json(JsonConfiguration(strictMode = false, supportAlternateNames = true))
+    private val json = Json(JsonConfiguration(strictMode = false, supportAlternativeNames = true))
 
     @Test
     fun parsesAllAlternativeNames() {
@@ -47,13 +47,13 @@ class JsonAlternativeNamesTest : JsonTestBase() {
 
     @Test
     fun throwsAnErrorOnDuplicateNames() = doThrowTest(
-        """Suggested name 'foo' for property data is already one of the names for property foo in kotlinx.serialization.json.WithDuplicateNames(foo: kotlin.String, data: kotlin.String)""",
+        """The suggested name 'foo' for property data is already one of the names for property foo in kotlinx.serialization.json.WithDuplicateNames(foo: kotlin.String, data: kotlin.String)""",
         WithDuplicateNames.serializer()
     )
 
     @Test
     fun throwsAnErrorOnDuplicateNames2() = doThrowTest(
-        """Suggested name 'foo' for property foo is already one of the names for property data in kotlinx.serialization.json.WithDuplicateNames2(data: kotlin.String, foo: kotlin.String)""",
+        """The suggested name 'foo' for property foo is already one of the names for property data in kotlinx.serialization.json.WithDuplicateNames2(data: kotlin.String, foo: kotlin.String)""",
         WithDuplicateNames2.serializer()
     )
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Serializable
+data class WithNames(@JsonAlternativeNames(["foo", "_foo"]) val data: String)
+
+@Serializable
+data class WithDuplicateNames(val foo: String, @JsonAlternativeNames(["foo", "_foo"]) val data: String)
+
+@Serializable
+data class WithDuplicateNames2(@JsonAlternativeNames(["foo", "_foo"]) val data: String, val foo: String)
+
+class JsonAlternativeNamesTest : JsonTestBase() {
+    private val inputString1 = """{"foo":"foo"}"""
+    private val inputString2 = """{"_foo":"foo"}"""
+    val json = Json(JsonConfiguration(strictMode = false, supportAlternateNames = true))
+
+    @Test
+    fun parsesAllAlternativeNames() {
+        val data1 = json.parse(WithNames.serializer(), inputString1)
+        assertEquals("foo", data1.data)
+        val data2 = json.parse(WithNames.serializer(), inputString2)
+        assertEquals("foo", data2.data)
+    }
+
+    @Test
+    fun parseAllAlternativeNamesTree() {
+        val data1 = json.parse(WithNames.serializer(), inputString1, useStreaming = false)
+        assertEquals("foo", data1.data)
+        val data2 = json.parse(WithNames.serializer(), inputString2, useStreaming = false)
+        assertEquals("foo", data2.data)
+    }
+
+    @Test
+    fun throwsAnErrorOnDuplicateNames() {
+        val errorMessage =
+            """Suggested name 'foo' for property data is already one of the names for property foo in kotlinx.serialization.json.WithDuplicateNames(data: kotlin.String, foo: kotlin.String)"""
+        assertFailsWithMessage<IllegalStateException>(errorMessage) {
+            json.parse(WithDuplicateNames.serializer(), inputString1, useStreaming = true)
+        }
+        assertFailsWithMessage<IllegalStateException>(errorMessage) {
+            json.parse(WithDuplicateNames.serializer(), inputString1, useStreaming = false)
+        }
+    }
+
+    @Test
+    fun throwsAnErrorOnDuplicateNames2() {
+        val errorMessage =
+            """Suggested name 'foo' for property foo is already one of the names for property data in kotlinx.serialization.json.WithDuplicateNames2(data: kotlin.String, foo: kotlin.String)"""
+        assertFailsWithMessage<IllegalStateException>(errorMessage) {
+            json.parse(WithDuplicateNames2.serializer(), inputString1, useStreaming = true)
+        }
+        assertFailsWithMessage<IllegalStateException>(errorMessage) {
+            json.parse(WithDuplicateNames2.serializer(), inputString1, useStreaming = false)
+        }
+    }
+}

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
@@ -2,63 +2,58 @@
  * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("ReplaceArrayOfWithLiteral") // https://youtrack.jetbrains.com/issue/KT-22578
+
 package kotlinx.serialization.json
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @Serializable
-data class WithNames(@JsonAlternativeNames(["foo", "_foo"]) val data: String)
+data class WithNames(@JsonAlternativeNames(arrayOf("foo", "_foo")) val data: String)
 
 @Serializable
-data class WithDuplicateNames(val foo: String, @JsonAlternativeNames(["foo", "_foo"]) val data: String)
+data class WithDuplicateNames(val foo: String, @JsonAlternativeNames(arrayOf("foo", "_foo")) val data: String)
 
 @Serializable
-data class WithDuplicateNames2(@JsonAlternativeNames(["foo", "_foo"]) val data: String, val foo: String)
+data class WithDuplicateNames2(@JsonAlternativeNames(arrayOf("foo", "_foo")) val data: String, val foo: String)
 
 class JsonAlternativeNamesTest : JsonTestBase() {
     private val inputString1 = """{"foo":"foo"}"""
     private val inputString2 = """{"_foo":"foo"}"""
-    val json = Json(JsonConfiguration(strictMode = false, supportAlternateNames = true))
+    private val json = Json(JsonConfiguration(strictMode = false, supportAlternateNames = true))
 
     @Test
     fun parsesAllAlternativeNames() {
-        val data1 = json.parse(WithNames.serializer(), inputString1)
-        assertEquals("foo", data1.data)
-        val data2 = json.parse(WithNames.serializer(), inputString2)
-        assertEquals("foo", data2.data)
-    }
-
-    @Test
-    fun parseAllAlternativeNamesTree() {
-        val data1 = json.parse(WithNames.serializer(), inputString1, useStreaming = false)
-        assertEquals("foo", data1.data)
-        val data2 = json.parse(WithNames.serializer(), inputString2, useStreaming = false)
-        assertEquals("foo", data2.data)
-    }
-
-    @Test
-    fun throwsAnErrorOnDuplicateNames() {
-        val errorMessage =
-            """Suggested name 'foo' for property data is already one of the names for property foo in kotlinx.serialization.json.WithDuplicateNames(data: kotlin.String, foo: kotlin.String)"""
-        assertFailsWithMessage<IllegalStateException>(errorMessage) {
-            json.parse(WithDuplicateNames.serializer(), inputString1, useStreaming = true)
-        }
-        assertFailsWithMessage<IllegalStateException>(errorMessage) {
-            json.parse(WithDuplicateNames.serializer(), inputString1, useStreaming = false)
+        for (input in listOf(inputString1, inputString2)) {
+            for (streaming in listOf(true, false)) {
+                val data = json.parse(WithNames.serializer(), input, useStreaming = streaming)
+                assertEquals("foo", data.data, "Failed to parse input '$input' with streaming=$streaming")
+            }
         }
     }
 
+    private fun <T> doThrowTest(expectedErrorMessage: String, serializer: KSerializer<T>) =
+        parametrizedTest { streaming ->
+            assertFailsWithMessage<IllegalStateException>(
+                expectedErrorMessage,
+                "Class ${serializer.descriptor.name} did not fail with streaming=$streaming"
+            ) {
+                json.parse(serializer, inputString1, useStreaming = streaming)
+            }
+        }
+
     @Test
-    fun throwsAnErrorOnDuplicateNames2() {
-        val errorMessage =
-            """Suggested name 'foo' for property foo is already one of the names for property data in kotlinx.serialization.json.WithDuplicateNames2(data: kotlin.String, foo: kotlin.String)"""
-        assertFailsWithMessage<IllegalStateException>(errorMessage) {
-            json.parse(WithDuplicateNames2.serializer(), inputString1, useStreaming = true)
-        }
-        assertFailsWithMessage<IllegalStateException>(errorMessage) {
-            json.parse(WithDuplicateNames2.serializer(), inputString1, useStreaming = false)
-        }
-    }
+    fun throwsAnErrorOnDuplicateNames() = doThrowTest(
+        """Suggested name 'foo' for property data is already one of the names for property foo in kotlinx.serialization.json.WithDuplicateNames(foo: kotlin.String, data: kotlin.String)""",
+        WithDuplicateNames.serializer()
+    )
+
+    @Test
+    fun throwsAnErrorOnDuplicateNames2() = doThrowTest(
+        """Suggested name 'foo' for property foo is already one of the names for property data in kotlinx.serialization.json.WithDuplicateNames2(data: kotlin.String, foo: kotlin.String)""",
+        WithDuplicateNames2.serializer()
+    )
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonAlternativeNamesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("ReplaceArrayOfWithLiteral") // https://youtrack.jetbrains.com/issue/KT-22578
@@ -8,22 +8,23 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.test.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @Serializable
-data class WithNames(@JsonAlternativeNames(arrayOf("foo", "_foo")) val data: String)
+data class WithNames(@JsonNames(arrayOf("foo", "_foo")) val data: String)
 
 @Serializable
-data class WithDuplicateNames(val foo: String, @JsonAlternativeNames(arrayOf("foo", "_foo")) val data: String)
+data class WithDuplicateNames(val foo: String, @JsonNames(arrayOf("foo", "_foo")) val data: String)
 
 @Serializable
-data class WithDuplicateNames2(@JsonAlternativeNames(arrayOf("foo", "_foo")) val data: String, val foo: String)
+data class WithDuplicateNames2(@JsonNames(arrayOf("foo", "_foo")) val data: String, val foo: String)
 
 class JsonAlternativeNamesTest : JsonTestBase() {
     private val inputString1 = """{"foo":"foo"}"""
     private val inputString2 = """{"_foo":"foo"}"""
-    private val json = Json(JsonConfiguration(strictMode = false, supportAlternativeNames = true))
+    private val json = Json(JsonConfiguration(strictMode = false, useAlternativeNames = true))
 
     @Test
     fun parsesAllAlternativeNames() {
@@ -39,7 +40,7 @@ class JsonAlternativeNamesTest : JsonTestBase() {
         parametrizedTest { streaming ->
             assertFailsWithMessage<IllegalStateException>(
                 expectedErrorMessage,
-                "Class ${serializer.descriptor.name} did not fail with streaming=$streaming"
+                "Class ${serializer.descriptor.serialName} did not fail with streaming=$streaming"
             ) {
                 json.parse(serializer, inputString1, useStreaming = streaming)
             }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -62,7 +62,7 @@ abstract class JsonTestBase {
             parse(deserializer, source)
         } else {
             val parser = JsonReader(source)
-            val input = StreamingJsonInput(this, WriteMode.OBJ, parser)
+            val input = StreamingJsonInput(this, WriteMode.OBJ, parser, DescriptorSchemaCache())
             val tree = input.decodeJson()
             if (!input.reader.isDone) { error("Reader has not consumed the whole input: ${input.reader}") }
             readJson(tree, deserializer)

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.json
@@ -62,7 +62,7 @@ abstract class JsonTestBase {
             parse(deserializer, source)
         } else {
             val parser = JsonReader(source)
-            val input = StreamingJsonInput(this, WriteMode.OBJ, parser, DescriptorSchemaCache())
+            val input = StreamingJsonInput(this, WriteMode.OBJ, parser)
             val tree = input.decodeJson()
             if (!input.reader.isDone) { error("Reader has not consumed the whole input: ${input.reader}") }
             readJson(tree, deserializer)
@@ -143,14 +143,5 @@ abstract class JsonTestBase {
             val deserialized: T = json.parse(serializer, serialized, useStreaming)
             assertEquals(data, deserialized)
         }
-    }
-
-    inline fun <reified T : Throwable> assertFailsWithMessage(
-        message: String,
-        assertionMessage: String? = null,
-        block: () -> Unit
-    ) {
-        val exception = assertFailsWith(T::class, assertionMessage, block)
-        assertTrue(exception.message!!.contains(message), "Expected message '${exception.message}' to contain substring '$message'")
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -145,8 +145,12 @@ abstract class JsonTestBase {
         }
     }
 
-    inline fun <reified T : Throwable> assertFailsWithMessage(message: String, block: () -> Unit) {
-        val exception = assertFailsWith(T::class, null, block)
+    inline fun <reified T : Throwable> assertFailsWithMessage(
+        message: String,
+        assertionMessage: String? = null,
+        block: () -> Unit
+    ) {
+        val exception = assertFailsWith(T::class, assertionMessage, block)
         assertTrue(exception.message!!.contains(message), "Expected message '${exception.message}' to contain substring '$message'")
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/test/TestingFramework.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/test/TestingFramework.kt
@@ -1,13 +1,12 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.test
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.HexConverter
-import kotlinx.serialization.json.Json
-import kotlin.test.assertEquals
+import kotlinx.serialization.json.*
+import kotlin.test.*
 
 
 inline fun <reified T : Any> assertStringForm(
@@ -53,3 +52,15 @@ inline fun <reified T : Any> StringFormat.assertStringFormAndRestored(
 }
 
 infix fun <T> T.shouldBe(expected: T) = assertEquals(expected, this)
+
+inline fun <reified T : Throwable> assertFailsWithMessage(
+    message: String,
+    assertionMessage: String? = null,
+    block: () -> Unit
+) {
+    val exception = assertFailsWith(T::class, assertionMessage, block)
+    assertTrue(
+        exception.message!!.contains(message),
+        "Expected message '${exception.message}' to contain substring '$message'"
+    )
+}

--- a/runtime/jsMain/src/kotlinx/serialization/Serialization.kt
+++ b/runtime/jsMain/src/kotlinx/serialization/Serialization.kt
@@ -30,7 +30,7 @@ actual fun <E: Enum<E>> enumFromOrdinal(enumClass: KClass<E>, ordinal: Int): E =
 actual fun <E: Enum<E>> KClass<E>.enumClassName(): String = this.js.name
 actual fun <E: Enum<E>> KClass<E>.enumMembers(): Array<E> = (this.js.asDynamic().values() as Array<E>)
 
-actual fun <T: Any, E: T?> ArrayList<E>.toNativeArray(eClass: KClass<T>): Array<E> = toTypedArray()
+actual fun <T : Any, E : T?> ArrayList<E>.toNativeArray(eClass: KClass<T>): Array<E> = toTypedArray()
 
 internal actual fun Any.isInstanceOf(kclass: KClass<*>): Boolean = kclass.isInstance(this)
 
@@ -39,3 +39,5 @@ internal actual fun <T : Any> KClass<T>.simpleName(): String? = simpleName
 internal actual fun <T : Any> KClass<T>.constructSerializerForGivenTypeArgs(vararg args: KSerializer<Any?>): KSerializer<T>? {
     throw NotImplementedError("This method is not supported for Kotlin/JS yet. Please provide serializer explicitly.")
 }
+
+internal actual fun <K, V> createMapForCache(initialCapacity: Int): MutableMap<K, V> = HashMap(initialCapacity)

--- a/runtime/jvmMain/src/kotlinx/serialization/Serialization.kt
+++ b/runtime/jvmMain/src/kotlinx/serialization/Serialization.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import java.lang.reflect.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.*
 
 @Suppress("UNCHECKED_CAST")
@@ -59,6 +60,7 @@ private fun <T : Any> findObjectSerializer(jClass: Class<T>): KSerializer<T>? {
         jClass.methods.singleOrNull { it.name == "serializer" && it.parameters.isEmpty() && it.returnType == KSerializer::class.java }
             ?: return null
     val result = method.invoke(instance)
+    @Suppress("UNCHECKED_CAST")
     return result as? KSerializer<T>
 }
 
@@ -77,3 +79,6 @@ private fun <T : Any> findObjectSerializer(jClass: Class<T>): KSerializer<T>? {
 internal actual fun Any.isInstanceOf(kclass: KClass<*>): Boolean = kclass.javaObjectType.isInstance(this)
 
 internal actual fun <T : Any> KClass<T>.simpleName(): String? = java.simpleName
+
+internal actual fun <K, V> createMapForCache(initialCapacity: Int): MutableMap<K, V> =
+    ConcurrentHashMap(initialCapacity)

--- a/runtime/nativeMain/src/kotlinx/serialization/Platform.kt
+++ b/runtime/nativeMain/src/kotlinx/serialization/Platform.kt
@@ -64,3 +64,5 @@ private fun <T> arrayOfAnyNulls(size: Int): Array<T> = arrayOfNulls<Any>(size) a
 internal actual fun Any.isInstanceOf(kclass: KClass<*>): Boolean = kclass.isInstance(this)
 
 internal actual fun <T : Any> KClass<T>.simpleName(): String? = simpleName
+
+internal actual fun <K, V> createMapForCache(initialCapacity: Int): MutableMap<K, V> = HashMap(initialCapacity)


### PR DESCRIPTION
* Configurable via `@JsonAlternativeNames` annotation
* Uses new `DescriptorSchemaCache` – class for associating custom format info with descriptors in effective and type-safe way
* Stabilize .toString() for SerialClassDescImpl; because HashMaps on different platforms have different iteration order

Fixes #203 