### PR TITLE
Proto rework

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -21,14 +21,10 @@ private const val MASK = Int.MAX_VALUE.toLong() shl 32
  * @see ProtoType
  */
 @Suppress("NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING")
-public enum class ProtoNumberType(@JvmField internal val signature: Long) {
-    DEFAULT(1L shl 32),
-    SIGNED(2L shl 32),
-    FIXED(3L shl 32);
-
-    internal fun equalTo(descriptor: ProtoDesc): Boolean {
-        return descriptor and MASK == signature
-    }
+public enum class ProtoNumberType(internal val signature: Long) {
+    DEFAULT(0L shl 32),
+    SIGNED(1L shl 32),
+    FIXED(2L shl 32);
 }
 
 /**

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -65,7 +65,7 @@ internal fun SerialDescriptor.extractParameters(index: Int): ProtoDesc {
     return ProtoDesc(protoId, format)
 }
 
-internal fun extractProtoId(descriptor: SerialDescriptor, index: Int, zeroBasedDefault: Boolean = false): Int {
+internal fun extractProtoId(descriptor: SerialDescriptor, index: Int, zeroBasedDefault: Boolean): Int {
     val annotations = descriptor.getElementAnnotations(index)
     for (i in annotations.indices) { // Allocation-friendly loop
         val annotation = annotations[i]

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf.internal
+
+import kotlinx.io.*
+import kotlinx.serialization.protobuf.*
+import kotlin.jvm.*
+
+internal class ProtobufReader(private val input: ByteArrayInput) {
+    @JvmField
+    public var currentId = -1
+    @JvmField
+    public var currentType = -1
+
+    init {
+        readTag()
+    }
+
+    private fun readTag() {
+        val header = input.readVarint64(true).toInt()
+        if (header == -1) {
+            currentId = -1
+            currentType = -1
+        } else {
+            currentId = header ushr 3
+            currentType = header and 0b111
+        }
+    }
+
+    fun skipElement() {
+        when (currentType) {
+            ProtoBuf.VARINT -> nextInt(ProtoNumberType.DEFAULT)
+            ProtoBuf.i64 -> nextLong(ProtoNumberType.FIXED)
+            ProtoBuf.SIZE_DELIMITED -> nextObject()
+            ProtoBuf.i32 -> nextInt(ProtoNumberType.FIXED)
+            else -> throw ProtobufDecodingException("Unsupported start group or end group wire type")
+        }
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun assertWireType(expected: Int) {
+        if (currentType != expected) throw ProtobufDecodingException("Expected wire type $expected, but found $currentType")
+    }
+
+    fun nextObject(): ByteArray {
+        assertWireType(ProtoBuf.SIZE_DELIMITED)
+        val length = decode32()
+        check(length >= 0)
+        val result = input.readExactNBytes(length)
+        readTag()
+        return result
+    }
+
+    fun nextObjectNoTag(): ByteArray {
+        assertWireType(ProtoBuf.SIZE_DELIMITED)
+        val length = decode32()
+        check(length >= 0)
+        return input.readExactNBytes(length)
+    }
+
+    private fun Input.readExactNBytes(bytes: Int): ByteArray {
+        val array = ByteArray(bytes)
+        var read = 0
+        while (read < bytes) {
+            val i = this.read(array, read, bytes - read)
+            if (i == -1) error("Unexpected EOF")
+            read += i
+        }
+        return array
+    }
+
+    fun nextBoolean(): Boolean = when (val i = nextInt(ProtoNumberType.DEFAULT)) {
+        0 -> false
+        1 -> true
+        else -> throw ProtobufDecodingException("Expected boolean value (0 or 1), found $i")
+    }
+
+    fun nextInt(format: ProtoNumberType): Int {
+        val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i32 else ProtoBuf.VARINT
+        assertWireType(wireType)
+        val result = decode32(format)
+        readTag()
+        return result
+    }
+
+    fun nextInt32NoTag(): Int {
+        assertWireType(ProtoBuf.i32)
+        return decode32()
+    }
+
+    fun nextLong(format: ProtoNumberType): Long {
+        val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i64 else ProtoBuf.VARINT
+        assertWireType(wireType)
+        val result = decode64(format)
+        readTag()
+        return result
+    }
+
+    fun nextLongNoTag(): Long {
+        assertWireType(ProtoBuf.i64)
+        return decode64(ProtoNumberType.DEFAULT)
+    }
+
+    fun nextFloat(): Float {
+        assertWireType(ProtoBuf.i32)
+        val result = Float.fromBits(readIntLittleEndian())
+        readTag()
+        return result
+    }
+
+    fun nextFloatNoTag(): Float {
+        assertWireType(ProtoBuf.i32)
+        return Float.fromBits(readIntLittleEndian())
+    }
+
+    private fun readIntLittleEndian(): Int {
+        // TODO this could be optimized by extracting method to the IS
+        var result = 0
+        for (i in 0..3) {
+            val byte = input.read() and 0x000000FF
+            result = result or (byte shl (i * 8))
+        }
+        return result
+    }
+
+    private fun readLongLittleEndian(): Long {
+        // TODO this could be optimized by extracting method to the IS
+        var result = 0L
+        for (i in 0..7) {
+            val byte = (input.read() and 0x000000FF).toLong()
+            result = result or (byte shl (i * 8))
+        }
+        return result
+    }
+
+    fun nextDouble(): Double {
+        assertWireType(ProtoBuf.i64)
+        val result = Double.fromBits(readLongLittleEndian())
+        readTag()
+        return result
+    }
+
+    fun nextDoubleNoTag(): Double {
+        assertWireType(ProtoBuf.i64)
+        return Double.fromBits(readLongLittleEndian())
+    }
+
+    fun nextString(): String {
+        assertWireType(ProtoBuf.SIZE_DELIMITED)
+        val length = decode32()
+        check(length >= 0)
+        val result = input.readString(length)
+        readTag()
+        return result
+    }
+
+    fun nextStringNoTag(): String {
+        assertWireType(ProtoBuf.SIZE_DELIMITED)
+        val length = decode32()
+        check(length >= 0)
+        return input.readString(length)
+    }
+
+    private fun decode32(format: ProtoNumberType = ProtoNumberType.DEFAULT): Int = when (format) {
+        ProtoNumberType.DEFAULT -> input.readVarint64(false).toInt()
+        ProtoNumberType.SIGNED -> Varint.decodeSignedVarintInt(
+            input
+        )
+        ProtoNumberType.FIXED -> readIntLittleEndian()
+    }
+
+    private fun decode64(format: ProtoNumberType = ProtoNumberType.DEFAULT): Long = when (format) {
+        ProtoNumberType.DEFAULT -> input.readVarint64(false)
+        ProtoNumberType.SIGNED -> Varint.decodeSignedVarintLong(
+            input
+        )
+        ProtoNumberType.FIXED -> readLongLittleEndian()
+    }
+}

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
@@ -33,16 +33,16 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         }
     }
 
-    public fun pushBack() {
+    public fun pushBackTag() {
         pushBack = true
     }
 
     fun skipElement() {
         when (currentType) {
-            ProtoBuf.VARINT -> nextInt(ProtoNumberType.DEFAULT)
-            ProtoBuf.i64 -> nextLong(ProtoNumberType.FIXED)
-            ProtoBuf.SIZE_DELIMITED -> nextObject()
-            ProtoBuf.i32 -> nextInt(ProtoNumberType.FIXED)
+            ProtoBuf.VARINT -> readInt(ProtoNumberType.DEFAULT)
+            ProtoBuf.i64 -> readLong(ProtoNumberType.FIXED)
+            ProtoBuf.SIZE_DELIMITED -> readObject()
+            ProtoBuf.i32 -> readInt(ProtoNumberType.FIXED)
             else -> throw ProtobufDecodingException("Unsupported start group or end group wire type")
         }
     }
@@ -52,14 +52,14 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         if (currentType != expected) throw ProtobufDecodingException("Expected wire type $expected, but found $currentType")
     }
 
-    fun nextObject(): ByteArray {
+    fun readObject(): ByteArray {
         assertWireType(ProtoBuf.SIZE_DELIMITED)
         val length = decode32()
         check(length >= 0)
         return input.readExactNBytes(length)
     }
 
-    fun nextObjectNoTag(): ByteArray {
+    fun readObjectNoTag(): ByteArray {
         val length = decode32()
         check(length >= 0)
         return input.readExactNBytes(length)
@@ -76,28 +76,28 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return array
     }
 
-    fun nextInt(format: ProtoNumberType): Int {
+    fun readInt(format: ProtoNumberType): Int {
         val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i32 else ProtoBuf.VARINT
         assertWireType(wireType)
         return decode32(format)
     }
 
-    fun nextInt32NoTag(): Int = decode32()
+    fun readInt32NoTag(): Int = decode32()
 
-    fun nextLong(format: ProtoNumberType): Long {
+    fun readLong(format: ProtoNumberType): Long {
         val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i64 else ProtoBuf.VARINT
         assertWireType(wireType)
         return decode64(format)
     }
 
-    fun nextLongNoTag(): Long = decode64(ProtoNumberType.DEFAULT)
+    fun readLongNoTag(): Long = decode64(ProtoNumberType.DEFAULT)
 
-    fun nextFloat(): Float {
+    fun readFloat(): Float {
         assertWireType(ProtoBuf.i32)
         return Float.fromBits(readIntLittleEndian())
     }
 
-    fun nextFloatNoTag(): Float = Float.fromBits(readIntLittleEndian())
+    fun readFloatNoTag(): Float = Float.fromBits(readIntLittleEndian())
 
     private fun readIntLittleEndian(): Int {
         // TODO this could be optimized by extracting method to the IS
@@ -119,23 +119,23 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return result
     }
 
-    fun nextDouble(): Double {
+    fun readDouble(): Double {
         assertWireType(ProtoBuf.i64)
         return Double.fromBits(readLongLittleEndian())
     }
 
-    fun nextDoubleNoTag(): Double {
+    fun readDoubleNoTag(): Double {
         return Double.fromBits(readLongLittleEndian())
     }
 
-    fun nextString(): String {
+    fun readString(): String {
         assertWireType(ProtoBuf.SIZE_DELIMITED)
         val length = decode32()
         check(length >= 0)
         return input.readString(length)
     }
 
-    fun nextStringNoTag(): String {
+    fun readStringNoTag(): String {
         val length = decode32()
         check(length >= 0)
         return input.readString(length)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
@@ -54,7 +54,6 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
     }
 
     fun nextObjectNoTag(): ByteArray {
-        assertWireType(ProtoBuf.SIZE_DELIMITED)
         val length = decode32()
         check(length >= 0)
         return input.readExactNBytes(length)
@@ -71,12 +70,6 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return array
     }
 
-    fun nextBoolean(): Boolean = when (val i = nextInt(ProtoNumberType.DEFAULT)) {
-        0 -> false
-        1 -> true
-        else -> throw ProtobufDecodingException("Expected boolean value (0 or 1), found $i")
-    }
-
     fun nextInt(format: ProtoNumberType): Int {
         val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i32 else ProtoBuf.VARINT
         assertWireType(wireType)
@@ -85,10 +78,7 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return result
     }
 
-    fun nextInt32NoTag(): Int {
-        assertWireType(ProtoBuf.i32)
-        return decode32()
-    }
+    fun nextInt32NoTag(): Int = decode32()
 
     fun nextLong(format: ProtoNumberType): Long {
         val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i64 else ProtoBuf.VARINT
@@ -98,10 +88,7 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return result
     }
 
-    fun nextLongNoTag(): Long {
-        assertWireType(ProtoBuf.i64)
-        return decode64(ProtoNumberType.DEFAULT)
-    }
+    fun nextLongNoTag(): Long = decode64(ProtoNumberType.DEFAULT)
 
     fun nextFloat(): Float {
         assertWireType(ProtoBuf.i32)
@@ -110,10 +97,7 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return result
     }
 
-    fun nextFloatNoTag(): Float {
-        assertWireType(ProtoBuf.i32)
-        return Float.fromBits(readIntLittleEndian())
-    }
+    fun nextFloatNoTag(): Float = Float.fromBits(readIntLittleEndian())
 
     private fun readIntLittleEndian(): Int {
         // TODO this could be optimized by extracting method to the IS
@@ -143,7 +127,6 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
     }
 
     fun nextDoubleNoTag(): Double {
-        assertWireType(ProtoBuf.i64)
         return Double.fromBits(readLongLittleEndian())
     }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedBase.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedBase.kt
@@ -15,7 +15,7 @@ import kotlin.jvm.*
  */
 internal const val MISSING_TAG = 19_500L
 
-internal abstract class TaggedBase {
+internal abstract class ProtobufTaggedBase {
     private var tagsStack = LongArray(8)
     @JvmField
     protected var stackSize = -1
@@ -26,10 +26,7 @@ internal abstract class TaggedBase {
     protected val currentTagOrDefault: ProtoDesc
         get() = if (stackSize == -1) MISSING_TAG else tagsStack[stackSize]
 
-    protected val currentTagOrNull: ProtoDesc?
-        get() = if (stackSize == -1) null else tagsStack[stackSize]
-
-    protected fun popTagOrMissing(): ProtoDesc = if (stackSize == -1) MISSING_TAG else tagsStack[stackSize--]
+    protected fun popTagOrDefault(): ProtoDesc = if (stackSize == -1) MISSING_TAG else tagsStack[stackSize--]
 
     protected fun pushTag(tag: ProtoDesc) {
         if (tag == MISSING_TAG) return // Missing tag is never added
@@ -41,11 +38,7 @@ internal abstract class TaggedBase {
     }
 
     private fun expand() {
-        val newArray = LongArray(tagsStack.size * 2) {
-            if (it < tagsStack.size) tagsStack[it]
-            else 0L
-        }
-        tagsStack = newArray
+        tagsStack = tagsStack.copyOf(tagsStack.size * 2)
     }
 
     protected fun popTag(): ProtoDesc {
@@ -56,7 +49,7 @@ internal abstract class TaggedBase {
         }
     }
 
-    protected fun <E> tagBlock(tag: ProtoDesc, block: () -> E): E {
+    protected inline fun <E> tagBlock(tag: ProtoDesc, block: () -> E): E {
         pushTag(tag)
         return block()
     }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedDecoder.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedDecoder.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf.internal
+
+import kotlinx.serialization.*
+import kotlinx.serialization.protobuf.*
+
+internal abstract class ProtobufTaggedDecoder : TaggedBase(), Decoder, CompositeDecoder {
+    override val updateMode: UpdateMode =
+        UpdateMode.UPDATE
+
+
+    protected abstract fun SerialDescriptor.getTag(index: Int): ProtoDesc
+
+    protected abstract fun decodeTaggedBoolean(tag: ProtoDesc): Boolean
+    protected abstract fun decodeTaggedByte(tag: ProtoDesc): Byte
+    protected abstract fun decodeTaggedShort(tag: ProtoDesc): Short
+    protected abstract fun decodeTaggedInt(tag: ProtoDesc): Int
+    protected abstract fun decodeTaggedLong(tag: ProtoDesc): Long
+    protected abstract fun decodeTaggedFloat(tag: ProtoDesc): Float
+    protected abstract fun decodeTaggedDouble(tag: ProtoDesc): Double
+    protected abstract fun decodeTaggedChar(tag: ProtoDesc): Char
+    protected abstract fun decodeTaggedString(tag: ProtoDesc): String
+    protected abstract fun decodeTaggedEnum(tag: ProtoDesc, enumDescription: SerialDescriptor): Int
+
+    // ---- Implementation of low-level API ----
+
+    final override fun decodeNotNullMark(): Boolean = true
+    final override fun decodeNull(): Nothing? = null
+    final override fun decodeBoolean(): Boolean = decodeTaggedBoolean(popTagOrMissing())
+    final override fun decodeByte(): Byte = decodeTaggedByte(popTagOrMissing())
+    final override fun decodeShort(): Short = decodeTaggedShort(popTagOrMissing())
+    final override fun decodeInt(): Int = decodeTaggedInt(popTagOrMissing())
+    final override fun decodeLong(): Long = decodeTaggedLong(popTagOrMissing())
+    final override fun decodeFloat(): Float = decodeTaggedFloat(popTagOrMissing())
+    final override fun decodeDouble(): Double = decodeTaggedDouble(popTagOrMissing())
+    final override fun decodeChar(): Char = decodeTaggedChar(popTagOrMissing())
+    final override fun decodeString(): String = decodeTaggedString(popTagOrMissing())
+    final override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = decodeTaggedEnum(popTagOrMissing(), enumDescriptor)
+
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        return this
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) {
+        // Nothing
+    }
+
+    final override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean =
+        decodeTaggedBoolean(descriptor.getTag(index))
+
+    final override fun decodeByteElement(descriptor: SerialDescriptor, index: Int): Byte =
+        decodeTaggedByte(descriptor.getTag(index))
+
+    final override fun decodeShortElement(descriptor: SerialDescriptor, index: Int): Short =
+        decodeTaggedShort(descriptor.getTag(index))
+
+    final override fun decodeIntElement(descriptor: SerialDescriptor, index: Int): Int =
+        decodeTaggedInt(descriptor.getTag(index))
+
+    final override fun decodeLongElement(descriptor: SerialDescriptor, index: Int): Long =
+        decodeTaggedLong(descriptor.getTag(index))
+
+    final override fun decodeFloatElement(descriptor: SerialDescriptor, index: Int): Float =
+        decodeTaggedFloat(descriptor.getTag(index))
+
+    final override fun decodeDoubleElement(descriptor: SerialDescriptor, index: Int): Double =
+        decodeTaggedDouble(descriptor.getTag(index))
+
+    final override fun decodeCharElement(descriptor: SerialDescriptor, index: Int): Char =
+        decodeTaggedChar(descriptor.getTag(index))
+
+    final override fun decodeStringElement(descriptor: SerialDescriptor, index: Int): String =
+        decodeTaggedString(descriptor.getTag(index))
+
+    final override fun <T : Any?> decodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T>
+    ): T = // TODO inline
+        tagBlock(descriptor.getTag(index)) { decodeSerializableValue(deserializer) }
+
+    final override fun <T : Any> decodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T?>
+    ): T? =
+        tagBlock(descriptor.getTag(index)) { decodeNullableSerializableValue(deserializer) }
+
+    override fun <T> updateSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T>,
+        old: T
+    ): T = tagBlock(descriptor.getTag(index)) { updateSerializableValue(deserializer, old) }
+
+    override fun <T : Any> updateNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T?>,
+        old: T?
+    ): T? =
+        tagBlock(descriptor.getTag(index)) { updateNullableSerializableValue(deserializer, old) }
+
+    override fun decodeUnit() {
+        error("Should not be called")
+    }
+
+    override fun decodeUnitElement(descriptor: SerialDescriptor, index: Int) {
+        error("Should not be called")
+    }
+}

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
 
 
-internal abstract class ProtobufTaggedEncoder : TaggedBase(), Encoder, CompositeEncoder {
+internal abstract class ProtobufTaggedEncoder : ProtobufTaggedBase(), Encoder, CompositeEncoder {
 
     protected abstract fun SerialDescriptor.getTag(index: Int): ProtoDesc
 
@@ -27,45 +27,45 @@ internal abstract class ProtobufTaggedEncoder : TaggedBase(), Encoder, Composite
     public final override fun encodeNull(): Unit = encodeTaggedNull()
 
     public final override fun encodeBoolean(value: Boolean) {
-        encodeTaggedBoolean(popTagOrMissing(), value)
+        encodeTaggedBoolean(popTagOrDefault(), value)
     }
 
     public final override fun encodeByte(value: Byte) {
-        encodeTaggedByte(popTagOrMissing(), value)
+        encodeTaggedByte(popTagOrDefault(), value)
     }
 
     public final override fun encodeShort(value: Short) {
-        encodeTaggedShort(popTagOrMissing(), value)
+        encodeTaggedShort(popTagOrDefault(), value)
     }
 
     public final override fun encodeInt(value: Int) {
-        encodeTaggedInt(popTagOrMissing(), value)
+        encodeTaggedInt(popTagOrDefault(), value)
     }
 
     public final override fun encodeLong(value: Long) {
-        encodeTaggedLong(popTagOrMissing(), value)
+        encodeTaggedLong(popTagOrDefault(), value)
     }
 
     public final override fun encodeFloat(value: Float) {
-        encodeTaggedFloat(popTagOrMissing(), value)
+        encodeTaggedFloat(popTagOrDefault(), value)
     }
 
     public final override fun encodeDouble(value: Double) {
-        encodeTaggedDouble(popTagOrMissing(), value)
+        encodeTaggedDouble(popTagOrDefault(), value)
     }
 
     public final override fun encodeChar(value: Char) {
-        encodeTaggedChar(popTagOrMissing(), value)
+        encodeTaggedChar(popTagOrDefault(), value)
     }
 
     public final override fun encodeString(value: String) {
-        encodeTaggedString(popTagOrMissing(), value)
+        encodeTaggedString(popTagOrDefault(), value)
     }
 
     public final override fun encodeEnum(
         enumDescriptor: SerialDescriptor,
         index: Int
-    ): Unit = encodeTaggedEnum(popTagOrMissing(), enumDescriptor, index)
+    ): Unit = encodeTaggedEnum(popTagOrDefault(), enumDescriptor, index)
 
     public override fun beginStructure(
         descriptor: SerialDescriptor,

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf.internal
+
+import kotlinx.serialization.*
+import kotlinx.serialization.protobuf.*
+
+
+internal abstract class ProtobufTaggedEncoder : TaggedBase(), Encoder, CompositeEncoder {
+
+    protected abstract fun SerialDescriptor.getTag(index: Int): ProtoDesc
+
+    protected fun encodeTaggedNull(): Unit = throw SerializationException("null is not supported") // TODO investigate null support separately
+    protected abstract fun encodeTaggedInt(tag: ProtoDesc, value: Int)
+    protected abstract fun encodeTaggedByte(tag: ProtoDesc, value: Byte)
+    protected abstract fun encodeTaggedShort(tag: ProtoDesc, value: Short)
+    protected abstract fun encodeTaggedLong(tag: ProtoDesc, value: Long)
+    protected abstract fun encodeTaggedFloat(tag: ProtoDesc, value: Float)
+    protected abstract fun encodeTaggedDouble(tag: ProtoDesc, value: Double)
+    protected abstract fun encodeTaggedBoolean(tag: ProtoDesc, value: Boolean)
+    protected abstract fun encodeTaggedChar(tag: ProtoDesc, value: Char)
+    protected abstract fun encodeTaggedString(tag: ProtoDesc, value: String)
+    protected abstract fun encodeTaggedEnum(tag: ProtoDesc, enumDescription: SerialDescriptor, ordinal: Int)
+    public final override fun encodeNotNullMark() {}
+    public final override fun encodeNull(): Unit = encodeTaggedNull()
+
+    public final override fun encodeBoolean(value: Boolean) {
+        encodeTaggedBoolean(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeByte(value: Byte) {
+        encodeTaggedByte(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeShort(value: Short) {
+        encodeTaggedShort(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeInt(value: Int) {
+        encodeTaggedInt(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeLong(value: Long) {
+        encodeTaggedLong(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeFloat(value: Float) {
+        encodeTaggedFloat(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeDouble(value: Double) {
+        encodeTaggedDouble(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeChar(value: Char) {
+        encodeTaggedChar(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeString(value: String) {
+        encodeTaggedString(popTagOrMissing(), value)
+    }
+
+    public final override fun encodeEnum(
+        enumDescriptor: SerialDescriptor,
+        index: Int
+    ): Unit = encodeTaggedEnum(popTagOrMissing(), enumDescriptor, index)
+
+    public override fun beginStructure(
+        descriptor: SerialDescriptor,
+        vararg typeSerializers: KSerializer<*>
+    ): CompositeEncoder {
+        return this
+    }
+
+    public final override fun endStructure(descriptor: SerialDescriptor) {
+        if (stackSize >= 0) {
+            popTag()
+        }
+        endEncode(descriptor)
+    }
+
+    protected open fun endEncode(descriptor: SerialDescriptor) {}
+
+    public final override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean): Unit =
+        encodeTaggedBoolean(descriptor.getTag(index), value)
+
+    public final override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte): Unit =
+        encodeTaggedByte(descriptor.getTag(index), value)
+
+    public final override fun encodeShortElement(descriptor: SerialDescriptor, index: Int, value: Short): Unit =
+        encodeTaggedShort(descriptor.getTag(index), value)
+
+    public final override fun encodeIntElement(descriptor: SerialDescriptor, index: Int, value: Int): Unit =
+        encodeTaggedInt(descriptor.getTag(index), value)
+
+    public final override fun encodeLongElement(descriptor: SerialDescriptor, index: Int, value: Long): Unit =
+        encodeTaggedLong(descriptor.getTag(index), value)
+
+    public final override fun encodeFloatElement(descriptor: SerialDescriptor, index: Int, value: Float): Unit =
+        encodeTaggedFloat(descriptor.getTag(index), value)
+
+    public final override fun encodeDoubleElement(descriptor: SerialDescriptor, index: Int, value: Double): Unit =
+        encodeTaggedDouble(descriptor.getTag(index), value)
+
+    public final override fun encodeCharElement(descriptor: SerialDescriptor, index: Int, value: Char): Unit =
+        encodeTaggedChar(descriptor.getTag(index), value)
+
+    public final override fun encodeStringElement(descriptor: SerialDescriptor, index: Int, value: String): Unit =
+        encodeTaggedString(descriptor.getTag(index), value)
+
+    public final override fun <T : Any?> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T
+    ) {
+        pushTag(descriptor.getTag(index))
+        encodeSerializableValue(serializer, value)
+    }
+
+    public final override fun <T : Any> encodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T?
+    ) {
+        pushTag(descriptor.getTag(index))
+        encodeNullableSerializableValue(serializer, value)
+    }
+
+    override fun encodeUnit() {
+        error("Should not be called")
+    }
+
+    override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int) {
+        error("Should not be called")
+    }
+}

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufWriter.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufWriter.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf.internal
+
+import kotlinx.io.*
+import kotlinx.serialization.protobuf.*
+import kotlin.jvm.*
+
+internal class ProtobufWriter(@JvmField val out: ByteArrayOutput) {
+    fun writeBytes(bytes: ByteArray, tag: Int) {
+        out.encode32((tag shl 3) or ProtoBuf.SIZE_DELIMITED)
+        out.encode32(bytes.size)
+        out.write(bytes)
+    }
+
+    fun writeBytes(bytes: ByteArray) {
+        out.encode32(bytes.size)
+        out.write(bytes)
+    }
+
+    fun writeInt(value: Int, tag: Int, format: ProtoNumberType) {
+        val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i32 else ProtoBuf.VARINT
+        out.encode32((tag shl 3) or wireType)
+        out.encode32(value, format)
+    }
+
+    fun writeInt(value: Int) {
+        out.encode32(value)
+    }
+
+    fun writeLong(value: Long, tag: Int, format: ProtoNumberType) {
+        val wireType = if (format == ProtoNumberType.FIXED) ProtoBuf.i64 else ProtoBuf.VARINT
+        out.encode32((tag shl 3) or wireType)
+        out.encode64(value, format)
+    }
+
+    fun writeLong(value: Long) {
+        out.encode64(value)
+    }
+
+    fun writeString(value: String, tag: Int) {
+        val bytes = value.encodeToByteArray()
+        writeBytes(bytes, tag)
+    }
+
+    fun writeString(value: String) {
+        val bytes = value.encodeToByteArray()
+        writeBytes(bytes)
+    }
+
+    fun writeDouble(value: Double, tag: Int) {
+        out.encode32((tag shl 3) or ProtoBuf.i64)
+        out.writeLong(value.reverseBytes())
+    }
+
+    fun writeDouble(value: Double) {
+        out.writeLong(value.reverseBytes())
+    }
+
+    fun writeFloat(value: Float, tag: Int) {
+        out.encode32((tag shl 3) or ProtoBuf.i32)
+        out.writeInt(value.reverseBytes())
+    }
+
+    fun writeFloat(value: Float) {
+        out.writeInt(value.reverseBytes())
+    }
+
+    private fun Output.encode32(
+        number: Int,
+        format: ProtoNumberType = ProtoNumberType.DEFAULT
+    ) {
+        when (format) {
+            ProtoNumberType.FIXED -> out.writeInt(number.reverseBytes())
+            ProtoNumberType.DEFAULT -> encodeVarint64(number.toLong())
+            ProtoNumberType.SIGNED -> encodeVarint32(((number shl 1) xor (number shr 31)))
+        }
+    }
+
+    private fun Output.encode64(number: Long, format: ProtoNumberType = ProtoNumberType.DEFAULT) {
+        when (format) {
+            ProtoNumberType.FIXED -> out.writeLong(number.reverseBytes())
+            ProtoNumberType.DEFAULT -> encodeVarint64(number)
+            ProtoNumberType.SIGNED -> encodeVarint64((number shl 1) xor (number shr 63))
+        }
+    }
+
+    private fun Float.reverseBytes(): Int = toRawBits().reverseBytes()
+
+    private fun Double.reverseBytes(): Long = toRawBits().reverseBytes()
+}

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/TaggedBase.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/TaggedBase.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf.internal
+
+import kotlinx.serialization.*
+import kotlinx.serialization.protobuf.*
+import kotlin.jvm.*
+
+/*
+ * In ProtoBuf spec, ids from 19000 to 19999 are reserved for protocol use,
+ * thus we are leveraging it here and use 19_500 as a marker no one us allowed to use.
+ * It does not leak to the resulting output.
+ */
+internal const val MISSING_TAG = 19_500L
+
+internal abstract class TaggedBase {
+    private var tagsStack = LongArray(8)
+    @JvmField
+    protected var stackSize = -1
+
+    protected val currentTag: ProtoDesc
+        get() = tagsStack[stackSize]
+
+    protected val currentTagOrDefault: ProtoDesc
+        get() = if (stackSize == -1) MISSING_TAG else tagsStack[stackSize]
+
+    protected val currentTagOrNull: ProtoDesc?
+        get() = if (stackSize == -1) null else tagsStack[stackSize]
+
+    protected fun popTagOrMissing(): ProtoDesc = if (stackSize == -1) MISSING_TAG else tagsStack[stackSize--]
+
+    protected fun pushTag(tag: ProtoDesc) {
+        if (tag == MISSING_TAG) return // Missing tag is never added
+        val idx = ++stackSize
+        if (stackSize >= tagsStack.size) {
+            expand()
+        }
+        tagsStack[idx] = tag
+    }
+
+    private fun expand() {
+        val newArray = LongArray(tagsStack.size * 2) {
+            if (it < tagsStack.size) tagsStack[it]
+            else 0L
+        }
+        tagsStack = newArray
+    }
+
+    protected fun popTag(): ProtoDesc {
+        return if (stackSize >= 0) {
+            tagsStack[stackSize--]
+        } else {
+            throw SerializationException("No tag in stack for requested element")
+        }
+    }
+
+    protected fun <E> tagBlock(tag: ProtoDesc, block: () -> E): E {
+        pushTag(tag)
+        return block()
+    }
+}

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Varint.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Varint.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf.internal
+
+import kotlinx.io.*
+import kotlin.jvm.*
+
+/**
+ *  Source for all varint operations:
+ *  https://github.com/addthis/stream-lib/blob/master/src/main/java/com/clearspring/analytics/util/Varint.java
+ */
+internal object Varint {
+    @JvmStatic
+    internal fun decodeSignedVarintInt(input: Input): Int {
+        val raw = input.readVarint32()
+        val temp = raw shl 31 shr 31 xor raw shr 1
+        // This extra step lets us deal with the largest signed values by treating
+        // negative results from read unsigned methods as like unsigned values.
+        // Must re-flip the top bit if the original read value had it set.
+        return temp xor (raw and (1 shl 31))
+    }
+
+    @JvmStatic
+    internal fun decodeSignedVarintLong(input: Input): Long {
+        val raw = input.readVarint64(false)
+        val temp = raw shl 63 shr 63 xor raw shr 1
+        // This extra step lets us deal with the largest signed values by treating
+        // negative results from read unsigned methods as like unsigned values
+        // Must re-flip the top bit if the original read value had it set.
+        return temp xor (raw and (1L shl 63))
+
+    }
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/TestUtils.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/TestUtils.kt
@@ -6,7 +6,7 @@ package kotlinx.serialization
 
 import kotlin.test.*
 
-internal inline fun <reified T : Any> assertSerializedToBinaryAndRestored(
+internal inline fun <reified T> assertSerializedToBinaryAndRestored(
     original: T,
     serializer: KSerializer<T>,
     format: BinaryFormat,

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufMissingFieldsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufMissingFieldsTest.kt
@@ -13,7 +13,7 @@ class ProtobufMissingFieldsTest {
     private val buffer = byteArrayOf(10, 30, 8, 11, 16, 2, 26, 3, 115, 112, 97, 26, 6, 115, 112, 97, 95, 101, 115, 26, 2, 101, 115, 26, 5, 101, 115, 95, 101, 115, 32, 1, 16, 25)
 
     @Test
-    fun deserialize() {
+    fun testDeserializeAllFields() {
         val items = ProtoBuf.load(Items.serializer(), buffer)
         assertEquals(25, items.pageSize)
         assertFalse(items.nextPage)
@@ -25,7 +25,7 @@ class ProtobufMissingFieldsTest {
     }
 
     @Test
-    fun deserializeWithoutFields() {
+    fun testDeserializeSomeTagsAreNotInSchema() {
         val items = ProtoBuf.load(ItemsWithoutPageSize.serializer(), buffer)
         assertFalse(items.nextPage)
         assertEquals(1, items.items.size)
@@ -33,109 +33,108 @@ class ProtobufMissingFieldsTest {
         assertEquals(listOf("spa", "spa_es", "es", "es_es"), items.items[0].language)
         assertEquals(ItemContext.Context1, items.items[0].context)
     }
-}
 
+    enum class ItemPlatform {
+        Unknown,
+        iOS,
+        Android
+    }
 
-enum class ItemPlatform {
-    Unknown,
-    iOS,
-    Android
-}
+    enum class ItemContext {
+        Unknown,
+        Context1,
+        Context2
+    }
 
-enum class ItemContext {
-    Unknown,
-    Context1,
-    Context2
-}
+    @Serializable
+    data class Items(
+        @ProtoId(1)
+        val items: List<Item> = emptyList(),
+        @ProtoId(2)
+        val pageSize: Int? = null,
+        @ProtoId(3)
+        val nextPage: Boolean = false
+    )
 
-@Serializable
-data class Items(
-    @ProtoId(1)
-    val items: List<Item> = emptyList(),
-    @ProtoId(2)
-    val pageSize: Int? = null,
-    @ProtoId(3)
-    val nextPage: Boolean = false
-)
+    @Serializable
+    data class Item(
+        @ProtoId(1)
+        val id: Int,
+        @ProtoId(2) @Serializable(with = ItemPlatformSerializer::class)
+        val platform: ItemPlatform = ItemPlatform.Unknown,
+        @ProtoId(3)
+        val language: List<String> = emptyList(),
+        @ProtoId(4) @Serializable(with = ItemContextSerializer::class)
+        val context: ItemContext = ItemContext.Unknown
+    )
 
-@Serializable
-data class Item(
-    @ProtoId(1)
-    val id: Int,
-    @ProtoId(2) @Serializable(with = ItemPlatformSerializer::class)
-    val platform: ItemPlatform = ItemPlatform.Unknown,
-    @ProtoId(3)
-    val language: List<String> = emptyList(),
-    @ProtoId(4) @Serializable(with = ItemContextSerializer::class)
-    val context: ItemContext = ItemContext.Unknown
-)
+    @Serializable
+    data class ItemsWithoutPageSize(
+        @ProtoId(1)
+        val items: List<ItemWithoutPlatform> = emptyList(),
+        @ProtoId(3)
+        val nextPage: Boolean = false
+    )
 
-@Serializable
-data class ItemsWithoutPageSize(
-    @ProtoId(1)
-    val items: List<ItemWithoutPlatform> = emptyList(),
-    @ProtoId(3)
-    val nextPage: Boolean = false
-)
+    @Serializable
+    data class ItemWithoutPlatform(
+        @ProtoId(1)
+        val id: Int,
+        @ProtoId(3)
+        val language: List<String> = emptyList(),
+        @ProtoId(4) @Serializable(with = ItemContextSerializer::class)
+        val context: ItemContext = ItemContext.Unknown
+    )
 
-@Serializable
-data class ItemWithoutPlatform(
-    @ProtoId(1)
-    val id: Int,
-    @ProtoId(3)
-    val language: List<String> = emptyList(),
-    @ProtoId(4) @Serializable(with = ItemContextSerializer::class)
-    val context: ItemContext = ItemContext.Unknown
-)
+    class ItemPlatformSerializer : KSerializer<ItemPlatform> {
 
-class ItemPlatformSerializer : KSerializer<ItemPlatform> {
+        override val descriptor: SerialDescriptor = SerialDescriptor("ItemPlatform", UnionKind.ENUM_KIND) {
+            enumValues<ItemPlatform>().forEach {
+                element(it.name, SerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
+            }
+        }
 
-    override val descriptor: SerialDescriptor = SerialDescriptor("ItemPlatform", UnionKind.ENUM_KIND) {
-        enumValues<ItemPlatform>().forEach {
-            element(it.name, SerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
+        override fun deserialize(decoder: Decoder): ItemPlatform {
+            if (decoder is JsonInput) {
+                val str = decoder.decodeString()
+                return ItemPlatform.valueOf(str)
+            }
+            val index = decoder.decodeInt()
+            return ItemPlatform.values()[index]
+        }
+
+        override fun serialize(encoder: Encoder, value: ItemPlatform) {
+            if (encoder is JsonOutput) {
+                encoder.encodeString(value.name.toLowerCase())
+            } else {
+                encoder.encodeInt(value.ordinal)
+            }
         }
     }
 
-    override fun deserialize(decoder: Decoder): ItemPlatform {
-        if (decoder is JsonInput) {
-            val str = decoder.decodeString()
-            return ItemPlatform.valueOf(str)
+    class ItemContextSerializer : KSerializer<ItemContext> {
+
+        override val descriptor: SerialDescriptor = SerialDescriptor("ItemContext", UnionKind.ENUM_KIND) {
+            enumValues<ItemContext>().forEach {
+                element(it.name, SerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
+            }
         }
-        val index = decoder.decodeInt()
-        return ItemPlatform.values()[index]
-    }
 
-    override fun serialize(encoder: Encoder, value: ItemPlatform) {
-        if (encoder is JsonOutput) {
-            encoder.encodeString(value.name.toLowerCase())
-        } else {
-            encoder.encodeInt(value.ordinal)
+        override fun deserialize(decoder: Decoder): ItemContext {
+            if (decoder is JsonInput) {
+                val str = decoder.decodeString()
+                return ItemContext.valueOf(str)
+            }
+            val index = decoder.decodeInt()
+            return ItemContext.values()[index]
         }
-    }
-}
 
-class ItemContextSerializer : KSerializer<ItemContext> {
-
-    override val descriptor: SerialDescriptor = SerialDescriptor("ItemContext", UnionKind.ENUM_KIND) {
-        enumValues<ItemContext>().forEach {
-            element(it.name, SerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
-        }
-    }
-
-    override fun deserialize(decoder: Decoder): ItemContext {
-        if (decoder is JsonInput) {
-            val str = decoder.decodeString()
-            return ItemContext.valueOf(str)
-        }
-        val index = decoder.decodeInt()
-        return ItemContext.values()[index]
-    }
-
-    override fun serialize(encoder: Encoder, value: ItemContext) {
-        if (encoder is JsonOutput) {
-            encoder.encodeString(value.name.toLowerCase())
-        } else {
-            encoder.encodeInt(value.ordinal)
+        override fun serialize(encoder: Encoder, value: ItemContext) {
+            if (encoder is JsonOutput) {
+                encoder.encodeString(value.name.toLowerCase())
+            } else {
+                encoder.encodeInt(value.ordinal)
+            }
         }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufPrimitiveWrappersTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufPrimitiveWrappersTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package kotlinx.serialization.protobuf
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+/*
+ * TODO improve these tests:
+ *  * All primitive types
+ *  * All nullable types
+ *  * Built-in types (TBD)
+ *  * Primitives nullability
+ */
+class ProtobufPrimitiveWrappersTest {
+
+    private fun <T> testConversion(data: T, serializer: KSerializer<T>, expectedHexString: String) {
+        val string = ProtoBuf.dumps(serializer, data).toUpperCase()
+        assertEquals(expectedHexString, string)
+        assertEquals(data, ProtoBuf.loads(serializer, string))
+    }
+
+    @Test
+    fun testSignedInteger() {
+        testConversion(TestInt(-150), TestInt.serializer(), "08AB02")
+    }
+
+    @Test
+    fun testIntList() {
+        testConversion(TestList(listOf(1, 2, 3)), TestList.serializer(), "080108020803")
+    }
+
+    @Test
+    fun testString() {
+        testConversion(TestString("testing"), TestString.serializer(), "120774657374696E67")
+    }
+
+    @Test
+    fun testTwiceNested() {
+        testConversion(TestInner(TestInt(-150)), TestInner.serializer(), "1A0308AB02")
+    }
+
+    @Test
+    fun testMixedTags() {
+        testConversion(TestComplex(42, "testing"), TestComplex.serializer(), "D0022A120774657374696E67")
+    }
+
+    @Test
+    fun testDefaultPrimitiveValues() {
+        testConversion(TestInt(0), TestInt.serializer(), "0800")
+        testConversion(TestList(listOf()), TestList.serializer(), "")
+        testConversion(TestString(""), TestString.serializer(), "1200")
+    }
+
+    @Test
+    fun testFixedIntWithLong() {
+        testConversion(TestNumbers(100500, Long.MAX_VALUE), TestNumbers.serializer(), "0D9488010010FFFFFFFFFFFFFFFF7F")
+    }
+
+
+    @Serializable
+    class Foo(val l: List<Int> = emptyList(), val i: Int? = null,  val nextPage: Boolean = false)
+
+    @Test
+    fun foo() {
+        testConversion(TestList(listOf(1)), TestList.serializer(), "0801")
+
+    }
+
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufPrimitiveWrappersTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufPrimitiveWrappersTest.kt
@@ -15,57 +15,58 @@ import kotlin.test.*
  */
 class ProtobufPrimitiveWrappersTest {
 
-    private fun <T> testConversion(data: T, serializer: KSerializer<T>, expectedHexString: String) {
-        val string = ProtoBuf.dumps(serializer, data).toUpperCase()
-        assertEquals(expectedHexString, string)
-        assertEquals(data, ProtoBuf.loads(serializer, string))
-    }
-
     @Test
     fun testSignedInteger() {
-        testConversion(TestInt(-150), TestInt.serializer(), "08AB02")
+        assertSerializedToBinaryAndRestored(TestInt(-150), TestInt.serializer(), ProtoBuf, hexResultToCheck = "08AB02")
     }
 
     @Test
     fun testIntList() {
-        testConversion(TestList(listOf(1, 2, 3)), TestList.serializer(), "080108020803")
+        assertSerializedToBinaryAndRestored(
+            TestList(listOf(1, 2, 3)),
+            TestList.serializer(), ProtoBuf, hexResultToCheck = "080108020803"
+        )
     }
 
     @Test
     fun testString() {
-        testConversion(TestString("testing"), TestString.serializer(), "120774657374696E67")
+        assertSerializedToBinaryAndRestored(
+            TestString("testing"),
+            TestString.serializer(), ProtoBuf, hexResultToCheck = "120774657374696E67"
+        )
     }
 
     @Test
     fun testTwiceNested() {
-        testConversion(TestInner(TestInt(-150)), TestInner.serializer(), "1A0308AB02")
+        assertSerializedToBinaryAndRestored(
+            TestInner(TestInt(-150)),
+            TestInner.serializer(), ProtoBuf, hexResultToCheck = "1A0308AB02"
+        )
     }
 
     @Test
     fun testMixedTags() {
-        testConversion(TestComplex(42, "testing"), TestComplex.serializer(), "D0022A120774657374696E67")
+        assertSerializedToBinaryAndRestored(
+            TestComplex(42, "testing"),
+            TestComplex.serializer(), ProtoBuf, hexResultToCheck = "D0022A120774657374696E67"
+        )
     }
 
     @Test
     fun testDefaultPrimitiveValues() {
-        testConversion(TestInt(0), TestInt.serializer(), "0800")
-        testConversion(TestList(listOf()), TestList.serializer(), "")
-        testConversion(TestString(""), TestString.serializer(), "1200")
+        assertSerializedToBinaryAndRestored(TestInt(0), TestInt.serializer(), ProtoBuf, hexResultToCheck = "0800")
+        assertSerializedToBinaryAndRestored(TestList(listOf()), TestList.serializer(), ProtoBuf, hexResultToCheck = "")
+        assertSerializedToBinaryAndRestored(
+            TestString(""),
+            TestString.serializer(), ProtoBuf, hexResultToCheck = "1200"
+        )
     }
 
     @Test
     fun testFixedIntWithLong() {
-        testConversion(TestNumbers(100500, Long.MAX_VALUE), TestNumbers.serializer(), "0D9488010010FFFFFFFFFFFFFFFF7F")
+        assertSerializedToBinaryAndRestored(
+            TestNumbers(100500, Long.MAX_VALUE),
+            TestNumbers.serializer(), ProtoBuf, hexResultToCheck = "0D9488010010FFFFFFFFFFFFFFFF7F"
+        )
     }
-
-
-    @Serializable
-    class Foo(val l: List<Int> = emptyList(), val i: Int? = null,  val nextPage: Boolean = false)
-
-    @Test
-    fun foo() {
-        testConversion(TestList(listOf(1)), TestList.serializer(), "0801")
-
-    }
-
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufPrimitivesTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufPrimitivesTest.kt
@@ -4,15 +4,10 @@
 package kotlinx.serialization.protobuf
 
 import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.serializer
 import kotlin.test.*
 
-/*
- * TODO improve these tests:
- *  * All primitive types
- *  * All nullable types
- *  * Built-in types (TBD)
- *  * Primitives nullability
- */
 class ProtobufPrimitivesTest {
 
     private fun <T> testConversion(data: T, serializer: KSerializer<T>, expectedHexString: String) {
@@ -22,40 +17,16 @@ class ProtobufPrimitivesTest {
     }
 
     @Test
-    fun testSignedInteger() {
-        testConversion(TestInt(-150), TestInt.serializer(), "08AB02")
-    }
-
-    @Test
-    fun testIntList() {
-        testConversion(TestList(listOf(150, 228, 1337)), TestList.serializer(), "08960108E40108B90A")
-
-    }
-
-    @Test
-    fun testString() {
-        testConversion(TestString("testing"), TestString.serializer(), "120774657374696E67")
-    }
-
-    @Test
-    fun testTwiceNested() {
-        testConversion(TestInner(TestInt(-150)), TestInner.serializer(), "1A0308AB02")
-    }
-
-    @Test
-    fun testMixedTags() {
-        testConversion(TestComplex(42, "testing"), TestComplex.serializer(), "D0022A120774657374696E67")
-    }
-
-    @Test
-    fun testDefaultPrimitiveValues() {
-        testConversion(TestInt(0), TestInt.serializer(), "0800")
-        testConversion(TestList(listOf()), TestList.serializer(), "")
-        testConversion(TestString(""), TestString.serializer(), "1200")
-    }
-
-    @Test
-    fun testFixedIntWithLong() {
-        testConversion(TestNumbers(100500, Long.MAX_VALUE), TestNumbers.serializer(), "0D9488010010FFFFFFFFFFFFFFFF7F")
+    fun testPrimitiveTypes() {
+        testConversion(true, Boolean.serializer(), "01")
+        testConversion('c', Char.serializer(), "63")
+        testConversion(1, Byte.serializer(), "01")
+        testConversion(1, Short.serializer(), "01")
+        testConversion(1, Int.serializer(), "01")
+        testConversion(1, Long.serializer(), "01")
+        testConversion(1f, Float.serializer(), "0000803F")
+        testConversion(1.0, Double.serializer(), "000000000000F03F")
+        testConversion("string", String.serializer(), "06737472696E67")
+        testConversion(Unit, UnitSerializer(), "")
     }
 }

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtobufTopLevelPrimitivesCompatibilityTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtobufTopLevelPrimitivesCompatibilityTest.kt
@@ -19,64 +19,64 @@ class ProtobufTopLevelPrimitivesCompatibilityTest {
 
     @Test
     fun testPrimitivesCompatibility() {
-        testConversion(true, Boolean.serializer(), "01") { writeBoolNoTag(it) }
-        testConversion('c', Char.serializer(), "63") { writeInt32NoTag(it.toInt()) }
-        testConversion(1, Byte.serializer(), "01") { writeInt32NoTag(it.toInt()) }
-        testConversion(1, Short.serializer(), "01") { writeInt32NoTag(it.toInt()) }
-        testConversion(1, Int.serializer(), "01") { writeInt32NoTag(it) }
-        testConversion(1, Long.serializer(), "01") { writeInt64NoTag(it) }
-        testConversion(1f, Float.serializer(), "0000803F") { writeFloatNoTag(it) }
-        testConversion(1.0, Double.serializer(), "000000000000F03F") { writeDoubleNoTag(it) }
-        testConversion("string", String.serializer(), "06737472696E67") { writeStringNoTag(it) }
+        testCompatibility(true, Boolean.serializer(), "01") { writeBoolNoTag(it) }
+        testCompatibility('c', Char.serializer(), "63") { writeInt32NoTag(it.toInt()) }
+        testCompatibility(1, Byte.serializer(), "01") { writeInt32NoTag(it.toInt()) }
+        testCompatibility(1, Short.serializer(), "01") { writeInt32NoTag(it.toInt()) }
+        testCompatibility(1, Int.serializer(), "01") { writeInt32NoTag(it) }
+        testCompatibility(1, Long.serializer(), "01") { writeInt64NoTag(it) }
+        testCompatibility(1f, Float.serializer(), "0000803F") { writeFloatNoTag(it) }
+        testCompatibility(1.0, Double.serializer(), "000000000000F03F") { writeDoubleNoTag(it) }
+        testCompatibility("string", String.serializer(), "06737472696E67") { writeStringNoTag(it) }
     }
 
     @Test
     fun testArraysCompatibility() {
-        testConversion(byteArrayOf(1, 2, 3), ByteArraySerializer(), "03010203") { writeByteArrayNoTag(it) }
-        testConversion(byteArrayOf(), ByteArraySerializer(), "00") { writeByteArrayNoTag(it) }
-        testConversion(intArrayOf(1, 2, 3), IntArraySerializer(), "03010203") {
+        testCompatibility(byteArrayOf(1, 2, 3), ByteArraySerializer(), "03010203") { writeByteArrayNoTag(it) }
+        testCompatibility(byteArrayOf(), ByteArraySerializer(), "00") { writeByteArrayNoTag(it) }
+        testCompatibility(intArrayOf(1, 2, 3), IntArraySerializer(), "03010203") {
             writeUInt32NoTag(it.size)
             for (i in it) writeInt32NoTag(i)
         }
 
-        testConversion(arrayOf(Box(2)), serializer(), "010802") {
+        testCompatibility(arrayOf(Box(2)), serializer(), "010802") {
             writeUInt32NoTag(it.size)
             for (box in it) writeInt32(1, box.i)
         }
 
-        testConversion(arrayOf<Box>(), serializer(), "00") {
+        testCompatibility(arrayOf<Box>(), serializer(), "00") {
             writeUInt32NoTag(it.size)
         }
     }
 
     @Test
     fun testListsCompatibility() {
-        testConversion(listOf(1, 2, 3), serializer(), "03010203") {
+        testCompatibility(listOf(1, 2, 3), serializer(), "03010203") {
             writeUInt32NoTag(it.size)
             for (i in it) writeInt32NoTag(i)
         }
-        testConversion(listOf(Box(2)), serializer(), "010802") {
+        testCompatibility(listOf(Box(2)), serializer(), "010802") {
             writeUInt32NoTag(it.size)
             for (box in it) writeInt32(1, box.i)
         }
 
-        testConversion(listOf<Int>(), serializer(), "00") {
+        testCompatibility(listOf<Int>(), serializer(), "00") {
             writeUInt32NoTag(it.size)
         }
     }
 
     @Test
     fun testMapsCompatibility() {
-        testConversion(mapOf(1 to 2, 3 to 4), serializer(), "0204080110020408031004") {
+        testCompatibility(mapOf(1 to 2, 3 to 4), serializer(), "0204080110020408031004") {
             writeUInt32NoTag(it.size)
             for (pair in it) {
-                writeInt32NoTag(4)
+                writeInt32NoTag(4) // tag
                 writeInt32(1, pair.key)
                 writeInt32(2, pair.value)
             }
         }
 
-        testConversion(mapOf<Int, Int>(), serializer(), "00") {
+        testCompatibility(mapOf<Int, Int>(), serializer(), "00") {
             writeInt32NoTag(0)
         }
     }
@@ -88,16 +88,16 @@ class ProtobufTopLevelPrimitivesCompatibilityTest {
 
     @Test
     fun testTopLevelEnum() {
-        testConversion(Enum.E1, serializer<Enum>(), "00") {
+        testCompatibility(Enum.E1, serializer<Enum>(), "00") {
             writeUInt32NoTag(0)
         }
 
-        testConversion(Enum.E2, serializer<Enum>(), "01") {
+        testCompatibility(Enum.E2, serializer<Enum>(), "01") {
             writeUInt32NoTag(1)
         }
     }
 
-    private fun <T> testConversion(
+    private fun <T> testCompatibility(
         data: T,
         serializer: KSerializer<T>,
         expectedHexString: String,

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtobufTopLevelPrimitivesCompatibilityTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtobufTopLevelPrimitivesCompatibilityTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf
+
+import com.google.protobuf.*
+import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.*
+import org.junit.Test
+import java.io.*
+import kotlin.test.*
+
+class ProtobufTopLevelPrimitivesCompatibilityTest {
+
+    @Serializable
+    data class Box(@ProtoId(1) val i: Int)
+
+    @Test
+    fun testPrimitivesCompatibility() {
+        testConversion(true, Boolean.serializer(), "01") { writeBoolNoTag(it) }
+        testConversion('c', Char.serializer(), "63") { writeInt32NoTag(it.toInt()) }
+        testConversion(1, Byte.serializer(), "01") { writeInt32NoTag(it.toInt()) }
+        testConversion(1, Short.serializer(), "01") { writeInt32NoTag(it.toInt()) }
+        testConversion(1, Int.serializer(), "01") { writeInt32NoTag(it) }
+        testConversion(1, Long.serializer(), "01") { writeInt64NoTag(it) }
+        testConversion(1f, Float.serializer(), "0000803F") { writeFloatNoTag(it) }
+        testConversion(1.0, Double.serializer(), "000000000000F03F") { writeDoubleNoTag(it) }
+        testConversion("string", String.serializer(), "06737472696E67") { writeStringNoTag(it) }
+    }
+
+    @Test
+    fun testArraysCompatibility() {
+        testConversion(byteArrayOf(1, 2, 3), ByteArraySerializer(), "03010203") { writeByteArrayNoTag(it) }
+        testConversion(byteArrayOf(), ByteArraySerializer(), "00") { writeByteArrayNoTag(it) }
+        testConversion(intArrayOf(1, 2, 3), IntArraySerializer(), "03010203") {
+            writeUInt32NoTag(it.size)
+            for (i in it) writeInt32NoTag(i)
+        }
+
+        testConversion(arrayOf(Box(2)), serializer(), "010802") {
+            writeUInt32NoTag(it.size)
+            for (box in it) writeInt32(1, box.i)
+        }
+
+        testConversion(arrayOf<Box>(), serializer(), "00") {
+            writeUInt32NoTag(it.size)
+        }
+    }
+
+    @Test
+    fun testListsCompatibility() {
+        testConversion(listOf(1, 2, 3), serializer(), "03010203") {
+            writeUInt32NoTag(it.size)
+            for (i in it) writeInt32NoTag(i)
+        }
+        testConversion(listOf(Box(2)), serializer(), "010802") {
+            writeUInt32NoTag(it.size)
+            for (box in it) writeInt32(1, box.i)
+        }
+
+        testConversion(listOf<Int>(), serializer(), "00") {
+            writeUInt32NoTag(it.size)
+        }
+    }
+
+    @Test
+    fun testMapsCompatibility() {
+        testConversion(mapOf(1 to 2, 3 to 4), serializer(), "0204080110020408031004") {
+            writeUInt32NoTag(it.size)
+            for (pair in it) {
+                writeInt32NoTag(4)
+                writeInt32(1, pair.key)
+                writeInt32(2, pair.value)
+            }
+        }
+
+        testConversion(mapOf<Int, Int>(), serializer(), "00") {
+            writeInt32NoTag(0)
+        }
+    }
+
+    @Serializable
+    enum class Enum {
+        E1, E2
+    }
+
+    @Test
+    fun testTopLevelEnum() {
+        testConversion(Enum.E1, serializer<Enum>(), "00") {
+            writeUInt32NoTag(0)
+        }
+
+        testConversion(Enum.E2, serializer<Enum>(), "01") {
+            writeUInt32NoTag(1)
+        }
+    }
+
+    private fun <T> testConversion(
+        data: T,
+        serializer: KSerializer<T>,
+        expectedHexString: String,
+        block: CodedOutputStream.(T) -> Unit
+    ) {
+        val bytes = ProtoBuf.dump(serializer, data)
+        val string = HexConverter.printHexBinary(bytes)
+        val baos = ByteArrayOutputStream()
+        val cos = CodedOutputStream.newInstance(baos)
+        cos.block(data)
+        cos.flush()
+        assertTrue(
+            baos.toByteArray().contentEquals(bytes),
+            "Original: ${baos.toByteArray().contentToString()}, kx: ${bytes.contentToString()}"
+        )
+        assertEquals(expectedHexString, string)
+        val deserialized = ProtoBuf.loads(serializer, string)
+        when (data) {
+            is Array<*> -> {
+                assertTrue(data.contentEquals(deserialized as Array<out Any?>))
+            }
+            is IntArray -> {
+                assertTrue(data.contentEquals(deserialized as IntArray))
+            }
+            is ByteArray -> {
+                assertTrue(data.contentEquals(deserialized as ByteArray))
+            }
+            else -> {
+                assertEquals(data, deserialized)
+            }
+        }
+    }
+}

--- a/runtime/commonMain/src/kotlinx/serialization/Decoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Decoding.kt
@@ -229,7 +229,7 @@ public interface Decoder {
 
     /**
      * Decodes the value of type [T] by delegating the decoding process to the given [deserializer].
-     * For example, `decodeInt` call us equivalent to delegating integer decoding to [IntSerializer]:
+     * For example, `decodeInt` call us equivalent to delegating integer decoding to [Int.serializer]:
      * `decodeSerializableValue(IntSerializer)`
      */
     public fun <T : Any?> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T =

--- a/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
@@ -264,8 +264,8 @@ public interface Encoder {
 
     /**
      * Encodes the [value] of type [T] by delegating the encoding process to the given [serializer].
-     * For example, `encodeInt` call us equivalent to delegating integer encoding to [IntSerializer]:
-     * `encodeSerializableValue(IntSerializer())`
+     * For example, `encodeInt` call us equivalent to delegating integer encoding to [Int.serializer]:
+     * `encodeSerializableValue(Int.serializer())`
      */
     public fun <T : Any?> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
         serializer.serialize(this, value)

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -96,7 +96,10 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
     }
 
     final override fun endStructure(descriptor: SerialDescriptor) {
-        if (tagStack.isNotEmpty()) popTag(); endEncode(descriptor)
+        if (tagStack.isNotEmpty()) {
+            popTag()
+        }
+        endEncode(descriptor)
     }
 
     /**


### PR DESCRIPTION
* Support of top-level primitives 
* Further performance optimizations

On my machine:
```
Master:
Benchmark                         Mode  Cnt  Score   Error   Units
ProtoBaseline.fromBytes          thrpt    5  5.298 ± 0.227  ops/us
ProtoBaseline.fromBytesExplicit  thrpt    5  2.102 ± 0.040  ops/us
ProtoBaseline.toBytes            thrpt    5  6.430 ± 0.150  ops/us
ProtoBaseline.toBytesExplicit    thrpt    5  4.371 ± 0.204  ops/us


This branch:
Benchmark                         Mode  Cnt   Score   Error   Units
ProtoBaseline.fromBytes          thrpt    5  22.977 ± 0.626  ops/us
ProtoBaseline.fromBytesExplicit  thrpt    5  17.763 ± 0.856  ops/us
ProtoBaseline.toBytes            thrpt    5  20.502 ± 0.702  ops/us
ProtoBaseline.toBytesExplicit    thrpt    5  17.304 ± 2.093  ops/us
```

Fixes #216