### PR TITLE
Validate Input available bytes once beforehand in readExactNBytes to …

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -332,14 +332,12 @@ public class Cbor(
             return result
         }
 
-        private fun Input.readExactNBytes(bytes: Int): ByteArray {
-            val array = ByteArray(bytes)
-            var read = 0
-            while (read < bytes) {
-                val i = this.read(array, read, bytes - read)
-                if (i == -1) error("Unexpected EOF")
-                read += i
+        private fun Input.readExactNBytes(bytesCount: Int): ByteArray {
+            if (bytesCount > availableBytes) {
+                error("Unexpected EOF, available $availableBytes bytes, requested: $bytesCount")
             }
+            val array = ByteArray(bytesCount)
+            read(array, 0, bytesCount)
             return array
         }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
@@ -65,14 +65,12 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
         return input.readExactNBytes(length)
     }
 
-    private fun Input.readExactNBytes(bytes: Int): ByteArray {
-        val array = ByteArray(bytes)
-        var read = 0
-        while (read < bytes) {
-            val i = this.read(array, read, bytes - read)
-            if (i == -1) error("Unexpected EOF")
-            read += i
+    private fun Input.readExactNBytes(bytesCount: Int): ByteArray {
+        if (bytesCount > availableBytes) {
+            error("Unexpected EOF, available $availableBytes bytes, requested: $bytesCount")
         }
+        val array = ByteArray(bytesCount)
+        read(array, 0, bytesCount)
         return array
     }
 

--- a/runtime/commonMain/src/kotlinx/io/Streams.kt
+++ b/runtime/commonMain/src/kotlinx/io/Streams.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.*
 
 @InternalSerializationApi
 public abstract class Input {
+    abstract val availableBytes: Int
     public abstract fun read(): Int
     public abstract fun read(b: ByteArray, offset: Int, length: Int): Int
     public abstract fun readString(length: Int): String
@@ -19,6 +20,7 @@ public abstract class Input {
 public class ByteArrayInput(private var array: ByteArray) : Input() {
 
     private var position: Int = 0
+    public override val availableBytes: Int get() = array.size - position
 
     override fun read(): Int {
         return if (position < array.size) array[position++].toInt() and 0xFF else -1


### PR DESCRIPTION
…avoid loops and excess allocations

Fixes #798