### PR TITLE
Add option to use HOCON naming convention

### DIFF
--- a/formats/config/src/main/kotlin/org/jetbrains/kotlinx/serialization/config/ConfigParserConfiguration.kt
+++ b/formats/config/src/main/kotlin/org/jetbrains/kotlinx/serialization/config/ConfigParserConfiguration.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.kotlinx.serialization.config
+
+/**
+ * The class responsible for Config-specific customizable behaviour in [ConfigParser] format.
+ *
+ * Options list:
+ * * [useConfigNamingConvention] switches naming resolution to config naming convention (hyphen separated)
+ *   `someField` will be read as `some-field`
+ */
+public data class ConfigParserConfiguration(val useConfigNamingConvention: Boolean = false)

--- a/formats/config/src/test/kotlin/org/jetbrains/kotlinx/serialization/config/ConfigParserNamingConventionTest.kt
+++ b/formats/config/src/test/kotlin/org/jetbrains/kotlinx/serialization/config/ConfigParserNamingConventionTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlinx.serialization.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConfigParserNamingConventionTest {
+
+    @Serializable
+    data class CaseConfig(val aCharValue: Char, val aStringValue: String)
+
+    @Serializable
+    data class SerialNameConfig(@SerialName("an-id-value") val anIDValue: Int)
+
+    @Serializable
+    data class CaseWithInnerConfig(val caseConfig: CaseConfig, val serialNameConfig: SerialNameConfig)
+
+    @Test
+    fun `deserialize using naming convention`() {
+        val obj = deserializeConfig("a-char-value = t, a-string-value = test", CaseConfig.serializer(), true)
+        assertEquals('t', obj.aCharValue)
+        assertEquals("test", obj.aStringValue)
+    }
+
+    @Test
+    fun `use serial name instead of naming convention if provided`() {
+        val obj = deserializeConfig("an-id-value = 42", SerialNameConfig.serializer(), true)
+        assertEquals(42, obj.anIDValue)
+    }
+
+    @Test
+    fun `deserialize inner values using naming convention`() {
+        val configString = "case-config {a-char-value = b, a-string-value = bar}, serial-name-config {an-id-value = 21}"
+        val obj = deserializeConfig(configString, CaseWithInnerConfig.serializer(), true)
+        with(obj.caseConfig) {
+            assertEquals('b', aCharValue)
+            assertEquals("bar", aStringValue)
+        }
+        assertEquals(21, obj.serialNameConfig.anIDValue)
+    }
+}

--- a/formats/config/src/test/kotlin/org/jetbrains/kotlinx/serialization/config/ConfigParserObjectsTest.kt
+++ b/formats/config/src/test/kotlin/org/jetbrains/kotlinx/serialization/config/ConfigParserObjectsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 JetBrains s.r.o.
+ * Copyright 2018-2020 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,12 @@ import kotlinx.serialization.Serializable
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal inline fun <reified T> deserializeConfig(configString: String, deserializer: DeserializationStrategy<T>): T =
-    ConfigParser.parse(ConfigFactory.parseString(configString), deserializer)
+internal inline fun <reified T> deserializeConfig(
+    configString: String,
+    deserializer: DeserializationStrategy<T>,
+    useNamingConvention: Boolean = false
+): T = ConfigParser(ConfigParserConfiguration(useNamingConvention))
+        .parse(ConfigFactory.parseString(configString), deserializer)
 
 class ConfigParserObjectsTest {
 
@@ -146,7 +150,7 @@ class ConfigParserObjectsTest {
     @Test
     fun `config with nested object`() {
         val obj = deserializeConfig("x: [{a: 42}, {a: 43}, {a: 44}]", NestedObj.serializer())
-        assertEquals(listOf(42,43,44).map { Simple(it) }, obj.x)
+        assertEquals(listOf(42, 43, 44).map { Simple(it) }, obj.x)
     }
 
     @Test


### PR DESCRIPTION
[HOCON naming convention](https://github.com/lightbend/config/blob/master/HOCON.md#hyphen-separated-vs-camelcase)