### PR TITLE
Get rid of PrimitiveKind.UNIT and corresponding encoder methods

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/ElementWise.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ElementWise.kt
@@ -4,8 +4,7 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.modules.EmptyModule
-import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.*
 
 abstract class ElementValueEncoder : Encoder, CompositeEncoder {
     override val context: SerialModule
@@ -30,7 +29,7 @@ abstract class ElementValueEncoder : Encoder, CompositeEncoder {
     }
 
     override fun encodeUnit() {
-        val encoder = beginStructure(UnitSerializer.descriptor); encoder.endStructure(UnitSerializer.descriptor)
+        UnitSerializer.serialize(this, Unit)
     }
 
     override fun encodeBoolean(value: Boolean) = encodeValue(value)
@@ -46,7 +45,13 @@ abstract class ElementValueEncoder : Encoder, CompositeEncoder {
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = encodeValue(index)
 
     // Delegating implementation of CompositeEncoder
-    final override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int) { if (encodeElement(descriptor, index)) encodeUnit() }
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
+    final override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int) {
+        if (encodeElement(descriptor, index)) {
+            @Suppress("DEPRECATION_ERROR")
+            encodeUnit()
+        }
+    }
     final override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) { if (encodeElement(descriptor, index)) encodeBoolean(value) }
     final override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte) { if (encodeElement(descriptor, index)) encodeByte(value) }
     final override fun encodeShortElement(descriptor: SerialDescriptor, index: Int, value: Short) { if (encodeElement(descriptor, index)) encodeShort(value) }
@@ -79,8 +84,9 @@ abstract class ElementValueDecoder : Decoder, CompositeDecoder {
 
     open fun decodeValue(): Any = throw SerializationException("${this::class} can't retrieve untyped values")
 
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
     override fun decodeUnit() {
-        val reader = beginStructure(UnitSerializer.descriptor); reader.endStructure(UnitSerializer.descriptor)
+        UnitSerializer.deserialize(this)
     }
 
     override fun decodeBoolean(): Boolean = decodeValue() as Boolean
@@ -104,6 +110,8 @@ abstract class ElementValueDecoder : Decoder, CompositeDecoder {
     override fun endStructure(descriptor: SerialDescriptor) {
     }
 
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
+    @Suppress("DEPRECATION_ERROR")
     final override fun decodeUnitElement(desc: SerialDescriptor, index: Int) = decodeUnit()
     final override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean = decodeBoolean()
     final override fun decodeByteElement(descriptor: SerialDescriptor, index: Int): Byte = decodeByte()

--- a/runtime/commonMain/src/kotlinx/serialization/PrimitiveSerializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/PrimitiveSerializers.kt
@@ -9,11 +9,8 @@ import kotlinx.serialization.internal.*
 /**
  * Built-in serializer for [Unit] type.
  */
-public object UnitSerializer : KSerializer<Unit> {
-    override val descriptor: SerialDescriptor = BuiltinDescriptor("kotlin.Unit", PrimitiveKind.UNIT)
-    override fun serialize(encoder: Encoder, value: Unit) = encoder.encodeUnit()
-    override fun deserialize(decoder: Decoder): Unit = decoder.decodeUnit()
-}
+@Suppress("DEPRECATION_ERROR")
+public object UnitSerializer : KSerializer<Unit> by ObjectSerializer("kotlin.Unit", Unit)
 
 /**
  * Built-in serializer for [Boolean] type.
@@ -107,8 +104,6 @@ public fun Double.Companion.serializer(): KSerializer<Double> = DoubleSerializer
 public fun Boolean.Companion.serializer(): KSerializer<Boolean> = BooleanSerializer
 
 // Source-level migration aids
-
-
 @Deprecated(
     message = "Deprecated in the favour of PrimitiveDescriptor factory function",
     level = DeprecationLevel.ERROR

--- a/runtime/commonMain/src/kotlinx/serialization/SerialKinds.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SerialKinds.kt
@@ -111,6 +111,10 @@ public sealed class PrimitiveKind : SerialKind() {
     /*
      * Not documented, reworked in #664
      */
+    @Deprecated(
+        message = "Primitive kind Unit is deprecated with no replacement. Use StructureKind.OBJECT instead or check for a particular serialName",
+        level = DeprecationLevel.ERROR
+    )
     public object UNIT : PrimitiveKind()
 
     /**

--- a/runtime/commonMain/src/kotlinx/serialization/Tagged.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Tagged.kt
@@ -4,8 +4,11 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.modules.EmptyModule
-import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.*
+
+internal const val unitDeprecated =
+    "This method is deprecated with no replacement. Unit is encoded as an empty object and does not require a dedicated method. " +
+            "To migrate, just remove your own implementation of this method"
 
 abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
 
@@ -24,6 +27,7 @@ abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
 
     open fun encodeTaggedNotNullMark(tag: Tag) {}
     open fun encodeTaggedNull(tag: Tag): Unit = throw SerializationException("null is not supported")
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
     open fun encodeTaggedUnit(tag: Tag) = encodeTaggedValue(tag, Unit)
     open fun encodeTaggedInt(tag: Tag, value: Int) = encodeTaggedValue(tag, value)
     open fun encodeTaggedByte(tag: Tag, value: Byte) = encodeTaggedValue(tag, value)
@@ -57,8 +61,8 @@ abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
 
     final override fun encodeNotNullMark() = encodeTaggedNotNullMark(currentTag)
     final override fun encodeNull() = encodeTaggedNull(popTag())
-
-    final override fun encodeUnit() = encodeTaggedUnit(popTag())
+    @Suppress("DEPRECATION_ERROR")
+    final override fun encodeUnit() = UnitSerializer.serialize(this, Unit)
     final override fun encodeBoolean(value: Boolean) = encodeTaggedBoolean(popTag(), value)
     final override fun encodeByte(value: Byte) = encodeTaggedByte(popTag(), value)
     final override fun encodeShort(value: Short) = encodeTaggedShort(popTag(), value)
@@ -87,7 +91,8 @@ abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
      */
     open fun endEncode(descriptor: SerialDescriptor) {}
 
-    final override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int) = encodeTaggedUnit(descriptor.getTag(index))
+    @Suppress("DEPRECATION_ERROR")
+    final override fun encodeUnitElement(desc: SerialDescriptor, index: Int) = encodeTaggedUnit(desc.getTag(index))
     final override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) = encodeTaggedBoolean(descriptor.getTag(index), value)
     final override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte) = encodeTaggedByte(descriptor.getTag(index), value)
     final override fun encodeShortElement(descriptor: SerialDescriptor, index: Int, value: Short) = encodeTaggedShort(descriptor.getTag(index), value)
