### PR TITLE
Provide context aware descriptor

### DIFF
--- a/integration-test/src/commonTest/kotlin/sample/JsonTest.kt
+++ b/integration-test/src/commonTest/kotlin/sample/JsonTest.kt
@@ -65,7 +65,7 @@ class JsonTest {
     @Test
     fun testDescriptor() {
         val desc = Holder.serializer().descriptor
-        assertSame(PolymorphicKind.OPEN, desc.getElementDescriptor(0).kind)
+        assertEquals(PolymorphicSerializer(IMessage::class).descriptor, desc.getElementDescriptor(0))
     }
 
     @Test

--- a/runtime/commonMain/src/kotlinx/serialization/ContextAware.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ContextAware.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.internal.*
+import kotlinx.serialization.modules.*
+import kotlin.jvm.*
+import kotlin.reflect.*
+
+
+/**
+ * Retrieves [KClass] associated with serializer and its descriptor, if it was captured.
+ *
+ * For schema introspection purposes, [capturedKClass] can be used in [SerialModule] as a key
+ * to retrieve registered descriptor at runtime.
+ * This property is intended to be used on [UnionKind.CONTEXTUAL] and [PolymorphicKind.OPEN] kinds of descriptors,
+ * where actual serializer used for a property can be determined only at runtime.
+ * Serializers which represent contextual serialization and open polymorphism (namely, [ContextSerializer] and
+ * [PolymorphicSerializer]) capture statically known KClass in a descriptor and can expose it via this property.
+ *
+ * This property is `null` for descriptors that are not of [UnionKind.CONTEXTUAL] or [PolymorphicKind.OPEN] kinds.
+ * It _may_ be `null` for descriptors of these kinds, if captured class information is unavailable for various reasons.
+ * It means that schema introspection should be performed in an application-specific manner.
+ *
+ * ### Example
+ * Imagine we need to find all distinct properties names, which may occur in output after serializing a given class
+ * with respect to [`@ContextualSerialization`][ContextualSerialization] annotation and all possible inheritors when the class is
+ * serialized polymorphically.
+ * Then we can write following function:
+ * ```
+ * fun allDistinctNames(descriptor: SerialDescriptor, module: SerialModule) = when (descriptor.kind) {
+ *   is PolymorphicKind.OPEN -> module.getPolymorphicDescriptors(descriptor)
+ *     .map { it.elementNames() }.flatten().toSet()
+ *   is UnionKind.CONTEXTUAL -> module.getContextualDescriptor(descriptor)
+ *     ?.elementNames().orEmpty().toSet()
+ *   else -> descriptor.elementNames().toSet()
+ * }
+ * ```
+ * @see SerialModule.getContextualDescriptor
+ * @see SerialModule.getPolymorphicDescriptors
+ */
+public val SerialDescriptor.capturedKClass: KClass<*>?
+    get() = when (this) {
+        is ContextDescriptor -> kClass
+        is SerialDescriptorForNullable -> original.capturedKClass
+        else -> null
+    }
+
+/**
+ * Wraps [this] in [ContextDescriptor].
+ */
+internal fun SerialDescriptor.withContext(context: KClass<*>): SerialDescriptor =
+    ContextDescriptor(this, context)
+
+/**
+ * Descriptor that captures [kClass] and allows retrieving additional runtime information,
+ * if proper [SerialModule] is provided.
+ */
+private class ContextDescriptor(
+    private val original: SerialDescriptor,
+    @JvmField val kClass: KClass<*>
+) : SerialDescriptor by original {
+    override val serialName = "${original.serialName}<${kClass.simpleName()}>"
+
+    override fun equals(other: Any?): Boolean {
+        val another = other as? ContextDescriptor ?: return false
+        return original == another.original && another.kClass == this.kClass
+    }
+
+    override fun hashCode(): Int {
+        var result = kClass.hashCode()
+        result = 31 * result + serialName.hashCode()
+        return result
+    }
+}

--- a/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.*
 @ImplicitReflectionSerializer
 public class ContextSerializer<T : Any>(private val serializableClass: KClass<T>) : KSerializer<T> {
     public override val descriptor: SerialDescriptor =
-        SerialDescriptor("kotlinx.serialization.ContextSerializer", UnionKind.CONTEXTUAL)
+        SerialDescriptor("kotlinx.serialization.ContextSerializer", UnionKind.CONTEXTUAL).withContext(serializableClass)
 
     public override fun serialize(encoder: Encoder, value: T) {
         val serializer = encoder.context.getContextualOrDefault(value)

--- a/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
@@ -9,16 +9,12 @@ import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.reflect.*
 
-@Suppress("UNUSED")
+@Suppress("UNUSED", "DeprecatedCallableAddReplaceWith")
 @Deprecated(
     message = "Top-level polymorphic descriptor is deprecated, use descriptor from the instance of PolymorphicSerializer or" +
-            "check for descriptor kind instead", level = DeprecationLevel.WARNING
+            "check for descriptor kind instead", level = DeprecationLevel.ERROR
 )
-public val PolymorphicClassDescriptor: SerialDescriptor =
-    SerialDescriptor("kotlinx.serialization.Polymorphic", PolymorphicKind.OPEN) {
-        element("type", String.serializer().descriptor)
-        element("value", SerialDescriptor("kotlinx.serialization.Polymorphic", UnionKind.CONTEXTUAL))
-    }
+public val PolymorphicClassDescriptor: SerialDescriptor get() = error("This property is no longer supported")
 
 /**
  * This class provides support for multiplatform polymorphic serialization for interfaces and abstract classes.
@@ -82,5 +78,5 @@ public class PolymorphicSerializer<T : Any>(override val baseClass: KClass<T>) :
                 "value",
                 SerialDescriptor("kotlinx.serialization.Polymorphic<${baseClass.simpleName}>", UnionKind.CONTEXTUAL)
             )
-        }
+        }.withContext(baseClass)
 }

--- a/runtime/commonMain/src/kotlinx/serialization/SerialKinds.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SerialKinds.kt
@@ -4,6 +4,10 @@
 
 package kotlinx.serialization
 
+import kotlinx.serialization.PrimitiveKind.*
+import kotlinx.serialization.StructureKind.*
+import kotlinx.serialization.modules.*
+
 /**
  * Serial kind is an intrinsic property of [SerialDescriptor] that indicates how
  * the corresponding type is structurally represented by its serializer.
@@ -227,7 +231,10 @@ public sealed class UnionKind : SerialKind() {
      * Represents an "unknown" type that will be known only at the moment of the serialization.
      * Effectively it defers the choice of the serializer to a moment of the serialization, and can
      * be used for [contextual][ContextualSerialization] serialization.
-     * Possible options can be known statically (e.g. for sealed classes), in that case they can be
+     *
+     * To introspect descriptor of this kind, an instance of [SerialModule] is required.
+     * See [capturedKClass] extension property for more details.
+     * However, if possible options are known statically (e.g. for sealed classes), they can be
      * enumerated in child descriptors similarly to [ENUM_KIND].
      */
     public object CONTEXTUAL : UnionKind()
@@ -254,6 +261,9 @@ public sealed class PolymorphicKind : SerialKind() {
      * Due to security concerns and typical mistakes that arises from polymorphic serialization, by default
      * `kotlinx.serialization` provides only bounded polymorphic serialization, forcing users to register all possible
      * serializers for a given base class or interface.
+     *
+     * To introspect descriptor of this kind (e.g. list possible subclasses), an instance of [SerialModule] is required.
+     * See [capturedKClass] extension property for more details.
      */
     public object OPEN : PolymorphicKind()
 }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
@@ -58,7 +58,7 @@ public class NullableSerializer<T : Any>(private val serializer: KSerializer<T>)
     }
 }
 
-internal class SerialDescriptorForNullable(private val original: SerialDescriptor) : SerialDescriptor by original {
+internal class SerialDescriptorForNullable(internal val original: SerialDescriptor) : SerialDescriptor by original {
     override val serialName: String = original.serialName + "?"
     override val isNullable: Boolean
         get() = true

--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleImpl.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerialModuleImpl.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.*
  */
 internal class SerialModuleImpl(
     private val class2Serializer: Map<KClass<*>, KSerializer<*>>,
-    private val polyBase2Serializers: Map<KClass<*>, Map<KClass<*>, KSerializer<*>>>,
+    internal val polyBase2Serializers: Map<KClass<*>, Map<KClass<*>, KSerializer<*>>>,
     private val polyBase2NamedSerializers: Map<KClass<*>, Map<String, KSerializer<*>>>
 ) : SerialModule {
 

--- a/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
@@ -24,6 +24,7 @@ class ContextAndPolymorphicTest {
     )
 
     @Serializable
+    @SerialName("Payload")
     data class Payload(val s: String)
 
     @Serializable
@@ -33,7 +34,8 @@ class ContextAndPolymorphicTest {
     object PayloadSerializer
 
     object BinaryPayloadSerializer : KSerializer<Payload> {
-        override val descriptor: SerialDescriptor = PrimitiveDescriptor("Payload", PrimitiveKind.STRING)
+        override val descriptor: SerialDescriptor = PrimitiveDescriptor("BinaryPayload", PrimitiveKind.STRING)
+
         override fun serialize(encoder: Encoder, value: Payload) {
             encoder.encodeString(InternalHexConverter.printHexBinary(value.s.encodeToByteArray()))
         }
@@ -80,7 +82,7 @@ class ContextAndPolymorphicTest {
         val map = mapOf<String, Any>("Payload" to Payload("data"))
         val serializer = MapSerializer(String.serializer(), PolymorphicSerializer(Any::class))
         val s = json.stringify(serializer, map)
-        assertEquals("""{Payload:[kotlinx.serialization.features.ContextAndPolymorphicTest.Payload,{s:data}]}""", s)
+        assertEquals("""{Payload:[Payload,{s:data}]}""", s)
     }
 
     @Test
@@ -97,5 +99,29 @@ class ContextAndPolymorphicTest {
         val list = PayloadList(listOf(Payload("string")))
         assertEquals("""{"ps":[{"s":"string"}]}""", json1.stringify(PayloadList.serializer(), list))
         assertEquals("""{"ps":["737472696E67"]}""", json2.stringify(PayloadList.serializer(), list))
+    }
+
+    private fun SerialDescriptor.inContext(module: SerialModule): SerialDescriptor = when (kind) {
+        UnionKind.CONTEXTUAL -> requireNotNull(module.getContextualDescriptor(this)) { "Expected $this to be registered in module" }
+        else -> error("Expected this function to be called on CONTEXTUAL descriptor")
+    }
+
+    @Test
+    fun testResolveContextualDescriptor() {
+        val simpleModule = serializersModule(PayloadSerializer)
+        val binaryModule = serializersModule(BinaryPayloadSerializer)
+
+        val contextDesc = EnhancedData.serializer().descriptor.elementDescriptors()[1] // @ContextualSer stringPayload
+        assertEquals(UnionKind.CONTEXTUAL, contextDesc.kind)
+        assertEquals(0, contextDesc.elementsCount)
+
+        val resolvedToDefault = contextDesc.inContext(simpleModule)
+        assertEquals(StructureKind.CLASS, resolvedToDefault.kind)
+        assertEquals("Payload", resolvedToDefault.serialName)
+        assertEquals(1, resolvedToDefault.elementsCount)
+
+        val resolvedToBinary = contextDesc.inContext(binaryModule)
+        assertEquals(PrimitiveKind.STRING, resolvedToBinary.kind)
+        assertEquals("BinaryPayload", resolvedToBinary.serialName)
     }
 }


### PR DESCRIPTION
Which should capture KClass in case of contextual/polymorphic serialization, thus allowing to build full schema, provided correct SerialModule is present

Fixes #515 and #595 