### PR TITLE
Allow duplicating serializers during SerialModule concatenation if th…

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleImpl.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleImpl.kt
@@ -20,8 +20,13 @@ internal class SerialModuleImpl(
 
     override fun <T : Any> getPolymorphic(baseClass: KClass<T>, value: T): KSerializer<out T>? {
         if (!value.isInstanceOf(baseClass)) return null
-        (if (baseClass == Any::class) StandardSubtypesOfAny.getSubclassSerializer(value) else null)?.let { return it as KSerializer<out T> }
-        return polyBase2Serializers[baseClass]?.get(value::class) as? KSerializer<out T>
+        val custom = polyBase2Serializers[baseClass]?.get(value::class) as? KSerializer<out T>
+        if (custom != null) return custom
+        if (baseClass == Any::class) {
+            val serializer = StandardSubtypesOfAny.getSubclassSerializer(value)
+            return serializer as? KSerializer<out T>
+        }
+        return null
     }
 
     override fun <T : Any> getPolymorphic(baseClass: KClass<T>, serializedClassName: String): KSerializer<out T>? {

--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerializerAlreadyRegisteredException.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerializerAlreadyRegisteredException.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  * with [SerialModule.plus], consider using [SerialModule.overwriteWith] if you want overwriting behaviour.
  */
 @InternalSerializationApi // Will be hidden in the next release
-public class SerializerAlreadyRegisteredException private constructor(msg: String) : IllegalArgumentException(msg) {
+public class SerializerAlreadyRegisteredException internal constructor(msg: String) : IllegalArgumentException(msg) {
     constructor(
         baseClass: KClass<*>,
         concreteClass: KClass<*>

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonDefaultContextTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonDefaultContextTest.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlin.test.*
+
+class JsonDefaultContextTest {
+
+    @Test
+    fun testRepeatedSerializer() {
+        // #616
+        val json = Json(JsonConfiguration.Default)
+        Json(JsonConfiguration.Default, json.context)
+    }
+}


### PR DESCRIPTION
…ey are equal.

Additionally, fix a bug when builtin serializer was selected for known subtypes of Any even when custom one was registered

Fixes #616