### PR TITLE
Fix Gradle example rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }
 }
+```
 
 Then you can `apply plugin` (example in Groovy):
 


### PR DESCRIPTION
With recent version updates to README apparently the Gradle examples got a little broken.
The closing backticks were removed from one of the examples, leading to improper rendering of the remainder of the paragraph.