### PR TITLE
Update README with Gradle Kotlin DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ You can open example projects for [JS](examples/example-js), [JVM](examples/exam
 * [Current status](#current-project-status)
 * [Library installing](#setup)
     + [Gradle](#gradle)
-    + [Gradle (with `plugins` block)](#gradle-with-plugins-block)
     + [Android/JVM](#androidjvm)
     + [Multiplatform (common, JS, Native)](#multiplatform-common-js-native)
     + [Maven/JVM](#mavenjvm)
@@ -91,11 +90,35 @@ Example projects on JVM are available for [Gradle](examples/example-jvm/build.gr
 
 ### Gradle
 
-#### Adding the plugin to classpath
+#### Using the `plugins` block
 
-You have to add the serialization plugin to your classpath as the other [compiler plugins](https://kotlinlang.org/docs/reference/compiler-plugins.html):
+You can setup the serialization plugin with the Kotlin plugin using [Gradle plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
 
 Kotlin DSL:
+
+```kotlin
+plugins {
+    kotlin("multiplatform") // or kotlin("jvm") or any other kotlin plugin
+    id("kotlinx-serialization")
+}
+```
+Groovy DSL:
+
+```gradle
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform' version '1.3.61' // or any other kotlin plugin
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.3.61'
+}
+```
+
+Note: plugin marker for serialization has been published in Kotlin 1.3.50. If you need to use the earlier Kotlin version, see [KT-27612](https://youtrack.jetbrains.com/issue/KT-27612) for workaround with [plugin resolution rules](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_resolution_rules).
+
+#### Using `apply plugin` (the old way)
+
+First, you have to add the serialization plugin to your classpath as the other [compiler plugins](https://kotlinlang.org/docs/reference/compiler-plugins.html):
+
+Kotlin DSL:
+
 ```kotlin
 buildscript {
     repositories { jcenter() }
@@ -107,7 +130,9 @@ buildscript {
     }
 }
 ```
+
 Groovy DSL:
+
 ```gradle
 buildscript {
     ext.kotlin_version = '1.3.61'
@@ -120,38 +145,19 @@ buildscript {
 }
 ```
 
-#### Applying the plugin
+Then you can `apply plugin` (example in Groovy):
 
-Next, apply the plugin to your project.
-
-You can setup serialization plugin with the kotlin plugin using [Gradle plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) **instead** of traditional `apply plugin`:
-
-Kotlin DSL:
-```kotlin
-plugins {
-    kotlin("multiplatform") // or kotlin("jvm") or any other kotlin plugin
-    id("kotlinx-serialization")
-}
-```
-Groovy DSL:
-```gradle
-plugins {
-    id 'org.jetbrains.kotlin.multiplatform' version '1.3.61' // or any other kotlin plugin
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.3.61'
-}
-```
-Using the old way (with `apply plugin`) the setup looks like this (in Groovy):
 ```gradle
 apply plugin: 'kotlin' // or 'kotlin-multiplatform' for multiplatform projects
 apply plugin: 'kotlinx-serialization'
 ```
-Note: plugin marker for serialization has been published in Kotlin 1.3.50. If you need to use the earlier Kotlin version, see [KT-27612](https://youtrack.jetbrains.com/issue/KT-27612) for workaround with [plugin resolution rules](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_resolution_rules).
 
 #### Dependency on the runtime library
 
-And finally, you have to add a dependency on the serialization runtime library. Note that while the plugin has version the same as the compiler one, runtime library has different coordinates, repository and versioning.
+After setting up the plugin one way or another, you have to add a dependency on the serialization runtime library. Note that while the plugin has version the same as the compiler one, runtime library has different coordinates, repository and versioning.
 
 Kotlin DSL:
+
 ```kotlin
 repositories {
     // artifacts are published to JCenter
@@ -159,18 +165,20 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8", KotlinCompilerVersion.VERSION))
+    implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION)) // or "stdlib-jdk8"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0") // JVM dependency
 }
 ```
+
 Groovy DSL:
+
 ```gradle
 repositories {
     jcenter()
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version" // or "kotlin-stdlib-jdk8"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0" // JVM dependency
 }
 ```

--- a/README.md
+++ b/README.md
@@ -91,11 +91,26 @@ Example projects on JVM are available for [Gradle](examples/example-jvm/build.gr
 
 ### Gradle
 
-You have to add the serialization plugin as the other [compiler plugins](https://kotlinlang.org/docs/reference/compiler-plugins.html):
+#### Adding the plugin to classpath
 
+You have to add the serialization plugin to your classpath as the other [compiler plugins](https://kotlinlang.org/docs/reference/compiler-plugins.html):
+
+Kotlin DSL:
+```kotlin
+buildscript {
+    repositories { jcenter() }
+
+    dependencies {
+        val kotlinVersion = "1.3.61"
+        classpath(kotlin("gradle-plugin", version = kotlinVersion))
+        classpath(kotlin("serialization", version = kotlinVersion))
+    }
+}
+```
+Groovy DSL:
 ```gradle
 buildscript {
-    ext.kotlin_version = '1.3.60'
+    ext.kotlin_version = '1.3.61'
     repositories { jcenter() }
 
     dependencies {
@@ -105,18 +120,52 @@ buildscript {
 }
 ```
 
-Don't forget to apply the plugin:
+#### Applying the plugin
 
+Next, apply the plugin to your project.
+
+You can setup serialization plugin with the kotlin plugin using [Gradle plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) **instead** of traditional `apply plugin`:
+
+Kotlin DSL:
+```kotlin
+plugins {
+    kotlin("multiplatform") // or kotlin("jvm") or any other kotlin plugin
+    id("kotlinx-serialization")
+}
+```
+Groovy DSL:
+```gradle
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform' version '1.3.61' // or any other kotlin plugin
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.3.61'
+}
+```
+Using the old way (with `apply plugin`) the setup looks like this (in Groovy):
 ```gradle
 apply plugin: 'kotlin' // or 'kotlin-multiplatform' for multiplatform projects
 apply plugin: 'kotlinx-serialization'
 ```
+Note: plugin marker for serialization has been published in Kotlin 1.3.50. If you need to use the earlier Kotlin version, see [KT-27612](https://youtrack.jetbrains.com/issue/KT-27612) for workaround with [plugin resolution rules](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_resolution_rules).
 
-Next, you have to add dependency on the serialization runtime library. Note that while plugin have version the same as compiler one, runtime library has different coordinates, repository and versioning.
+#### Dependency on the runtime library
 
-```gradle
+And finally, you have to add a dependency on the serialization runtime library. Note that while the plugin has version the same as the compiler one, runtime library has different coordinates, repository and versioning.
+
+Kotlin DSL:
+```kotlin
 repositories {
     // artifacts are published to JCenter
+    jcenter()
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8", KotlinCompilerVersion.VERSION))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0") // JVM dependency
+}
+```
+Groovy DSL:
+```gradle
+repositories {
     jcenter()
 }
 
@@ -125,21 +174,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0" // JVM dependency
 }
 ```
-
-### Gradle (with `plugins` block)
-
-You can setup serialization plugin with the kotlin plugin using [Gradle plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) **instead** of traditional `apply plugin`:
-
-```gradle
-plugins {
-    id 'org.jetbrains.kotlin.multiplatform' version '1.3.60' // or any other kotlin plugin
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.3.60'
-}
-```
-
-Note: plugin marker for serialization has been published in Kotlin 1.3.50. If you need to use the earlier Kotlin version, see [KT-27612](https://youtrack.jetbrains.com/issue/KT-27612) for workaround with [plugin resolution rules](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_resolution_rules).
-
-Runtime library should be added to dependencies the same way as before.
 
 ### Android/JVM
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Kotlin DSL:
 ```kotlin
 plugins {
     kotlin("multiplatform") // or kotlin("jvm") or any other kotlin plugin
-    id("kotlinx-serialization")
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.3.61"
 }
 ```
 Groovy DSL:
@@ -149,7 +149,7 @@ Then you can `apply plugin` (example in Groovy):
 
 ```gradle
 apply plugin: 'kotlin' // or 'kotlin-multiplatform' for multiplatform projects
-apply plugin: 'kotlinx-serialization'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 ```
 
 #### Dependency on the runtime library

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Kotlin DSL:
 ```kotlin
 plugins {
     kotlin("multiplatform") // or kotlin("jvm") or any other kotlin plugin
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.3.61"
+    kotlin("plugin.serialization") version "1.3.61"
 }
 ```
 Groovy DSL:
@@ -149,7 +149,7 @@ Then you can `apply plugin` (example in Groovy):
 
 ```gradle
 apply plugin: 'kotlin' // or 'kotlin-multiplatform' for multiplatform projects
-apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: 'kotlinx-serialization'
 ```
 
 #### Dependency on the runtime library


### PR DESCRIPTION
This fills the gap with missing documentation of configuration for Gradle Kotlin DSL (as described in https://github.com/Kotlin/kotlinx.serialization/issues/273).
Also divides the "Gradle" chapter into 3 subchapters for easier navigation (Adding the plugin, Applying the plugin, Dependency on the runtime library).