### PR TITLE
Add support for String enum values in maps for Properties loading (#818)

### DIFF
--- a/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
@@ -103,6 +103,14 @@ public class Properties(override val context: SerialModule = EmptyModule) : Seri
             return map.getValue(tag)
         }
 
+        override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int {
+            return when (val taggedValue = map.getValue(tag)) {
+                is Int -> taggedValue
+                is String -> enumDescription.getElementIndex(taggedValue)
+                else -> throw SerializationException("Value of enum entry '$tag' is neither an Int nor a String")
+            }
+        }
+
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             val tag = nested("size")
             val size = if (map.containsKey(tag)) decodeTaggedInt(tag) else descriptor.elementsCount
@@ -138,6 +146,14 @@ public class Properties(override val context: SerialModule = EmptyModule) : Seri
         }
 
         override fun decodeTaggedValue(tag: String): Any = map.getValue(tag)!!
+
+        override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int {
+            return when (val taggedValue = map.getValue(tag)!!) {
+                is Int -> taggedValue
+                is String -> enumDescription.getElementIndex(taggedValue)
+                else -> throw SerializationException("Value of enum entry '$tag' is neither an Int nor a String")
+            }
+        }
 
         override fun decodeTaggedNotNullMark(tag: String): Boolean {
             return tag !in map || // in case of complex object, its fields are

--- a/formats/properties/commonTest/src/kotlinx/serialization/PropertiesTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/PropertiesTest.kt
@@ -36,6 +36,14 @@ class PropertiesTest {
         val last: Boolean = true
     )
 
+    @Serializable
+    data class EnumData(val data: TestEnum)
+
+    @Serializable
+    data class NullableEnumData(val data0: TestEnum?, val data1: TestEnum?)
+
+    enum class TestEnum { ZERO, ONE }
+
     private inline fun <reified T : Any> assertMappedAndRestored(
         expectedMap: Map<String, Any>,
         obj: T,
@@ -177,5 +185,39 @@ class PropertiesTest {
         doTest(map0)
         doTest(map1)
         doTest(map2)
+    }
+
+    @Test
+    fun testEnum() {
+        val obj = EnumData(TestEnum.ZERO)
+        assertMappedAndRestored(
+                mapOf("data" to 0),
+                obj,
+                EnumData.serializer()
+        )
+    }
+
+    @Test
+    fun testNullableEnum() {
+        val obj = NullableEnumData(null, TestEnum.ONE)
+        assertMappedNullableAndRestored(
+                mapOf("data0" to null, "data1" to 1),
+                obj,
+                NullableEnumData.serializer()
+        )
+    }
+
+    @Test
+    fun testEnumString() {
+        val map = mapOf("data" to "ZERO")
+        val loaded = Properties.load(EnumData.serializer(), map)
+        assertEquals(EnumData(TestEnum.ZERO), loaded)
+    }
+
+    @Test
+    fun testNullableEnumString() {
+        val map = mapOf("data0" to null, "data1" to "ONE")
+        val loaded = Properties.loadNullable(NullableEnumData.serializer(), map)
+        assertEquals(NullableEnumData(null, TestEnum.ONE), loaded)
     }
 }


### PR DESCRIPTION
This is a proposal to fix the issue described in #818.

The first commit adds tests for the Properties format, two of which complement the tests for the current implementation. The other two additional tests demonstrate the failure described in the issue.

The proposed fix adds the possibility to also declare enum values as Strings (declared names of the enum instances). This fixes the previously failing additional tests. The former behavior of specifying the enum values as ordinals is still supported. The complementing added tests show this.