### PR TITLE
Refactor decoder

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -27,7 +27,6 @@ import kotlin.experimental.*
  * @param encodeDefaults specifies whether default values of Kotlin properties are encoded.
  */
 public class Cbor(
-    public val updateMode: UpdateMode = UpdateMode.BANNED,
     public val encodeDefaults: Boolean = true,
     override val context: SerialModule = EmptyModule
 ) : BinaryFormat {

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -53,7 +53,7 @@ public class Cbor(
         protected open fun writeBeginToken() = encoder.startMap()
 
         //todo: Write size of map or array if known
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
             val writer = when (descriptor.kind) {
                 StructureKind.LIST, is PolymorphicKind -> CborListWriter(encoder)
                 StructureKind.MAP -> CborMapWriter(encoder)
@@ -190,12 +190,9 @@ public class Cbor(
         override val context: SerialModule
             get() = this@Cbor.context
 
-        override val updateMode: UpdateMode
-            get() = this@Cbor.updateMode
-
         protected open fun skipBeginToken() = setSize(decoder.startMap())
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             val re = when (descriptor.kind) {
                 StructureKind.LIST, is PolymorphicKind -> CborListReader(decoder)
                 StructureKind.MAP -> CborMapReader(decoder)

--- a/formats/config/src/main/kotlin/kotlinx/serialization/config/ConfigReader.kt
+++ b/formats/config/src/main/kotlin/kotlinx/serialization/config/ConfigReader.kt
@@ -58,8 +58,6 @@ public class ConfigParser(
         override fun decodeTaggedFloat(tag: T): Float = getTaggedNumber(tag).toFloat()
         override fun decodeTaggedDouble(tag: T): Double = getTaggedNumber(tag).toDouble()
 
-        override fun decodeTaggedUnit(tag: T) = Unit
-
         override fun decodeTaggedChar(tag: T): Char {
             val s = validateAndCast<String>(tag, ConfigValueType.STRING)
             if (s.length != 1) throw SerializationException("String \"$s\" is not convertible to Char")
@@ -109,7 +107,7 @@ public class ConfigParser(
             return !conf.getIsNull(tag)
         }
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder =
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
                 descriptor.kind.listLike -> ListConfigReader(conf.getList(currentTag))
                 descriptor.kind.objLike -> if (ind > -1) ConfigReader(conf.getConfig(currentTag)) else this
@@ -121,7 +119,7 @@ public class ConfigParser(
     private inner class ListConfigReader(private val list: ConfigList) : ConfigConverter<Int>() {
         private var ind = -1
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder =
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
                 descriptor.kind.listLike -> ListConfigReader(list[currentTag] as ConfigList)
                 descriptor.kind.objLike -> ConfigReader((list[currentTag] as ConfigObject).toConfig())
@@ -153,7 +151,7 @@ public class ConfigParser(
 
         private val indexSize = values.size * 2
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder =
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
                 descriptor.kind.listLike -> ListConfigReader(values[currentTag / 2] as ConfigList)
                 descriptor.kind.objLike -> ConfigReader((values[currentTag / 2] as ConfigObject).toConfig())

--- a/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
@@ -45,8 +45,7 @@ public class Properties(override val context: SerialModule = EmptyModule) : Seri
 
         override fun beginCollection(
             descriptor: SerialDescriptor,
-            collectionSize: Int,
-            vararg typeSerializers: KSerializer<*>
+            collectionSize: Int
         ): CompositeEncoder {
             // todo: decide whether this is responsibility of the format
             //       OR beginCollection should pass collectionSize = 2 * size in case of maps
@@ -71,8 +70,7 @@ public class Properties(override val context: SerialModule = EmptyModule) : Seri
 
         override fun beginCollection(
             descriptor: SerialDescriptor,
-            collectionSize: Int,
-            vararg typeSerializers: KSerializer<*>
+            collectionSize: Int
         ): CompositeEncoder {
             val size = if (descriptor.kind is StructureKind.MAP) collectionSize * 2 else collectionSize
             encodeTaggedInt(nested("size"), size)
@@ -93,7 +91,7 @@ public class Properties(override val context: SerialModule = EmptyModule) : Seri
 
         private var currentIndex = 0
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             return InMapper(map).also { copyTagsTo(it) }
         }
 
@@ -121,7 +119,7 @@ public class Properties(override val context: SerialModule = EmptyModule) : Seri
 
         private var currentIndex = 0
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             return InNullableMapper(map).also { copyTagsTo(it) }
         }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoBuf.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoBuf.kt
@@ -130,8 +130,7 @@ public class ProtoBuf(
         override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = encodeDefaults
 
         override fun beginStructure(
-            descriptor: SerialDescriptor,
-            vararg typeSerializers: KSerializer<*>
+            descriptor: SerialDescriptor
         ): CompositeEncoder = when (descriptor.kind) {
             StructureKind.LIST -> RepeatedWriter(encoder, currentTag)
             StructureKind.CLASS, StructureKind.OBJECT, is PolymorphicKind -> ObjectWriter(currentTagOrNull, encoder)
@@ -340,7 +339,7 @@ public class ProtoBuf(
             return -1
         }
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder =
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when (descriptor.kind) {
                 StructureKind.LIST -> RepeatedReader(decoder, currentTag, descriptor)
                 StructureKind.CLASS, StructureKind.OBJECT, is PolymorphicKind ->

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ScatteredArraysTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ScatteredArraysTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+class ScatteredArraysTest {
+    @Serializable
+    data class ListData(val data: List<String>, val separator: String)
+
+    @Serializable
+    data class ByteData(val data: ByteArray, val separator: String) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ByteData) return false
+
+            if (!data.contentEquals(other.data)) return false
+            if (separator != other.separator) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = data.contentHashCode()
+            result = 31 * result + separator.hashCode()
+            return result
+        }
+    }
+
+    private fun prepareListTestData(): String {
+        // Concatenate two serialized representations
+        // Resulting bytes would be [1, 2, foo, 3, bar]
+        // Protobuf per spec must read it as ListData([1,2,3], bar)
+        val d1 = ListData(listOf("1", "2"), "foo")
+        val d2 = ListData(listOf("3"), "bar")
+        return ProtoBuf.dumps(ListData.serializer(), d1) + ProtoBuf.dumps(ListData.serializer(), d2)
+    }
+
+    private fun prepareByteTestData(): String {
+        // Concatenate two serialized representations
+        // Resulting bytes would be [1, 2, foo, 3, bar]
+        // Protobuf per spec must read it as ByteData([1,2,3], bar)
+        val d1 = ByteData(byteArrayOf(1, 2), "foo")
+        val d2 = ByteData(byteArrayOf(3), "bar")
+        return ProtoBuf.dumps(ByteData.serializer(), d1) + ProtoBuf.dumps(ByteData.serializer(), d2)
+    }
+
+    private fun <T> doTest(serializer: KSerializer<T>, testData: String, goldenValue: T) {
+        val parsed = ProtoBuf.loads(serializer, testData)
+        assertEquals(goldenValue, parsed)
+    }
+
+    @Test
+    fun testListData() =
+        doTest(ListData.serializer(), prepareListTestData(), ListData(listOf("1", "2", "3"), "bar"))
+
+    @Test
+    fun testByteData() =
+        doTest(ByteData.serializer(), prepareByteTestData(), ByteData(byteArrayOf(1, 2, 3), "bar"))
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 group=org.jetbrains.kotlinx
 version=0.20.0-SNAPSHOT
 
-kotlin.version=1.3.70
+kotlin.version=1.4.0-dev-5730
 
 # This version take precedence if 'bootstrap' property passed to project
 kotlin.version.snapshot=1.4-SNAPSHOT

--- a/gradle/native_mpp.gradle
+++ b/gradle/native_mpp.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 

--- a/integration-test/gradle.properties
+++ b/integration-test/gradle.properties
@@ -2,7 +2,7 @@
 # Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
 #
 
-mainKotlinVersion=1.3.70
+mainKotlinVersion=1.4.0-dev-5730
 mainLibVersion=0.20.0-SNAPSHOT
 
 kotlin.code.style=official

--- a/runtime/commonMain/src/kotlinx/serialization/Decoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Decoding.kt
@@ -214,6 +214,14 @@ public interface Decoder {
      * ```
      * has three nested structures: the very beginning of the data, "b" value and "c" value.
      */
+    @Suppress("DEPRECATION_ERROR", "RemoveRedundantSpreadOperator")
+    public fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder = beginStructure(descriptor, *arrayOf<KSerializer<*>>())
+
+    @Deprecated(
+        "Parameter typeSerializers is deprecated for removal. Please migrate to beginStructure method with one argument.",
+        ReplaceWith("beginStructure(descriptor)"),
+        DeprecationLevel.ERROR
+    )
     public fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder
 
     /**

--- a/runtime/commonMain/src/kotlinx/serialization/Decoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Decoding.kt
@@ -105,8 +105,10 @@ public interface Decoder {
      */
     public val context: SerialModule
 
+    @Suppress("DEPRECATION")
     @Deprecated(updateModeDeprecated, level = DeprecationLevel.ERROR)
     public val updateMode: UpdateMode
+        get() = UpdateMode.OVERWRITE
 
     /**
      * Returns `true` if the current value in decoder is not null, false otherwise.
@@ -214,7 +216,7 @@ public interface Decoder {
      * ```
      * has three nested structures: the very beginning of the data, "b" value and "c" value.
      */
-    @Suppress("DEPRECATION_ERROR", "RemoveRedundantSpreadOperator")
+    @Suppress("DEPRECATION_ERROR")
     public fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder = beginStructure(descriptor, *arrayOf<KSerializer<*>>())
 
     @Deprecated(
@@ -302,8 +304,10 @@ public interface CompositeDecoder {
      */
     public val context: SerialModule
 
+    @Suppress("DEPRECATION")
     @Deprecated(updateModeDeprecated, level = DeprecationLevel.ERROR)
     public val updateMode: UpdateMode
+        get() = UpdateMode.OVERWRITE
 
     /**
      * Denotes the end of the structure associated with current decoder.
@@ -495,36 +499,38 @@ public interface CompositeDecoder {
     /**
      * Decodes value of the type [T] with the given [deserializer].
      *
-     * Particular implementations of [CompositeDecoder] may use their format-specific deserializers
+     * Implementations of [CompositeDecoder] may use their format-specific deserializers
      * for particular data types, e.g. handle [ByteArray] specifically if format is binary.
      *
      * If value at given [index] was already decoded with previous [decodeSerializableElement] call with the same index,
-     * [oldValue] would contain a previously decoded value.
-     * Implementation may ignore it and return new value, efficiently overwriting decoded value,
-     * or process it and return merged value if format supports such an operation.
+     * [previousValue] would contain a previously decoded value.
+     * This parameter can be used to aggregate multiple values of the given property to the only one.
+     * Implementation can safely ignore it and return a new value, effectively using 'the last one wins' strategy,
+     * or apply format-specific aggregating strategies, e.g. appending scattered Protobuf lists to a single one.
      */
     @Suppress("DEPRECATION_ERROR")
     public fun <T : Any?> decodeSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         deserializer: DeserializationStrategy<T>,
-        oldValue: T? = null
+        previousValue: T? = null
     ): T = decodeSerializableElement(descriptor, i = index, deserializer = deserializer)
 
     /**
      * Decodes nullable value of the type [T] with the given [deserializer].
      *
-     * If value at given [index] was already decoded with previous [decodeNullableSerializableElement] call with the same index,
-     * [oldValue] would contain a previously decoded value.
-     * Implementation may ignore it and return new value, efficiently overwriting decoded value,
-     * or process it and return merged value if format supports such an operation.
+     * If value at given [index] was already decoded with previous [decodeSerializableElement] call with the same index,
+     * [previousValue] would contain a previously decoded value.
+     * This parameter can be used to aggregate multiple values of the given property to the only one.
+     * Implementation can safely ignore it and return a new value, efficiently using 'the last one wins' strategy,
+     * or apply format-specific aggregating strategies, e.g. appending scattered Protobuf lists to a single one.
      */
     @Suppress("DEPRECATION_ERROR")
     public fun <T : Any> decodeNullableSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         deserializer: DeserializationStrategy<T?>,
-        oldValue: T? = null
+        previousValue: T? = null
     ): T? = decodeNullableSerializableElement(descriptor, i = index, deserializer = deserializer)
 
     @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "DeprecatedCallableAddReplaceWith")
@@ -589,7 +595,7 @@ public inline fun <T> Decoder.decodeStructure(
 }
 
 
-private const val updateModeDeprecated = "Update mode in Decoder is deprecated for removal. " +
+internal const val updateModeDeprecated = "Update mode in Decoder is deprecated for removal. " +
         "Update behaviour is now considered an implementation detail of the format that should not concern serializer."
 
 private const val updateMethodDeprecated = "Update* methods are deprecated for removal. " +

--- a/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
@@ -238,7 +238,8 @@ public interface Encoder {
         ReplaceWith("beginStructure(descriptor)"),
         DeprecationLevel.ERROR
     )
-    public fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder
+    public fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder =
+        beginStructure(descriptor)
 
     /**
      * Encodes the beginning of the collection with size [collectionSize] and the given serializer of its type parameters.

--- a/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
@@ -228,21 +228,38 @@ public interface Encoder {
      * }
      *
      * ```
-     *
-     * [typeSerializers] are used for encoding collections or classes with type parameters and are serializers
-     * of type parameters.
      */
+    @Suppress("DEPRECATION_ERROR", "RemoveRedundantSpreadOperator")
+    public fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder =
+        beginStructure(descriptor, *arrayOf<KSerializer<*>>())
+
+    @Deprecated(
+        "Parameter typeSerializers is deprecated for removal. Please migrate to beginStructure method with one argument.",
+        ReplaceWith("beginStructure(descriptor)"),
+        DeprecationLevel.ERROR
+    )
     public fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder
 
     /**
      * Encodes the beginning of the collection with size [collectionSize] and the given serializer of its type parameters.
      * This method has to be implemented only if you need to know collection size in advance, otherwise, [beginStructure] can be used.
      */
+    @Suppress("DEPRECATION_ERROR", "RemoveRedundantSpreadOperator")
+    public fun beginCollection(
+        descriptor: SerialDescriptor,
+        collectionSize: Int
+    ): CompositeEncoder = beginCollection(descriptor, collectionSize, *arrayOf<KSerializer<*>>())
+
+    @Deprecated(
+        "Parameter typeSerializers is deprecated for removal. Please migrate to beginCollection method with two arguments.",
+        ReplaceWith("beginCollection(descriptor, collectionSize)"),
+        DeprecationLevel.ERROR
+    )
     public fun beginCollection(
         descriptor: SerialDescriptor,
         collectionSize: Int,
         vararg typeSerializers: KSerializer<*>
-    ): CompositeEncoder = beginStructure(descriptor, *typeSerializers)
+    ): CompositeEncoder = beginStructure(descriptor)
 
     /**
      * Encodes the [value] of type [T] by delegating the encoding process to the given [serializer].

--- a/runtime/commonMain/src/kotlinx/serialization/KSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/KSerializer.kt
@@ -61,6 +61,7 @@ public interface KSerializer<T> : SerializationStrategy<T>, DeserializationStrat
      */
     override val descriptor: SerialDescriptor
 
+    @Deprecated(patchDeprecated, level = DeprecationLevel.ERROR)
     override fun patch(decoder: Decoder, old: T): T = throw UpdateNotSupportedException(descriptor.serialName)
 }
 
@@ -172,10 +173,19 @@ public interface DeserializationStrategy<T> {
      */
     public fun deserialize(decoder: Decoder): T
 
+    @Deprecated(patchDeprecated, level = DeprecationLevel.ERROR)
     public fun patch(decoder: Decoder, old: T): T
 }
 
+// Can't be error yet because it's impossible to add default implementations for `val updateMode` in Decoder:
+// 'Class JsonInput must implement updateMode because it inherits it from multiple interfaces'
+// so users will have it in signature until we delete updateMode
+@Deprecated(updateModeDeprecated, level = DeprecationLevel.WARNING)
 @Suppress("NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING")
 public enum class UpdateMode {
     BANNED, OVERWRITE, UPDATE
 }
+
+internal const val patchDeprecated =
+    "Patch function is deprecated for removal since this functionality is no longer supported by serializer." +
+            "Some formats may provide implementation-specific patching in their Decoders."

--- a/runtime/commonMain/src/kotlinx/serialization/builtins/AbstractEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/builtins/AbstractEncoder.kt
@@ -17,6 +17,14 @@ public abstract class AbstractEncoder : Encoder, CompositeEncoder {
     override val context: SerialModule
         get() = EmptyModule
 
+    // do not update signature here because new signature is called by the plugin;
+    // and clients that have old signature would not be called.
+    @Suppress("OverridingDeprecatedMember")
+    @Deprecated(
+        "Parameter typeSerializers is deprecated for removal. Please migrate to beginStructure method with one argument.",
+        ReplaceWith("beginStructure(descriptor)"),
+        DeprecationLevel.ERROR
+    )
     override fun beginStructure(
         descriptor: SerialDescriptor,
         vararg typeSerializers: KSerializer<*>
@@ -67,11 +75,22 @@ public abstract class AbstractEncoder : Encoder, CompositeEncoder {
     final override fun encodeCharElement(descriptor: SerialDescriptor, index: Int, value: Char) { if (encodeElement(descriptor, index)) encodeChar(value) }
     final override fun encodeStringElement(descriptor: SerialDescriptor, index: Int, value: String) { if (encodeElement(descriptor, index)) encodeString(value) }
 
-    final override fun <T : Any?> encodeSerializableElement(descriptor: SerialDescriptor, index: Int, serializer: SerializationStrategy<T>, value: T) {
+    final override fun <T : Any?> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T
+    ) {
         if (encodeElement(descriptor, index))
             encodeSerializableValue(serializer, value)
     }
-    final override fun <T : Any> encodeNullableSerializableElement(descriptor: SerialDescriptor, index: Int, serializer: SerializationStrategy<T>, value: T?) {
+
+    final override fun <T : Any> encodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T?
+    ) {
         if (encodeElement(descriptor, index))
             encodeNullableSerializableValue(serializer, value)
     }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
@@ -68,7 +68,7 @@ public sealed class ListLikeSerializer<Element, Collection, Builder>(
 
     override fun serialize(encoder: Encoder, value: Collection) {
         val size = value.collectionSize()
-        val composite = encoder.beginCollection(descriptor, size, *typeParams)
+        val composite = encoder.beginCollection(descriptor, size)
         val iterator = value.collectionIterator()
         for (index in 0 until size)
             composite.encodeSerializableElement(descriptor, index, elementSerializer, iterator.next())
@@ -122,7 +122,7 @@ public sealed class MapLikeSerializer<Key, Value, Collection, Builder : MutableM
 
     override fun serialize(encoder: Encoder, value: Collection) {
         val size = value.collectionSize()
-        val composite = encoder.beginCollection(descriptor, size, *typeParams)
+        val composite = encoder.beginCollection(descriptor, size)
         val iterator = value.collectionIterator()
         var index = 0
         iterator.forEach { (k, v) ->
@@ -180,7 +180,7 @@ public abstract class PrimitiveArraySerializer<Element, Array, Builder
 
     final override fun serialize(encoder: Encoder, value: Array) {
         val size = value.collectionSize()
-        val composite = encoder.beginCollection(descriptor, size, *typeParams)
+        val composite = encoder.beginCollection(descriptor, size)
         writeContent(composite, value, size)
         composite.endStructure(descriptor)
     }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
@@ -113,7 +113,7 @@ public sealed class MapLikeSerializer<Key, Value, Collection, Builder : MutableM
             index + 1
         }
         val value: Value = if (builder.containsKey(key) && valueSerializer.descriptor.kind !is PrimitiveKind) {
-            decoder.updateSerializableElement(descriptor, vIndex, valueSerializer, builder.getValue(key))
+            decoder.decodeSerializableElement(descriptor, vIndex, valueSerializer, builder.getValue(key))
         } else {
             decoder.decodeSerializableElement(descriptor, vIndex, valueSerializer)
         }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
@@ -37,10 +37,6 @@ public class NullableSerializer<T : Any>(private val serializer: KSerializer<T>)
         return if (decoder.decodeNotNullMark()) decoder.decodeSerializableValue(serializer) else decoder.decodeNull()
     }
 
-    override fun patch(decoder: Decoder, old: T?): T? {
-        return deserialize(decoder)
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
@@ -38,11 +38,7 @@ public class NullableSerializer<T : Any>(private val serializer: KSerializer<T>)
     }
 
     override fun patch(decoder: Decoder, old: T?): T? {
-        return when {
-            old == null -> deserialize(decoder)
-            decoder.decodeNotNullMark() -> decoder.updateSerializableValue(serializer, old)
-            else -> decoder.decodeNull().let { old }
-        }
+        return deserialize(decoder)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -80,6 +80,14 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
         index: Int
     ): Unit = encodeTaggedEnum(popTag(), enumDescriptor, index)
 
+    // do not update signature here because new signature is called by the plugin;
+    // and clients that have old signature would not be called.
+    @Suppress("OverridingDeprecatedMember")
+    @Deprecated(
+        "Parameter typeSerializers is deprecated for removal. Please migrate to beginStructure method with one argument.",
+        ReplaceWith("beginStructure(descriptor)"),
+        DeprecationLevel.ERROR
+    )
     override fun beginStructure(
         descriptor: SerialDescriptor,
         vararg typeSerializers: KSerializer<*>
@@ -193,7 +201,7 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder,
     protected open fun decodeTaggedNull(tag: Tag): Nothing? = null
 
     @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
-    protected open fun decodeTaggedUnit(tag: Tag): Unit = decodeTaggedValue(tag) as Unit
+    protected open fun decodeTaggedUnit(tag: Tag): Unit = UnitSerializer.deserialize(this)
     protected open fun decodeTaggedBoolean(tag: Tag): Boolean = decodeTaggedValue(tag) as Boolean
     protected open fun decodeTaggedByte(tag: Tag): Byte = decodeTaggedValue(tag) as Byte
     protected open fun decodeTaggedShort(tag: Tag): Short = decodeTaggedValue(tag) as Short
@@ -227,6 +235,14 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder,
 
     final override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = decodeTaggedEnum(popTag(), enumDescriptor)
 
+    // do not update signature here because new signature is called by the plugin;
+    // and clients that have old signature would not be called.
+    @Suppress("OverridingDeprecatedMember")
+    @Deprecated(
+        "Parameter typeSerializers is deprecated for removal. Please migrate to beginStructure method with one argument.",
+        ReplaceWith("beginStructure(descriptor)"),
+        DeprecationLevel.ERROR
+    )
     override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
         return this
     }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
@@ -25,14 +25,15 @@ public sealed class KeyValueSerializer<K, V, R>(
     protected abstract fun toResult(key: K, value: V): R
 
     override fun serialize(encoder: Encoder, value: R) {
-        val structuredEncoder = encoder.beginStructure(descriptor, keySerializer, valueSerializer)
+        val structuredEncoder = encoder.beginStructure(descriptor)
         structuredEncoder.encodeSerializableElement(descriptor, 0, keySerializer, value.key)
         structuredEncoder.encodeSerializableElement(descriptor, 1, valueSerializer, value.value)
         structuredEncoder.endStructure(descriptor)
     }
 
     override fun deserialize(decoder: Decoder): R {
-        val composite = decoder.beginStructure(descriptor, keySerializer, valueSerializer)
+        arrayOf(keySerializer, valueSerializer)
+        val composite = decoder.beginStructure(descriptor)
         if (composite.decodeSequentially()) {
             val key = composite.decodeSerializableElement(descriptor, 0, keySerializer)
             val value = composite.decodeSerializableElement(descriptor, 1, valueSerializer)
@@ -134,7 +135,7 @@ public class TripleSerializer<A, B, C>(
     }
 
     override fun serialize(encoder: Encoder, value: Triple<A, B, C>) {
-        val structuredEncoder = encoder.beginStructure(descriptor, aSerializer, bSerializer, cSerializer)
+        val structuredEncoder = encoder.beginStructure(descriptor)
         structuredEncoder.encodeSerializableElement(descriptor, 0, aSerializer, value.first)
         structuredEncoder.encodeSerializableElement(descriptor, 1, bSerializer, value.second)
         structuredEncoder.encodeSerializableElement(descriptor, 2, cSerializer, value.third)
@@ -142,7 +143,8 @@ public class TripleSerializer<A, B, C>(
     }
 
     override fun deserialize(decoder: Decoder): Triple<A, B, C> {
-        val composite = decoder.beginStructure(descriptor, aSerializer, bSerializer, cSerializer)
+        arrayOf(aSerializer, bSerializer, cSerializer)
+        val composite = decoder.beginStructure(descriptor)
         if (composite.decodeSequentially()) {
             return decodeSequentially(composite)
         }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
@@ -32,7 +32,6 @@ public sealed class KeyValueSerializer<K, V, R>(
     }
 
     override fun deserialize(decoder: Decoder): R {
-        arrayOf(keySerializer, valueSerializer)
         val composite = decoder.beginStructure(descriptor)
         if (composite.decodeSequentially()) {
             val key = composite.decodeSerializableElement(descriptor, 0, keySerializer)
@@ -143,7 +142,6 @@ public class TripleSerializer<A, B, C>(
     }
 
     override fun deserialize(decoder: Decoder): Triple<A, B, C> {
-        arrayOf(aSerializer, bSerializer, cSerializer)
         val composite = decoder.beginStructure(descriptor)
         if (composite.decodeSequentially()) {
             return decodeSequentially(composite)

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -4,8 +4,7 @@
 
 package kotlinx.serialization.json
 
-import kotlinx.serialization.UnstableDefault
-import kotlinx.serialization.UpdateMode
+import kotlinx.serialization.*
 import kotlin.jvm.*
 
 /**
@@ -56,9 +55,7 @@ public data class JsonConfiguration @UnstableDefault constructor(
     internal val unquotedPrint: Boolean = false,
     internal val indent: String = defaultIndent,
     internal val useArrayPolymorphism: Boolean = false,
-    internal val classDiscriminator: String = defaultDiscriminator,
-    @Deprecated(message = "Custom update modes are not fully supported", level = DeprecationLevel.WARNING)
-    internal val updateMode: UpdateMode = UpdateMode.OVERWRITE
+    internal val classDiscriminator: String = defaultDiscriminator
 ) {
 
     init {

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonInput.kt
@@ -79,4 +79,11 @@ public interface JsonInput : Decoder, CompositeDecoder {
      * ```
      */
     public fun decodeJson(): JsonElement
+
+    // Class 'JsonInput' must override public open val updateMode: UpdateMode defined in kotlinx.serialization.Decoder
+    // because it inherits multiple interface methods of it
+    @Suppress("DEPRECATION")
+    @Deprecated(updateModeDeprecated, level = DeprecationLevel.HIDDEN)
+    override val updateMode: UpdateMode
+        get() = UpdateMode.OVERWRITE
 }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
@@ -23,6 +23,13 @@ internal class StreamingJsonInput internal constructor(
     private var currentIndex = -1
     private val configuration = json.configuration
 
+    // must override public open val updateMode: UpdateMode defined in kotlinx.serialization.json.JsonInput
+    // because it inherits many implementations of it
+    @Suppress("DEPRECATION")
+    @Deprecated(updateModeDeprecated, level = DeprecationLevel.HIDDEN)
+    override val updateMode: UpdateMode
+        get() = UpdateMode.OVERWRITE
+
     public override fun decodeJson(): JsonElement = JsonParser(json.configuration, reader).read()
 
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonInput.kt
@@ -25,15 +25,11 @@ internal class StreamingJsonInput internal constructor(
 
     public override fun decodeJson(): JsonElement = JsonParser(json.configuration, reader).read()
 
-    @Suppress("DEPRECATION")
-    override val updateMode: UpdateMode
-        get() = configuration.updateMode
-
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
         return decodeSerializableValuePolymorphic(deserializer)
     }
 
-    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
         val newMode = json.switchMode(descriptor)
         if (newMode.begin != INVALID) {
             reader.requireTokenClass(newMode.beginTc) { "Expected '${newMode.begin}, kind: ${descriptor.kind}'" }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonOutput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonOutput.kt
@@ -57,7 +57,7 @@ internal class StreamingJsonOutput(
         encodeString(descriptor.serialName)
     }
 
-    override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
         val newMode = json.switchMode(descriptor)
         if (newMode.begin != INVALID) { // entry
             composer.print(newMode.begin)

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -36,17 +36,13 @@ private sealed class AbstractJsonTreeInput(
 
     override fun decodeJson(): JsonElement = currentObject()
 
-    @Suppress("DEPRECATION")
-    override val updateMode: UpdateMode
-        get() = configuration.updateMode
-
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
         return decodeSerializableValuePolymorphic(deserializer)
     }
 
     override fun composeName(parentName: String, childName: String): String = childName
 
-    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
         val currentObject = currentObject()
         return when (descriptor.kind) {
             StructureKind.LIST, is PolymorphicKind -> JsonTreeListInput(json, cast(currentObject))

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonInput.kt
@@ -29,6 +29,13 @@ private sealed class AbstractJsonTreeInput(
     override val context: SerialModule
         get() = json.context
 
+    // must override public final val updateMode: UpdateMode defined in kotlinx.serialization.NamedValueDecoder
+    // because it inherits many implementations of it
+    @Suppress("DEPRECATION")
+    @Deprecated(updateModeDeprecated, level = DeprecationLevel.HIDDEN)
+    override val updateMode: UpdateMode
+        get() = UpdateMode.OVERWRITE
+
     @JvmField
     protected val configuration = json.configuration
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonOutput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonOutput.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.json.internal
@@ -86,7 +86,7 @@ private sealed class AbstractJsonTreeOutput(
         putElement(tag, JsonLiteral(value.toString()))
     }
 
-    override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
         val consumer =
             if (currentTagOrNull == null) nodeConsumer
             else { node -> putElement(currentTag, node) }

--- a/runtime/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
@@ -9,16 +9,15 @@ import kotlinx.serialization.builtins.*
 import kotlin.test.*
 
 /*
- * Test ensures that type type that aggregate all basic (primitive/collection/maps/arrays)
+ * Test ensures that type that aggregate all basic (primitive/collection/maps/arrays)
  * types is properly serialized/deserialized with dummy format that supports only classes and primitives as
  * first-class citizens.
  */
 class BasicTypesSerializationTest {
 
     // KeyValue Input/Output
-
     class KeyValueOutput(private val sb: StringBuilder) : AbstractEncoder() {
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
             sb.append('{')
             return this
         }
@@ -52,7 +51,7 @@ class BasicTypesSerializationTest {
     }
 
     class KeyValueInput(private val inp: Parser) : AbstractDecoder() {
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             inp.expectAfterWhiteSpace('{')
             return this
         }

--- a/runtime/commonTest/src/kotlinx/serialization/TaggedTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/TaggedTest.kt
@@ -45,7 +45,7 @@ class TaggedTest {
     }
 
     @Test
-    @Ignore // todo: unignore after migration to 1.3.70-eap-3
+    @Ignore
     fun testTagged() {
         val collector = Collector()
         val data = DataWithId(1, "2")

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonUpdateModeTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonUpdateModeTest.kt
@@ -43,23 +43,21 @@ class JsonOverwriteTest : JsonTestBase() {
 
     @Test
     fun testCanUpdateNullableValuesInside() = parametrizedTest { useStreaming ->
-        val json = Json(JsonConfiguration.Default)
-        val a1 = json.parse(NullableInnerIntList.serializer(), """{data:[null],data:[1]}""", useStreaming)
+        val a1 = unquotedLenient.parse(NullableInnerIntList.serializer(), """{data:[null],data:[1]}""", useStreaming)
         assertEquals(NullableInnerIntList(listOf(1)), a1)
-        val a2 = json.parse(NullableInnerIntList.serializer(), """{data:[42],data:[null]}""", useStreaming)
+        val a2 = unquotedLenient.parse(NullableInnerIntList.serializer(), """{data:[42],data:[null]}""", useStreaming)
         assertEquals(NullableInnerIntList(listOf(null)), a2)
-        val a3 = json.parse(NullableInnerIntList.serializer(), """{data:[31],data:[1]}""", useStreaming)
+        val a3 = unquotedLenient.parse(NullableInnerIntList.serializer(), """{data:[31],data:[1]}""", useStreaming)
         assertEquals(NullableInnerIntList(listOf(1)), a3)
     }
 
     @Test
     fun testCanUpdateNullableValues() = parametrizedTest { useStreaming ->
-        val json = Json(JsonConfiguration.Default)
-        val a1 = json.parse(NullableUpdatable.serializer(), """{data:null,data:[{a:42}]}""", useStreaming)
+        val a1 = unquotedLenient.parse(NullableUpdatable.serializer(), """{data:null,data:[{a:42}]}""", useStreaming)
         assertEquals(NullableUpdatable(listOf(Data(42))), a1)
-        val a2 = json.parse(NullableUpdatable.serializer(), """{data:[{a:42}],data:null}""", useStreaming)
+        val a2 = unquotedLenient.parse(NullableUpdatable.serializer(), """{data:[{a:42}],data:null}""", useStreaming)
         assertEquals(NullableUpdatable(null), a2)
-        val a3 = json.parse(NullableUpdatable.serializer(), """{data:[{a:42}],data:[{a:43}]}""", useStreaming)
+        val a3 = unquotedLenient.parse(NullableUpdatable.serializer(), """{data:[{a:42}],data:[{a:43}]}""", useStreaming)
         assertEquals(NullableUpdatable(listOf(Data(43))), a3)
     }
 }

--- a/runtime/jsMain/src/kotlinx/serialization/DynamicObjectParser.kt
+++ b/runtime/jsMain/src/kotlinx/serialization/DynamicObjectParser.kt
@@ -108,7 +108,7 @@ public class DynamicObjectParser @OptIn(UnstableDefault::class) constructor(
             return o != null
         }
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             val curObj = currentTagOrNull?.let { obj[it] } ?: obj
             val kind = when (descriptor.kind) {
                 is PolymorphicKind -> {

--- a/runtime/jvmTest/src/kotlinx/serialization/SerializationMethodInvocationOrderTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/SerializationMethodInvocationOrderTest.kt
@@ -41,10 +41,14 @@ class SerializationMethodInvocationOrderTest {
     class Out : AbstractEncoder() {
         var step = 0
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
-            when(step) {
-                1 -> { checkContainerDesc(descriptor); step++; return this }
-                4 -> { checkDataDesc(descriptor); step++; return this }
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+            when (step) {
+                1 -> {
+                    checkContainerDesc(descriptor); step++; return this
+                }
+                4 -> {
+                    checkDataDesc(descriptor); step++; return this
+                }
             }
             fail("@$step: beginStructure($descriptor)")
         }
@@ -107,7 +111,7 @@ class SerializationMethodInvocationOrderTest {
     class Inp : AbstractDecoder() {
         var step = 0
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             when (step) {
                 1 -> {
                     checkContainerDesc(descriptor); step++; return this

--- a/runtime/jvmTest/src/kotlinx/serialization/SerializeFlatTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/SerializeFlatTest.kt
@@ -197,8 +197,7 @@ class SerializeFlatTest() {
         var step = 0
 
         override fun beginStructure(
-            descriptor: SerialDescriptor,
-            vararg typeSerializers: KSerializer<*>
+            descriptor: SerialDescriptor
         ): CompositeEncoder {
             checkDesc(name, descriptor)
             if (step == 0) step++ else fail("@$step: beginStructure($descriptor)")
@@ -247,7 +246,7 @@ class SerializeFlatTest() {
     class Inp(private val name: String) : AbstractDecoder() {
         var step = 0
 
-        override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             checkDesc(name, descriptor)
             if (step == 0) step++ else fail("@$step: beginStructure($descriptor)")
             return this

--- a/runtime/jvmTest/src/kotlinx/serialization/features/JsonUpdateCustomTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/JsonUpdateCustomTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.features
@@ -9,11 +9,10 @@ import kotlinx.serialization.builtins.*
 import kotlinx.serialization.json.*
 import org.junit.Ignore
 import org.junit.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 // can't be in common yet because of issue with class literal annotations
 // and .serializer() resolving
-@Ignore
 class JsonUpdateCustomTest : JsonTestBase() {
     @Serializable
     data class Data(val a: Int)
@@ -27,12 +26,12 @@ class JsonUpdateCustomTest : JsonTestBase() {
     }
 
     @Serializable
-    data class Updatable(@Serializable(with=CustomDataUpdater::class) val d: Data)
+    data class Updatable(@Serializable(with = CustomDataUpdater::class) val d: Data)
 
     @Test
     fun canUpdateCustom() {
         val parsed: Updatable = unquotedLenient.parse("""{d:{a:42},d:{a:43}}""")
-        assertEquals(Data(42 + 43), parsed.d)
+        assertEquals(Data(43), parsed.d)
     }
 
     @Serializable
@@ -49,6 +48,6 @@ class JsonUpdateCustomTest : JsonTestBase() {
     @Test
     fun canUpdateValuesInMap() {
         val parsed = json.parse(WrappedMap.serializer(Int.serializer().list), """{"mp": { "x" : [23], "x" : [42], "y": [4] }}""")
-        assertEquals(WrappedMap(mapOf("x" to listOf(23, 42), "y" to listOf(4))), parsed)
+        assertEquals(WrappedMap(mapOf("x" to listOf(42), "y" to listOf(4))), parsed)
     }
 }


### PR DESCRIPTION
* Deprecate `typeParameters` argument in beginStructure
* Deprecate `updateX` methods and `val updateMode`
* Deprecate `patch` in KSerializer 