### PR TITLE
Fix exception messages & typos in JsonElement

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -27,7 +27,7 @@ public sealed class JsonElement {
      * @throws JsonException is current element is not a [JsonPrimitive]
      */
     public open val primitive: JsonPrimitive
-        get() = error("JsonLiteral")
+        get() = error("JsonPrimitive")
 
     /**
      * Convenience method to get current element as [JsonObject]
@@ -48,7 +48,7 @@ public sealed class JsonElement {
      * @throws JsonException is current element is not a [JsonNull]
      */
     public open val jsonNull: JsonNull
-        get() = error("JsonPrimitive")
+        get() = error("JsonNull")
 
     /**
      * Checks whether current element is [JsonNull]

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -24,28 +24,28 @@ public sealed class JsonElement {
 
     /**
      * Convenience method to get current element as [JsonPrimitive]
-     * @throws JsonException is current element is not a [JsonPrimitive]
+     * @throws JsonException if current element is not a [JsonPrimitive]
      */
     public open val primitive: JsonPrimitive
         get() = error("JsonPrimitive")
 
     /**
      * Convenience method to get current element as [JsonObject]
-     * @throws JsonException is current element is not a [JsonObject]
+     * @throws JsonException if current element is not a [JsonObject]
      */
     public open val jsonObject: JsonObject
         get() = error("JsonObject")
 
     /**
      * Convenience method to get current element as [JsonArray]
-     * @throws JsonException is current element is not a [JsonArray]
+     * @throws JsonException if current element is not a [JsonArray]
      */
     public open val jsonArray: JsonArray
         get() = error("JsonArray")
 
     /**
      * Convenience method to get current element as [JsonNull]
-     * @throws JsonException is current element is not a [JsonNull]
+     * @throws JsonException if current element is not a [JsonNull]
      */
     public open val jsonNull: JsonNull
         get() = error("JsonNull")


### PR DESCRIPTION
It looks like these were like this since the beginning of this file's history, so hopefully I'm not missing some intentional reason for these mismatches.

Sidenote: it's unfortunate that `primitive` is not prefixed with `json` like all the other members, but I'm guessing it would be a breaking change for no real benefit. It's just an eyesore in my code haha.