### PR TITLE
Add Linux ARM 64 bit target

### DIFF
--- a/gradle/native_mpp.gradle
+++ b/gradle/native_mpp.gradle
@@ -24,6 +24,7 @@ kotlin {
             // Linux
             addTarget(presets.linuxX64)
             addTarget(presets.linuxArm32Hfp)
+            addTarget(presets.linuxArm64)
 
             // Mac & iOS
             addTarget(presets.macosX64)


### PR DESCRIPTION
Same reasoning and flow as this pull request in atomicfu: https://github.com/Kotlin/kotlinx.atomicfu/pull/117 
just this time it's ktor-client and it's dependency kotlinx-serialization.

Background:
I tried compiling a multiplatform binary that included ktor-client-native-curl for Linux ARM 64 build target when I found out that there is no published artifact for that target. Then I found that one of dependencies is kotlinx-serialization, so that's the reason for this pull request.

I've ran tests with ./gradlew check, but I haven't done any deep dive into the code, so I might not be aware of all the consequences of including these build targets. 

**Summary:**

Add 64 bit Linux ARM target so the library can be used on 64bit ARM devices running Linux such as Raspberry PI.