@@ -143,12 +148,13 @@ abstract class TaggedDecoder<Tag : Any?> : Decoder, CompositeDecoder {
 
 
     // ---- API ----
-    open fun decodeTaggedValue(tag: Tag): Any
-            = throw SerializationException("${this::class} can't retrieve untyped values")
+    open fun decodeTaggedValue(tag: Tag): Any =
+        throw SerializationException("${this::class} can't retrieve untyped values")
 
     open fun decodeTaggedNotNullMark(tag: Tag): Boolean = true
     open fun decodeTaggedNull(tag: Tag): Nothing? = null
 
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
     open fun decodeTaggedUnit(tag: Tag): Unit = decodeTaggedValue(tag) as Unit
     open fun decodeTaggedBoolean(tag: Tag): Boolean = decodeTaggedValue(tag) as Boolean
     open fun decodeTaggedByte(tag: Tag): Byte = decodeTaggedValue(tag) as Byte
@@ -167,7 +173,9 @@ abstract class TaggedDecoder<Tag : Any?> : Decoder, CompositeDecoder {
     final override fun decodeNotNullMark(): Boolean = decodeTaggedNotNullMark(currentTag)
     final override fun decodeNull(): Nothing? = null
 
-    final override fun decodeUnit() = decodeTaggedUnit(popTag())
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
+    @Suppress("DEPRECATION_ERROR")
+    final override fun decodeUnit() = UnitSerializer.deserialize(this)
     final override fun decodeBoolean(): Boolean = decodeTaggedBoolean(popTag())
     final override fun decodeByte(): Byte = decodeTaggedByte(popTag())
     final override fun decodeShort(): Short = decodeTaggedShort(popTag())
@@ -188,7 +196,9 @@ abstract class TaggedDecoder<Tag : Any?> : Decoder, CompositeDecoder {
         // Nothing
     }
 
-    final override fun decodeUnitElement(descriptor: SerialDescriptor, index: Int) = decodeTaggedUnit(descriptor.getTag(index))
+    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
+    @Suppress("DEPRECATION_ERROR")
+    final override fun decodeUnitElement(desc: SerialDescriptor, index: Int) = decodeTaggedUnit(desc.getTag(index))
     final override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean = decodeTaggedBoolean(descriptor.getTag(index))
     final override fun decodeByteElement(descriptor: SerialDescriptor, index: Int): Byte = decodeTaggedByte(descriptor.getTag(index))
     final override fun decodeShortElement(descriptor: SerialDescriptor, index: Int): Short = decodeTaggedShort(descriptor.getTag(index))

--- a/runtime/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.*
             "should not be used directly. For the custom serializers please report your use-case to project issues, so proper public API could be introduced instead",
     level = DeprecationLevel.ERROR
 )
+@InternalSerializationApi
 public class ObjectSerializer<T : Any>(serialName: String, private val objectInstance: T) : KSerializer<T> {
     override val descriptor: SerialDescriptor = SerialDescriptor(serialName, StructureKind.OBJECT)
 

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Primitives.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Primitives.kt
@@ -73,11 +73,7 @@ internal fun <T : Any> KClass<T>.builtinSerializerOrNull(): KSerializer<T>? =
     BUILTIN_SERIALIZERS[this] as KSerializer<T>?
 
 @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
-object UnitSerializer : KSerializer<Unit> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("kotlin.Unit", PrimitiveKind.UNIT)
-    override fun serialize(encoder: Encoder, value: Unit) = encoder.encodeUnit()
-    override fun deserialize(decoder: Decoder): Unit = decoder.decodeUnit()
-}
+object UnitSerializer : KSerializer<Unit> by UnitSerializer
 
 @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
 object BooleanSerializer : KSerializer<Boolean> {

--- a/runtime/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
@@ -95,7 +95,6 @@ class BasicTypesSerializationTest {
     )
 
     // KeyValue Input/Output
-
     class KeyValueOutput(private val sb: StringBuilder) : ElementValueEncoder() {
         override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
             sb.append('{')

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -174,7 +174,6 @@ class SerialDescriptorSpecificationTest {
     @Test
     fun testPrimitiveDescriptors() {
         checkPrimitiveDescriptor("int", IntSerializer.descriptor)
-        checkPrimitiveDescriptor("unit", UnitSerializer.descriptor)
         checkPrimitiveDescriptor("boolean", BooleanSerializer.descriptor)
         checkPrimitiveDescriptor("byte", ByteSerializer.descriptor)
         checkPrimitiveDescriptor("short", ShortSerializer.descriptor)
@@ -183,6 +182,16 @@ class SerialDescriptorSpecificationTest {
         checkPrimitiveDescriptor("double", DoubleSerializer.descriptor)
         checkPrimitiveDescriptor("char", CharSerializer.descriptor)
         checkPrimitiveDescriptor("string", StringSerializer.descriptor)
+    }
+
+    @Test
+    fun testUnitDescriptor() {
+        val descriptor = UnitSerializer.descriptor
+        assertEquals(StructureKind.OBJECT, descriptor.kind)
+        assertFalse(descriptor.isNullable)
+        assertEquals("kotlin.Unit", descriptor.serialName)
+        assertEquals(0, descriptor.annotations.size)
+        assertFailsWith<IndexOutOfBoundsException> { descriptor.getElementName(0) }
     }
 
     @Test

--- a/runtime/commonTest/src/kotlinx/serialization/UmbrellaTypes.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/UmbrellaTypes.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlin.native.concurrent.*
+
+enum class Attitude { POSITIVE, NEUTRAL, NEGATIVE }
+
+@Serializable
+data class Tree(val name: String, val left: Tree? = null, val right: Tree? = null)
+
+@Serializable
+data class TypesUmbrella(
+    val unit: Unit,
+    val boolean: Boolean,
+    val byte: Byte,
+    val short: Short,
+    val int: Int,
+    val long: Long,
+    val float: Float,
+    val double: Double,
+    val char: Char,
+    val string: String,
+    val enum: Attitude,
+    val intData: IntData,
+    val unitN: Unit?,
+    val booleanN: Boolean?,
+    val byteN: Byte?,
+    val shortN: Short?,
+    val intN: Int?,
+    val longN: Long?,
+    val floatN: Float?,
+    val doubleN: Double?,
+    val charN: Char?,
+    val stringN: String?,
+    val enumN: Attitude?,
+    val intDataN: IntData?,
+    val listInt: List<Int>,
+    val listIntN: List<Int?>,
+    val listNInt: Set<Int>?,
+    val listNIntN: MutableSet<Int?>?,
+    val listListEnumN: List<List<Attitude?>>,
+    val listIntData: List<IntData>,
+    val listIntDataN: MutableList<IntData?>,
+    val tree: Tree,
+    val mapStringInt: Map<String, Int>,
+    val mapIntStringN: Map<Int, String?>,
+    val arrays: ArraysUmbrella
+)
+
+@Serializable
+data class ArraysUmbrella(
+    val arrByte: Array<Byte>,
+    val arrInt: Array<Int>,
+    val arrIntN: Array<Int?>,
+    val arrIntData: Array<IntData>
+) {
+    override fun equals(other: Any?) = other is ArraysUmbrella &&
+            arrByte.contentEquals(other.arrByte) &&
+            arrInt.contentEquals(other.arrInt) &&
+            arrIntN.contentEquals(other.arrIntN) &&
+            arrIntData.contentEquals(other.arrIntData)
+}
+
+@SharedImmutable
+val umbrellaInstance = TypesUmbrella(
+    Unit, true, 10, 20, 30, 40, 50.1f, 60.1, 'A', "Str0", Attitude.POSITIVE, IntData(70),
+    null, null, 11, 21, 31, 41, 51.1f, 61.1, 'B', "Str1", Attitude.NEUTRAL, null,
+    listOf(1, 2, 3),
+    listOf(4, 5, null),
+    setOf(6, 7, 8),
+    mutableSetOf(null, 9, 10),
+    listOf(listOf(Attitude.NEGATIVE, null)),
+    listOf(IntData(1), IntData(2), IntData(3)),
+    mutableListOf(IntData(1), null, IntData(3)),
+    Tree("root", Tree("left"), Tree("right", Tree("right.left"), Tree("right.right"))),
+    mapOf("one" to 1, "two" to 2, "three" to 3),
+    mapOf(0 to null, 1 to "first", 2 to "second"),
+    ArraysUmbrella(
+        arrayOf(1, 2, 3),
+        arrayOf(100, 200, 300),
+        arrayOf(null, -1, -2),
+        arrayOf(IntData(1), IntData(2))
+    )
+)

--- a/runtime/commonTest/src/kotlinx/serialization/json/BasicTypesSerializationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/BasicTypesSerializationTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+@UseExperimental(ImplicitReflectionSerializer::class)
+class BasicTypesSerializationTest : JsonTestBase() {
+
+    val goldenValue = """
+        {"unit":{},"boolean":true,"byte":10,"short":20,"int":30,"long":40,"float":50.1,"double":60.1,"char":"A","string":"Str0","enum":"POSITIVE","intData":{"intV":70},"unitN":null,"booleanN":null,"byteN":11,"shortN":21,"intN":31,"longN":41,"floatN":51.1,"doubleN":61.1,"charN":"B","stringN":"Str1","enumN":"NEUTRAL","intDataN":null,"listInt":[1,2,3],"listIntN":[4,5,null],"listNInt":[6,7,8],"listNIntN":[null,9,10],"listListEnumN":[["NEGATIVE",null]],"listIntData":[{"intV":1},{"intV":2},{"intV":3}],"listIntDataN":[{"intV":1},null,{"intV":3}],"tree":{"name":"root","left":{"name":"left","left":null,"right":null},"right":{"name":"right","left":{"name":"right.left","left":null,"right":null},"right":{"name":"right.right","left":null,"right":null}}},"mapStringInt":{"one":1,"two":2,"three":3},"mapIntStringN":{"0":null,"1":"first","2":"second"},"arrays":{"arrByte":[1,2,3],"arrInt":[100,200,300],"arrIntN":[null,-1,-2],"arrIntData":[{"intV":1},{"intV":2}]}}
+    """.trimIndent()
+
+    @Test
+    fun testSerialization() = parametrizedTest { useStreaming ->
+        val json = strict.stringify(TypesUmbrella.serializer(), umbrellaInstance)
+        assertEquals(goldenValue, json)
+        val instance = strict.parse(TypesUmbrella.serializer(), json, useStreaming)
+        assertEquals(umbrellaInstance, instance)
+        assertNotSame(umbrellaInstance, instance)
+    }
+
+    @Test
+    fun testTopLevelPrimitive() = parametrizedTest { useStreaming ->
+        testPrimitive(Unit, "{}", useStreaming)
+        testPrimitive(false, "false", useStreaming)
+        testPrimitive(1.toByte(), "1", useStreaming)
+        testPrimitive(2.toShort(), "2", useStreaming)
+        testPrimitive(3, "3", useStreaming)
+        testPrimitive(4L, "4", useStreaming)
+        testPrimitive(5.1f, "5.1", useStreaming)
+        testPrimitive(6.1, "6.1", useStreaming)
+        testPrimitive('c', "\"c\"", useStreaming)
+        testPrimitive("string", "\"string\"", useStreaming)
+    }
+
+    private inline fun <reified T : Any> testPrimitive(primitive: T, expectedJson: String, useStreaming: Boolean) {
+        val json = strict.stringify(primitive, false)
+        assertEquals(expectedJson, json)
+        val instance = strict.parse<T>(json, useStreaming)
+        assertEquals(primitive, instance)
+    }
+}


### PR DESCRIPTION
  * Treat Unit as a regular Kotlin object which Unit is.
  * Ensure SerialDescriptor invariants in ObjectDescriptor

Also, fixes #645