### PR TITLE
Get rid of unquoted usages in our tests

### DIFF
--- a/integration-test/src/commonTest/kotlin/sample/JsonTest.kt
+++ b/integration-test/src/commonTest/kotlin/sample/JsonTest.kt
@@ -56,18 +56,21 @@ class JsonTest {
 
     @Test
     fun testEnablesImplicitlyOnInterfacesAndAbstractClasses() {
-        val json = Json { useArrayPolymorphism = true; unquotedPrint = true; prettyPrint = false; serialModule = testModule }
+        val json = Json { useArrayPolymorphism = true; prettyPrint = false; serialModule = testModule }
         val data = genTestData()
-        assertEquals("""{iMessage:[MessageWithId,{id:0,body:"Message #0"}],iMessageList:[[MessageWithId,{id:1,body:"Message #1"}],[MessageWithId,{id:2,body:"Message #2"}]],message:[MessageWithId,{id:3,body:"Message #3"}],msgSet:[[SimpleMessage,{body:Simple}]],simple:[DoubleSimpleMessage,{body:Simple,body2:DoubleSimple}],withId:{id:4,body:"Message #4"}}""", json.stringify(Holder.serializer(), data))
+        assertEquals("""{"iMessage":["MessageWithId",{"id":0,"body":"Message #0"}],"iMessageList":[["MessageWithId",{"id":1,"body":"Message #1"}],""" +
+                """["MessageWithId",{"id":2,"body":"Message #2"}]],"message":["MessageWithId",{"id":3,"body":"Message #3"}],"msgSet":[["SimpleMessage",""" +
+                """{"body":"Simple"}]],"simple":["DoubleSimpleMessage",{"body":"Simple","body2":"DoubleSimple"}],"withId":{"id":4,"body":"Message #4"}}""",
+            json.stringify(Holder.serializer(), data))
     }
 
     @Test
-    fun polymorphicForGenericUpperBound() {
+    fun testPolymorphicForGenericUpperBound() {
         val generic = GenericMessage<Message, Any>(MessageWithId(42, "body"), "body2")
         val serial = GenericMessage.serializer(Message.serializer(), Int.serializer() as KSerializer<Any>)
-        val json = Json { useArrayPolymorphism = true; unquotedPrint = true; prettyPrint = false; serialModule = testModule }
+        val json = Json { useArrayPolymorphism = true; prettyPrint = false; serialModule = testModule }
         val s = json.stringify(serial, generic)
-        assertEquals("""{value:[MessageWithId,{id:42,body:body}],value2:[kotlin.String,body2]}""", s)
+        assertEquals("""{"value":["MessageWithId",{"id":42,"body":"body"}],"value2":["kotlin.String","body2"]}""", s)
     }
 
     @Test

--- a/runtime/commonTest/src/kotlinx/serialization/TuplesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/TuplesTest.kt
@@ -21,21 +21,21 @@ class TuplesTest : JsonTestBase() {
 
     @Test
     fun testCustomPair() = assertStringFormAndRestored(
-        "{k:42,v:foo}",
+        """{"k":42,"v":"foo"}""",
         MyPair(42, "foo"),
         MyPair.serializer(
             Int.serializer(),
             String.serializer()
         ),
-        unquotedLenient
+        lenient
     )
 
     @Test
     fun testStandardPair() = assertStringFormAndRestored(
-        "{p:{first:42,second:foo}}",
+        """{"p":{"first":42,"second":"foo"}}""",
         PairWrapper(42 to "foo"),
         PairWrapper.serializer(),
-        unquotedLenient
+        lenient
     )
 
     @Test
@@ -50,10 +50,10 @@ class TuplesTest : JsonTestBase() {
 
     @Test
     fun testStandardTriple() = assertStringFormAndRestored(
-        "{t:{first:42,second:foo,third:false}}",
+        """{"t":{"first":42,"second":"foo","third":false}}""",
         TripleWrapper(Triple(42, "foo", false)),
         TripleWrapper.serializer(),
-        unquotedLenient
+        lenient
     )
 
     @Test

--- a/runtime/commonTest/src/kotlinx/serialization/TypeOfSerializerLookupTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/TypeOfSerializerLookupTest.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.test.*
 import kotlin.reflect.*
 import kotlin.test.*
 
+@Suppress("RemoveExplicitTypeArguments") // This is exactly what's being tested
 class TypeOfSerializerLookupTest : JsonTestBase() {
 
     @Test
@@ -23,7 +24,7 @@ class TypeOfSerializerLookupTest : JsonTestBase() {
     @Test
     fun testPlainClass() {
         val b = StringData("some string")
-        assertSerializedWithType("""{data:"some string"}""", b)
+        assertSerializedWithType("""{"data":"some string"}""", b)
     }
 
     @Test
@@ -36,19 +37,19 @@ class TypeOfSerializerLookupTest : JsonTestBase() {
     @Test
     fun testPrimitiveList() {
         val myArr = listOf("a", "b", "c")
-        assertSerializedWithType("[a,b,c]", myArr)
+        assertSerializedWithType("""["a","b","c"]""", myArr)
     }
 
     @Test
     fun testPrimitiveSet() {
         val mySet = setOf("a", "b", "c", "c")
-        assertSerializedWithType("[a,b,c]", mySet)
+        assertSerializedWithType("""["a","b","c"]""", mySet)
     }
 
     @Test
     fun testMapWithT() {
         val myMap = mapOf("string" to StringData("foo"), "string2" to StringData("bar"))
-        assertSerializedWithType("""{string:{data:foo},string2:{data:bar}}""", myMap)
+        assertSerializedWithType("""{"string":{"data":"foo"},"string2":{"data":"bar"}}""", myMap)
     }
 
     @Test
@@ -84,23 +85,23 @@ class TypeOfSerializerLookupTest : JsonTestBase() {
         val intBox = Box(42)
         val intBoxSerializer = serializer<Box<Int>>()
         assertEquals(Box.serializer(Int.serializer()).descriptor, intBoxSerializer.descriptor)
-        assertSerializedWithType("""{boxed:42}""", intBox)
+        assertSerializedWithType("""{"boxed":42}""", intBox)
         val dataBox = Box(StringData("foo"))
-        assertSerializedWithType("""{boxed:{data:foo}}""", dataBox)
+        assertSerializedWithType("""{"boxed":{"data":"foo"}}""", dataBox)
     }
 
     @Test
     fun testRecursiveGeneric() = noLegacyJs {
         val boxBox = Box(Box(Box(IntData(42))))
-        assertSerializedWithType("""{boxed:{boxed:{boxed:{intV:42}}}}""", boxBox)
+        assertSerializedWithType("""{"boxed":{"boxed":{"boxed":{"intV":42}}}}""", boxBox)
     }
 
     @Test
     fun testMixedGeneric() = noLegacyJs {
         val listOfBoxes = listOf(Box("foo"), Box("bar"))
-        assertSerializedWithType("""[{boxed:foo},{boxed:bar}]""", listOfBoxes)
+        assertSerializedWithType("""[{"boxed":"foo"},{"boxed":"bar"}]""", listOfBoxes)
         val boxedList = Box(listOf("foo", "bar"))
-        assertSerializedWithType("""{boxed:[foo,bar]}""", boxedList)
+        assertSerializedWithType("""{"boxed":["foo","bar"]}""", boxedList)
     }
 
     @Test
@@ -137,7 +138,7 @@ class TypeOfSerializerLookupTest : JsonTestBase() {
     private inline fun <reified T> assertSerializedWithType(
         expected: String,
         value: T,
-        json: StringFormat = unquoted
+        json: StringFormat = default
     ) {
         val serial = serializer<T>()
         assertEquals(expected, json.stringify(serial, value))

--- a/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
@@ -45,7 +45,7 @@ class ContextAndPolymorphicTest {
         }
     }
 
-    private val obj = EnhancedData(Data(100500), Payload("string"), Payload("binary"))
+    private val value = EnhancedData(Data(100500), Payload("string"), Payload("binary"))
     private lateinit var json: Json
 
     @BeforeTest
@@ -53,28 +53,28 @@ class ContextAndPolymorphicTest {
         val scope = serializersModuleOf(Payload::class, PayloadSerializer)
         val bPolymorphicModule = SerializersModule { polymorphic(Any::class) { Payload::class with PayloadSerializer } }
         json = Json(
-            JsonConfiguration(unquotedPrint = true, useArrayPolymorphism = true),
+            JsonConfiguration(useArrayPolymorphism = true),
             context = scope + bPolymorphicModule
         )
     }
 
     @Test
     fun testWriteCustom() {
-        val s = json.stringify(EnhancedData.serializer(), obj)
-        assertEquals("{data:{a:100500,b:42},stringPayload:{s:string},binaryPayload:62696E617279}", s)
+        val s = json.stringify(EnhancedData.serializer(), value)
+        assertEquals("""{"data":{"a":100500,"b":42},"stringPayload":{"s":"string"},"binaryPayload":"62696E617279"}""", s)
     }
 
     @Test
     fun testReadCustom() {
         val s = json.parse(EnhancedData.serializer(),
             """{"data":{"a":100500,"b":42},"stringPayload":{"s":"string"},"binaryPayload":"62696E617279"}""")
-        assertEquals(obj, s)
+        assertEquals(value, s)
     }
 
     @Test
     fun testWriteCustomList() {
         val s = json.stringify(PayloadList.serializer(), PayloadList(listOf(Payload("1"), Payload("2"))))
-        assertEquals("{ps:[{s:1},{s:2}]}", s)
+        assertEquals("""{"ps":[{"s":"1"},{"s":"2"}]}""", s)
     }
 
     @Test
@@ -82,7 +82,7 @@ class ContextAndPolymorphicTest {
         val map = mapOf<String, Any>("Payload" to Payload("data"))
         val serializer = MapSerializer(String.serializer(), PolymorphicSerializer(Any::class))
         val s = json.stringify(serializer, map)
-        assertEquals("""{Payload:[Payload,{s:data}]}""", s)
+        assertEquals("""{"Payload":["Payload",{"s":"data"}]}""", s)
     }
 
     @Test

--- a/runtime/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
@@ -24,7 +24,7 @@ class PolymorphismTest : JsonTestBase() {
         )
     }
 
-    private val json = Json { unquotedPrint = true; useArrayPolymorphism = true; serialModule = module }
+    private val json = Json { useArrayPolymorphism = true; serialModule = module }
 
     @Test
     fun testInheritanceJson() = parametrizedTest { useStreaming ->
@@ -34,8 +34,8 @@ class PolymorphismTest : JsonTestBase() {
         )
         val bytes = json.stringify(Wrapper.serializer(), obj, useStreaming)
         assertEquals(
-            "{polyBase1:[kotlinx.serialization.PolyBase,{id:2}]," +
-                    "polyBase2:[kotlinx.serialization.PolyDerived,{id:1,s:b}]}", bytes
+            """{"polyBase1":["kotlinx.serialization.PolyBase",{"id":2}],""" +
+                    """"polyBase2":["kotlinx.serialization.PolyDerived",{"id":1,"s":"b"}]}""", bytes
         )
     }
 
@@ -43,7 +43,7 @@ class PolymorphismTest : JsonTestBase() {
     fun testSerializeWithExplicitPolymorphicSerializer() = parametrizedTest { useStreaming ->
         val obj = PolyDerived("b")
         val s = json.stringify(PolymorphicSerializer(PolyDerived::class), obj, useStreaming)
-        assertEquals("[kotlinx.serialization.PolyDerived,{id:1,s:b}]", s)
+        assertEquals("""["kotlinx.serialization.PolyDerived",{"id":1,"s":"b"}]""", s)
     }
 
     object PolyDefaultSerializer : JsonTransformingSerializer<PolyDefault>(PolyDefault.serializer(), "foo") {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
@@ -8,7 +8,6 @@ package kotlinx.serialization.json
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.modules.*
-import kotlinx.serialization.test.*
 import kotlin.test.*
 
 class JsonCustomSerializersTest : JsonTestBase() {
@@ -41,7 +40,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class C(@Id(1) val a: Int = 31, @Id(2) val b: Int = 42) {
         @Serializer(forClass = C::class)
-        companion object: KSerializer<C> {
+        companion object : KSerializer<C> {
             override fun serialize(encoder: Encoder, value: C) {
                 val elemOutput = encoder.beginStructure(descriptor)
                 elemOutput.encodeIntElement(descriptor, 1, value.b)
@@ -57,7 +56,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class CList2(@Id(1) val d: Int = 5, @Id(2) val c: List<C>) {
         @Serializer(forClass = CList2::class)
-        companion object: KSerializer<CList2> {
+        companion object : KSerializer<CList2> {
             override fun serialize(encoder: Encoder, value: CList2) {
                 val elemOutput = encoder.beginStructure(descriptor)
                 elemOutput.encodeSerializableElement(descriptor, 1, C.list, value.c)
@@ -70,7 +69,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class CList3(@Id(1) val e: List<C> = emptyList(), @Id(2) val f: Int) {
         @Serializer(forClass = CList3::class)
-        companion object: KSerializer<CList3> {
+        companion object : KSerializer<CList3> {
             override fun serialize(encoder: Encoder, value: CList3) {
                 val elemOutput = encoder.beginStructure(descriptor)
                 if (value.e.isNotEmpty()) elemOutput.encodeSerializableElement(descriptor, 0, C.list, value.e)
@@ -83,7 +82,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class CList4(@Id(1) val g: List<C> = emptyList(), @Id(2) val h: Int) {
         @Serializer(forClass = CList4::class)
-        companion object: KSerializer<CList4> {
+        companion object : KSerializer<CList4> {
             override fun serialize(encoder: Encoder, value: CList4) {
                 val elemOutput = encoder.beginStructure(descriptor)
                 elemOutput.encodeIntElement(descriptor, 1, value.h)
@@ -96,7 +95,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class CList5(@Id(1) val g: List<Int> = emptyList(), @Id(2) val h: Int) {
         @Serializer(forClass = CList5::class)
-        companion object: KSerializer<CList5> {
+        companion object : KSerializer<CList5> {
             override fun serialize(encoder: Encoder, value: CList5) {
                 val elemOutput = encoder.beginStructure(descriptor)
                 elemOutput.encodeIntElement(descriptor, 1, value.h)
@@ -111,14 +110,14 @@ class JsonCustomSerializersTest : JsonTestBase() {
 
     private val moduleWithB = serializersModuleOf(B::class, BSerializer)
 
-    private fun createJsonWithB() = Json { unquotedPrint = true; isLenient = true; serialModule = moduleWithB }
+    private fun createJsonWithB() = Json { isLenient = true; serialModule = moduleWithB }
 
     @Test
     fun testWriteCustom() = parametrizedTest { useStreaming ->
         val a = A(B(2))
         val j = createJsonWithB()
         val s = j.stringify(a, useStreaming)
-        assertEquals("{b:2}", s)
+        assertEquals("""{"b":2}""", s)
     }
 
     @Test
@@ -134,7 +133,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
         val obj = BList(listOf(B(1), B(2), B(3)))
         val j = createJsonWithB()
         val s = j.stringify(obj, useStreaming)
-        assertEquals("{bs:[1,2,3]}", s)
+        assertEquals("""{"bs":[1,2,3]}""", s)
     }
 
     @Test
@@ -164,52 +163,51 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Test
     fun testWriteCustomInvertedOrder() = parametrizedTest { useStreaming ->
         val obj = C(1, 2)
-        val s = unquoted.stringify(obj, useStreaming)
-        assertEquals("{b:2,a:1}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"b":2,"a":1}""", s)
     }
 
     @Test
     fun testWriteCustomOmitDefault() = parametrizedTest { useStreaming ->
         val obj = C(b = 2)
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{b:2}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"b":2}""", s)
     }
 
     @Test
     fun testReadCustomInvertedOrder() = parametrizedTest { useStreaming ->
         val obj = C(1, 2)
-        val s = unquotedLenient.parse<C>("{b:2,a:1}", useStreaming)
+        val s = default.parse<C>("""{"b":2,"a":1}""", useStreaming)
         assertEquals(obj, s)
     }
 
     @Test
     fun testReadCustomOmitDefault() = parametrizedTest { useStreaming ->
         val obj = C(b = 2)
-        val j = unquotedLenient
-        val s = j.parse<C>("{b:2}", useStreaming)
+        val s = default.parse<C>("""{"b":2}""", useStreaming)
         assertEquals(obj, s)
     }
 
     @Test
     fun testWriteListOfOptional() = parametrizedTest { useStreaming ->
         val obj = listOf(C(a = 1), C(b = 2), C(3, 4))
-        val s = unquotedLenient.stringify(C.list, obj, useStreaming)
-        assertEquals("[{b:42,a:1},{b:2},{b:4,a:3}]", s)
+        val s = default.stringify(C.list, obj, useStreaming)
+        assertEquals("""[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]""", s)
     }
 
     @Test
     fun testReadListOfOptional() = parametrizedTest { useStreaming ->
         val obj = listOf(C(a = 1), C(b = 2), C(3, 4))
-        val j = "[{b:42,a:1},{b:2},{b:4,a:3}]"
-        val s = unquotedLenient.parse(C.list, j, useStreaming)
+        val j = """[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]"""
+        val s = default.parse(C.list, j, useStreaming)
         assertEquals(obj, s)
     }
 
     @Test
     fun testWriteOptionalList1() = parametrizedTest { useStreaming ->
         val obj = CList1(listOf(C(a = 1), C(b = 2), C(3, 4)))
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{c:[{b:42,a:1},{b:2},{b:4,a:3}]}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"c":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}""", s)
     }
 
     @Test
@@ -222,129 +220,129 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Test
     fun testReadOptionalList1() = parametrizedTest { useStreaming ->
         val obj = CList1(listOf(C(a = 1), C(b = 2), C(3, 4)))
-        val j = "{c:[{b:42,a:1},{b:2},{b:4,a:3}]}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val j = """{"c":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList2a() = parametrizedTest { useStreaming ->
         val obj = CList2(7, listOf(C(a = 5), C(b = 6), C(7, 8)))
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{c:[{b:42,a:5},{b:6},{b:8,a:7}],d:7}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}],"d":7}""", s)
     }
 
     @Test
     fun testReadOptionalList2a() = parametrizedTest { useStreaming ->
         val obj = CList2(7, listOf(C(a = 5), C(b = 6), C(7, 8)))
-        val j = "{c:[{b:42,a:5},{b:6},{b:8,a:7}],d:7}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val j = """{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}],"d":7}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList2b() = parametrizedTest { useStreaming ->
         val obj = CList2(c = listOf(C(a = 5), C(b = 6), C(7, 8)))
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{c:[{b:42,a:5},{b:6},{b:8,a:7}]}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}]}""", s)
     }
 
     @Test
     fun testReadOptionalList2b() = parametrizedTest { useStreaming ->
         val obj = CList2(c = listOf(C(a = 5), C(b = 6), C(7, 8)))
-        val j = "{c:[{b:42,a:5},{b:6},{b:8,a:7}]}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val j = """{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}]}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList3a() = parametrizedTest { useStreaming ->
         val obj = CList3(listOf(C(a = 1), C(b = 2), C(3, 4)), 99)
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{e:[{b:42,a:1},{b:2},{b:4,a:3}],f:99}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"e":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}],"f":99}""", s)
     }
 
     @Test
     fun testReadOptionalList3a() = parametrizedTest { useStreaming ->
         val obj = CList3(listOf(C(a = 1), C(b = 2), C(3, 4)), 99)
-        val j = "{e:[{b:42,a:1},{b:2},{b:4,a:3}],f:99}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val j = """{"e":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}],"f":99}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList3b() = parametrizedTest { useStreaming ->
         val obj = CList3(f = 99)
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{f:99}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"f":99}""", s)
     }
 
     @Test
     fun testReadOptionalList3b() = parametrizedTest { useStreaming ->
         val obj = CList3(f = 99)
-        val j = "{f:99}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val j = """{"f":99}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList4a() = parametrizedTest { useStreaming ->
         val obj = CList4(listOf(C(a = 1), C(b = 2), C(3, 4)), 54)
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{h:54,g:[{b:42,a:1},{b:2},{b:4,a:3}]}", s)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"h":54,"g":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}""", s)
     }
 
     @Test
     fun testReadOptionalList4a() = parametrizedTest { useStreaming ->
         val obj = CList4(listOf(C(a = 1), C(b = 2), C(3, 4)), 54)
-        val j = "{h:54,g:[{b:42,a:1},{b:2},{b:4,a:3}]}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val j = """{"h":54,"g":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList4b() = parametrizedTest { useStreaming ->
-        val obj = CList4(h=97)
-        val j = "{h:97}"
-        val s = unquotedLenient.stringify(obj, useStreaming)
+        val obj = CList4(h = 97)
+        val j = """{"h":97}"""
+        val s = default.stringify(obj, useStreaming)
         assertEquals(j, s)
     }
 
     @Test
     fun testReadOptionalList4b() = parametrizedTest { useStreaming ->
-        val obj = CList4(h=97)
-        val j = "{h:97}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val obj = CList4(h = 97)
+        val j = """{"h":97}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList5a() = parametrizedTest { useStreaming ->
-        val obj = CList5(listOf(9,8,7,6,5), 5)
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{h:5,g:[9,8,7,6,5]}", s)
+        val obj = CList5(listOf(9, 8, 7, 6, 5), 5)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"h":5,"g":[9,8,7,6,5]}""", s)
     }
 
     @Test
     fun testReadOptionalList5a() = parametrizedTest { useStreaming ->
-        val obj = CList5(listOf(9,8,7,6,5), 5)
-        val j = "{h:5,g:[9,8,7,6,5]}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val obj = CList5(listOf(9, 8, 7, 6, 5), 5)
+        val j = """{"h":5,"g":[9,8,7,6,5]}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testWriteOptionalList5b() = parametrizedTest { useStreaming ->
-        val obj = CList5(h=999)
-        val s = unquotedLenient.stringify(obj, useStreaming)
-        assertEquals("{h:999}", s)
+        val obj = CList5(h = 999)
+        val s = default.stringify(obj, useStreaming)
+        assertEquals("""{"h":999}""", s)
     }
 
     @Test
     fun testReadOptionalList5b() = parametrizedTest { useStreaming ->
-        val obj = CList5(h=999)
-        val j = "{h:999}"
-        assertEquals(obj, unquotedLenient.parse(j, useStreaming))
+        val obj = CList5(h = 999)
+        val j = """{"h":999}"""
+        assertEquals(obj, default.parse(j, useStreaming))
     }
 
     @Test
     fun testMapBuiltinsTest() = parametrizedTest { useStreaming ->
         val map = mapOf(1 to "1", 2 to "2")
         val serial = MapSerializer(Int.serializer(), String.serializer())
-        val s = unquotedLenient.stringify(serial, map, useStreaming)
-        assertEquals("{1:1,2:2}", s)
+        val s = default.stringify(serial, map, useStreaming)
+        assertEquals("""{"1":"1","2":"2"}""", s)
     }
 
     @Test

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonGenericTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonGenericTest.kt
@@ -38,9 +38,9 @@ class JsonGenericTest : JsonTestBase() {
             String.serializer(),
             Boolean.serializer()
         )
-        val s = unquotedLenient.stringify(serializer, triple, useStreaming)
-        assertEquals("{first:42,second:foo,third:false}", s)
-        val restored = unquotedLenient.parse(serializer, s, useStreaming)
+        val s = default.stringify(serializer, triple, useStreaming)
+        assertEquals("""{"first":42,"second":"foo","third":false}""", s)
+        val restored = default.parse(serializer, s, useStreaming)
         assertEquals(triple, restored)
     }
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonInputOutputRecursiveTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonInputOutputRecursiveTest.kt
@@ -46,13 +46,6 @@ class JsonInputOutputRecursiveTest : JsonTestBase() {
     }
 
     @Test
-    fun testWriteDataStringUnquoted() = parametrizedTest { useStreaming ->
-        val outputData = Event(0, Either.Right(Payload(42, 43, "Hello world")), 1000)
-        val ev = unquoted.stringify(Event.serializer(), outputData, useStreaming)
-        assertEquals("""{id:0,payload:{from:42,to:43,msg:"Hello world"},timestamp:1000}""", ev)
-    }
-
-    @Test
     fun testWriteDataStringIndented() = parametrizedTest { useStreaming ->
         val outputData = Event(0, Either.Right(Payload(42, 43, "Hello world")), 1000)
         val ev = Json { prettyPrint = true }.stringify(Event.serializer(), outputData, useStreaming)

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonOptionalTests.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonOptionalTests.kt
@@ -31,7 +31,8 @@ class JsonOptionalTests : JsonTestBase() {
 
     @Test
     fun testAll() = parametrizedTest { useStreaming ->
-        assertEquals("{a:0,b:42,c:Hello}", unquoted.stringify(Data.serializer(), Data(), useStreaming))
+        assertEquals("""{"a":0,"b":42,"c":"Hello"}""",
+            default.stringify(Data.serializer(), Data(), useStreaming))
         assertEquals(lenient.parse(Data.serializer(), "{a:0,b:43,c:Hello}", useStreaming), Data(b = 43))
         assertEquals(lenient.parse(Data.serializer(), "{a:0,b:42,c:Hello}", useStreaming), Data())
     }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -13,8 +13,6 @@ import kotlin.test.*
 
 abstract class JsonTestBase {
     protected val default = Json(JsonConfiguration.Default)
-    protected val unquoted = Json { unquotedPrint = true }
-    protected val unquotedLenient = Json { unquotedPrint = true; isLenient = true; ignoreUnknownKeys = true; serializeSpecialFloatingPointValues = true }
     protected val lenient = Json { isLenient = true; ignoreUnknownKeys = true; serializeSpecialFloatingPointValues = true }
 
     internal inline fun <reified T : Any> Json.stringify(value: T, useStreaming: Boolean): String {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTransientTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTransientTest.kt
@@ -38,13 +38,14 @@ class JsonTransientTest : JsonTestBase() {
 
     @Test
     fun testAll() = parametrizedTest { useStreaming ->
-        assertEquals("{a:0,e:false,c:Hello}", unquoted.stringify(Data.serializer(), Data(), useStreaming))
+        assertEquals("""{"a":0,"e":false,"c":"Hello"}""",
+            default.stringify(Data.serializer(), Data(), useStreaming))
     }
 
     @Test
     fun testMissingOptionals() = parametrizedTest { useStreaming ->
-        assertEquals(unquotedLenient.parse(Data.serializer(), "{a:0,c:Hello}", useStreaming), Data())
-        assertEquals(unquotedLenient.parse(Data.serializer(), "{a:0}", useStreaming), Data())
+        assertEquals(default.parse(Data.serializer(), """{"a":0,"c":"Hello"}""", useStreaming), Data())
+        assertEquals(default.parse(Data.serializer(), """{"a":0}""", useStreaming), Data())
     }
 
     @Test

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonUpdateModeTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonUpdateModeTest.kt
@@ -26,16 +26,15 @@ class JsonOverwriteTest : JsonTestBase() {
     @Test
     fun testCanUpdatePrimitiveList() = parametrizedTest { useStreaming ->
         val parsed =
-            unquotedLenient
-                .parse<Updatable1>(Updatable1.serializer(), """{l:[1,2],f:foo,l:[3,4]}""", useStreaming)
+            lenient.parse<Updatable1>(Updatable1.serializer(), """{"l":[1,2],"f":"foo","l":[3,4]}""", useStreaming)
         assertEquals(Updatable1(listOf(3, 4)), parsed)
     }
 
     @Test
     fun testCanUpdateObjectList() = parametrizedTest { useStreaming ->
-        val parsed = unquotedLenient.parse<Updatable2>(
+        val parsed = lenient.parse<Updatable2>(
             Updatable2.serializer(),
-            """{f:bar,l:[{a:42}],l:[{a:43}]}""",
+            """{"f":"bar","l":[{"a":42}],"l":[{"a":43}]}""",
             useStreaming
         )
         assertEquals(Updatable2(listOf(Data(43))), parsed)
@@ -43,21 +42,21 @@ class JsonOverwriteTest : JsonTestBase() {
 
     @Test
     fun testCanUpdateNullableValuesInside() = parametrizedTest { useStreaming ->
-        val a1 = unquotedLenient.parse(NullableInnerIntList.serializer(), """{data:[null],data:[1]}""", useStreaming)
+        val a1 = default.parse(NullableInnerIntList.serializer(), """{"data":[null],"data":[1]}""", useStreaming)
         assertEquals(NullableInnerIntList(listOf(1)), a1)
-        val a2 = unquotedLenient.parse(NullableInnerIntList.serializer(), """{data:[42],data:[null]}""", useStreaming)
+        val a2 = default.parse(NullableInnerIntList.serializer(), """{"data":[42],"data":[null]}""", useStreaming)
         assertEquals(NullableInnerIntList(listOf(null)), a2)
-        val a3 = unquotedLenient.parse(NullableInnerIntList.serializer(), """{data:[31],data:[1]}""", useStreaming)
+        val a3 = default.parse(NullableInnerIntList.serializer(), """{"data":[31],"data":[1]}""", useStreaming)
         assertEquals(NullableInnerIntList(listOf(1)), a3)
     }
 
     @Test
     fun testCanUpdateNullableValues() = parametrizedTest { useStreaming ->
-        val a1 = unquotedLenient.parse(NullableUpdatable.serializer(), """{data:null,data:[{a:42}]}""", useStreaming)
+        val a1 = lenient.parse(NullableUpdatable.serializer(), """{"data":null,"data":[{"a":42}]}""", useStreaming)
         assertEquals(NullableUpdatable(listOf(Data(42))), a1)
-        val a2 = unquotedLenient.parse(NullableUpdatable.serializer(), """{data:[{a:42}],data:null}""", useStreaming)
+        val a2 = lenient.parse(NullableUpdatable.serializer(), """{"data":[{a:42}],"data":null}""", useStreaming)
         assertEquals(NullableUpdatable(null), a2)
-        val a3 = unquotedLenient.parse(NullableUpdatable.serializer(), """{data:[{a:42}],data:[{a:43}]}""", useStreaming)
+        val a3 = lenient.parse(NullableUpdatable.serializer(), """{"data":[{a:42}],"data":[{"a":43}]}""", useStreaming)
         assertEquals(NullableUpdatable(listOf(Data(43))), a3)
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/LenientTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/LenientTest.kt
@@ -58,11 +58,4 @@ class LenientTest : JsonTestBase() {
         assertFailsWith<JsonDecodingException> { default.parse(ListHolder.serializer(), json, it) }
         assertEquals(listValue, lenient.parse(ListHolder.serializer(), json, it))
     }
-
-    @Test
-    fun testUnquotedStringInArray2() = parametrizedTest {
-        val json = """{"l":[1, 2, "ss"]}"""
-        assertFailsWith<JsonDecodingException> { default.parse(ListHolder.serializer(), json, it) }
-        assertEquals(listValue, lenient.parse(ListHolder.serializer(), json, it))
-    }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonListPolymorphismTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonListPolymorphismTest.kt
@@ -19,9 +19,9 @@ class JsonListPolymorphismTest : JsonTestBase() {
     fun testPolymorphicValues() = assertJsonFormAndRestored(
         ListWrapper.serializer(),
         ListWrapper(listOf(InnerImpl(1), InnerImpl2(2))),
-        "{list:[" +
-                "{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:1,str:default,nullable:null}," +
-                "{type:kotlinx.serialization.json.polymorphic.InnerImpl2,field:2}]}",
+        """{"list":[""" +
+                """{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":1,"str":"default","nullable":null},""" +
+                """{"type":"kotlinx.serialization.json.polymorphic.InnerImpl2","field":2}]}""",
         polymorphicRelaxedJson)
 
     @Serializable
@@ -31,8 +31,8 @@ class JsonListPolymorphismTest : JsonTestBase() {
     fun testPolymorphicNullableValues() = assertJsonFormAndRestored(
         ListNullableWrapper.serializer(),
         ListNullableWrapper(listOf(InnerImpl(1), null)),
-        "{list:[" +
-                "{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:1,str:default,nullable:null}," +
+        """{"list":[""" +
+                """{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":1,"str":"default","nullable":null},""" +
                 "null]}",
         polymorphicRelaxedJson)
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonNestedPolymorphismTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonNestedPolymorphismTest.kt
@@ -12,7 +12,6 @@ import kotlin.test.*
 class JsonNestedPolymorphismTest : JsonTestBase() {
 
     private val polymorphicJson = Json {
-        unquotedPrint = true
         isLenient = true
         serialModule = SerializersModule {
             polymorphic(Any::class, InnerBase::class) {
@@ -33,9 +32,9 @@ class JsonNestedPolymorphismTest : JsonTestBase() {
     fun testAnyList() = assertJsonFormAndRestored(
         NestedGenericsList.serializer(),
         NestedGenericsList(listOf(listOf(InnerImpl(1)), listOf(InnerImpl(2)))),
-        "{list:[[" +
-                "{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:1,str:default,nullable:null}],[" +
-                "{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:2,str:default,nullable:null}]]}",
+        """{"list":[[""" +
+                """{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":1,"str":"default","nullable":null}],[""" +
+                """{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":2,"str":"default","nullable":null}]]}""",
         polymorphicJson)
 
     @Serializable
@@ -45,7 +44,8 @@ class JsonNestedPolymorphismTest : JsonTestBase() {
     fun testAnyMap() = assertJsonFormAndRestored(
         NestedGenericsMap.serializer(),
         NestedGenericsMap(mapOf("k1" to mapOf("k1" to InnerImpl(1)))),
-        "{list:{k1:{k1:{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:1,str:default,nullable:null}}}}",
+        """{"list":{"k1":{"k1":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl",""" +
+                """"field":1,"str":"default","nullable":null}}}}""",
         polymorphicJson)
 
     @Serializable
@@ -55,8 +55,9 @@ class JsonNestedPolymorphismTest : JsonTestBase() {
     fun testAny() = assertJsonFormAndRestored(
         AnyWrapper.serializer(),
         AnyWrapper(OuterImpl(InnerImpl2(1), InnerImpl(2))),
-        "{any:" +
-                "{type:kotlinx.serialization.json.polymorphic.OuterImpl,base:{type:kotlinx.serialization.json.polymorphic.InnerImpl2,field:1}," +
-                "base2:{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:2,str:default,nullable:null}}}",
+        """{"any":""" +
+                """{"type":"kotlinx.serialization.json.polymorphic.OuterImpl",""" +
+                """"base":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl2","field":1},""" +
+                """"base2":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":2,"str":"default","nullable":null}}}""",
         polymorphicJson)
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPolymorphicClassDescriptorTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPolymorphicClassDescriptorTest.kt
@@ -11,8 +11,6 @@ import kotlin.test.Test
 class JsonPolymorphicClassDescriptorTest : JsonTestBase() {
 
     private val json = Json {
-        unquotedPrint = true
-        isLenient = true
         classDiscriminator = "class"
         serialModule = polymorphicTestModule
     }
@@ -21,7 +19,8 @@ class JsonPolymorphicClassDescriptorTest : JsonTestBase() {
     fun testPolymorphicProperties() = assertJsonFormAndRestored(
         InnerBox.serializer(),
         InnerBox(InnerImpl(42, "foo")),
-        "{base:{class:kotlinx.serialization.json.polymorphic.InnerImpl,field:42,str:foo,nullable:null}}",
+        """{"base":{"class":"kotlinx.serialization.json.polymorphic.InnerImpl",""" +
+                """"field":42,"str":"foo","nullable":null}}""",
         json
     )
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPropertyPolymorphicTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPropertyPolymorphicTest.kt
@@ -15,14 +15,16 @@ class JsonPropertyPolymorphicTest : JsonTestBase() {
     fun testPolymorphicProperties() = assertJsonFormAndRestored(
         InnerBox.serializer(),
         InnerBox(InnerImpl(42, "foo")),
-        "{base:{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:42,str:foo,nullable:null}}",
+        """{"base":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl",""" +
+                """"field":42,"str":"foo","nullable":null}}""",
         polymorphicRelaxedJson)
 
     @Test
     fun testFlatPolymorphic() = parametrizedTest { useStreaming ->
         val base: InnerBase = InnerImpl(42, "foo")
         val string = polymorphicRelaxedJson.stringify(PolymorphicSerializer(InnerBase::class), base, useStreaming)
-        assertEquals("{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:42,str:foo,nullable:null}", string)
+        assertEquals("""{"type":"kotlinx.serialization.json.polymorphic.InnerImpl",""" +
+                """"field":42,"str":"foo","nullable":null}""", string)
         assertEquals(base, polymorphicRelaxedJson.parse(PolymorphicSerializer(InnerBase::class), string, useStreaming))
     }
 
@@ -30,18 +32,19 @@ class JsonPropertyPolymorphicTest : JsonTestBase() {
     fun testNestedPolymorphicProperties() = assertJsonFormAndRestored(
         OuterBox.serializer(),
         OuterBox(OuterImpl(InnerImpl(42), InnerImpl2(42)), InnerImpl2(239)),
-        "{outerBase:{" +
-                "type:kotlinx.serialization.json.polymorphic.OuterImpl," +
-                "base:{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:42,str:default,nullable:null}," +
-                "base2:{type:kotlinx.serialization.json.polymorphic.InnerImpl2,field:42}}," +
-                "innerBase:{type:kotlinx.serialization.json.polymorphic.InnerImpl2,field:239}}",
+        """{"outerBase":{""" +
+                """"type":"kotlinx.serialization.json.polymorphic.OuterImpl",""" +
+                """"base":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":42,"str":"default","nullable":null},""" +
+                """"base2":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl2","field":42}},""" +
+                """"innerBase":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl2","field":239}}""",
         polymorphicRelaxedJson)
 
     @Test
     fun testPolymorphicNullableProperties() = assertJsonFormAndRestored(
         InnerNullableBox.serializer(),
         InnerNullableBox(InnerImpl(42, "foo")),
-        "{base:{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:42,str:foo,nullable:null}}",
+        """{"base":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl",""" +
+                """"field":42,"str":"foo","nullable":null}}""",
         polymorphicRelaxedJson)
 
     @Test
@@ -52,9 +55,9 @@ class JsonPropertyPolymorphicTest : JsonTestBase() {
     fun testNestedPolymorphicNullableProperties() = assertJsonFormAndRestored(
         OuterNullableBox.serializer(),
         OuterNullableBox(OuterNullableImpl(InnerImpl(42), null), InnerImpl2(239)),
-        "{outerBase:{" +
-                "type:kotlinx.serialization.json.polymorphic.OuterNullableImpl," +
-                "base:{type:kotlinx.serialization.json.polymorphic.InnerImpl,field:42,str:default,nullable:null},base2:null}," +
-                "innerBase:{type:kotlinx.serialization.json.polymorphic.InnerImpl2,field:239}}",
+        """{"outerBase":{""" +
+                """"type":"kotlinx.serialization.json.polymorphic.OuterNullableImpl",""" +
+                """"base":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl","field":42,"str":"default","nullable":null},"base2":null},""" +
+                """"innerBase":{"type":"kotlinx.serialization.json.polymorphic.InnerImpl2","field":239}}""",
         polymorphicRelaxedJson)
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/PolymorphicClasses.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/PolymorphicClasses.kt
@@ -55,7 +55,6 @@ internal val polymorphicJson = Json {
 }
 
 internal val polymorphicRelaxedJson = Json {
-    unquotedPrint = true
     isLenient = true
     serialModule = polymorphicTestModule
 }

--- a/runtime/jvmTest/src/kotlinx/serialization/SerializationCasesTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/SerializationCasesTest.kt
@@ -83,10 +83,11 @@ class SerializationCasesTest : JsonTestBase() {
     @Test
     fun testNestedValues() {
         val data = Data3("Str", listOf(1, 2), mapOf("lt" to TintEnum.LIGHT, "dk" to TintEnum.DARK))
-//        // Serialize with internal serializer for Data class
-        assertEquals("{a:Str,b:[1,2],c:{lt:LIGHT,dk:DARK}}", unquoted.stringify(data))
-        assertEquals(data, Json.parse<Data3>("""{"a":"Str","b":[1,2],"c":{"lt":"LIGHT","dk":"DARK"}}"""))
-        assertEquals("{a:Str,b:[1,2],c:{lt:LIGHT,dk:DARK}}", unquoted.stringify(ExtDataSerializer3, data))
-        assertEquals(data, Json.parse(ExtDataSerializer3, """{"a":"Str","b":[1,2],"c":{"lt":"LIGHT","dk":"DARK"}}"""))
+        // Serialize with internal serializer for Data class
+        val expected = """{"a":"Str","b":[1,2],"c":{"lt":"LIGHT","dk":"DARK"}}"""
+        assertEquals(expected, default.stringify(data))
+        assertEquals(data, Json.parse<Data3>(expected))
+        assertEquals(expected, default.stringify(ExtDataSerializer3, data))
+        assertEquals(data, Json.parse(ExtDataSerializer3, expected))
     }
 }

--- a/runtime/jvmTest/src/kotlinx/serialization/features/InternalInheritanceTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/InternalInheritanceTest.kt
@@ -55,12 +55,13 @@ class InternalInheritanceTest : JsonTestBase() {
     @Test
     fun testStringify() {
         assertEquals(
-                "{parent:42,rootOptional:rootOptional,parent2:42,derived:derived,bodyDerived:body,parent3:42,lastDerived:optional}",
-                Json { unquotedPrint = true }.stringify(C(42))
+            """{"parent":42,"rootOptional":"rootOptional","parent2":42,"derived":"derived",""" +
+                    """"bodyDerived":"body","parent3":42,"lastDerived":"optional"}""",
+            default.stringify(C(42))
         )
         assertEquals(
-                "{parent:13,rootOptional:rootOptional,parent2:13,derived:bbb,bodyDerived:body}",
-                Json { unquotedPrint = true }.stringify(B(13, derived = "bbb"))
+            """{"parent":13,"rootOptional":"rootOptional","parent2":13,"derived":"bbb","bodyDerived":"body"}""",
+            default.stringify(B(13, derived = "bbb"))
         )
     }
 
@@ -68,11 +69,15 @@ class InternalInheritanceTest : JsonTestBase() {
     fun testParse() {
         assertEquals(
             C(42),
-            unquotedLenient.parse<C>("{parent:42,rootOptional:rootOptional,parent2:42,derived:derived,bodyDerived:body,parent3:42,lastDerived:optional}")
+            default.parse<C>(
+                """{"parent":42,"rootOptional":"rootOptional","parent2":42,""" +
+                        """"derived":"derived","bodyDerived":"body","parent3":42,"lastDerived":"optional"}"""
+            )
         )
         assertEquals(
             C(43),
-            unquotedLenient.parse<C>("{parent:43,rootOptional:rootOptional,parent2:43,derived:derived,bodyDerived:body,parent3:43,lastDerived:optional}")
+            default.parse<C>("""{"parent":43,"rootOptional":"rootOptional","parent2":43,"derived":"derived",""" +
+                    """"bodyDerived":"body","parent3":43,"lastDerived":"optional"}""")
         )
     }
 
@@ -80,34 +85,36 @@ class InternalInheritanceTest : JsonTestBase() {
     fun testParseOptionals() {
         assertEquals(
             B(100, derived = "wowstring"),
-            unquotedLenient.parse<B>("{parent:100,rootOptional:rootOptional,parent2:100,derived:wowstring,bodyDerived:body}")
+            default.parse<B>("""{"parent":100,"rootOptional":"rootOptional","parent2":100,"derived":"wowstring","bodyDerived":"body"}""")
         )
         assertEquals(
             C(44),
-            unquotedLenient.parse<C>("{parent:44, parent2:44,derived:derived,bodyDerived:body,parent3:44}")
+            default.parse<C>("""{"parent":44, "parent2":44,"derived":"derived","bodyDerived":"body","parent3":44}""")
         )
         assertEquals(
             B(101, derived = "wowstring"),
-            unquotedLenient.parse<B>("{parent:101,parent2:101,derived:wowstring,bodyDerived:body}")
+            default.parse<B>("""{"parent":101,"parent2":101,"derived":"wowstring","bodyDerived":"body"}""")
         )
         assertEquals(
             A(77),
-            unquotedLenient.parse<A>("{parent:77,rootOptional:rootOptional}")
+            default.parse<A>("""{"parent":77,"rootOptional":"rootOptional"}""")
         )
         assertEquals(
             A(78),
-            unquotedLenient.parse<A>("{parent:78}")
+            default.parse<A>("""{"parent":78}""")
         )
     }
 
     @Test(expected = SerializationException::class)
     fun testThrowTransient() {
-        Json(JsonConfiguration.Stable).parse<B>("""{"parent":100,"rootOptional":"rootOptional","transientDerived":"X","parent2":100,"derived":"wowstring","bodyDerived":"body"}""")
+        Json(JsonConfiguration.Stable).parse<B>("""{"parent":100,"rootOptional":"rootOptional","transientDerived":"X",""" +
+                """"parent2":100,"derived":"wowstring","bodyDerived":"body"}""")
     }
 
     @Test(expected = SerializationException::class)
     fun testThrowMissingField() {
-        unquotedLenient.parse<C>("{parent:42,rootOptional:rootOptional,derived:derived,bodyDerived:body,parent3:42,lastDerived:optional}")
+        default.parse<C>("""{"parent":42,"rootOptional":"rootOptional","derived":"derived",""" +
+                """"bodyDerived":"body","parent3":42,"lastDerived":"optional"}""")
     }
 
     @Test

--- a/runtime/jvmTest/src/kotlinx/serialization/features/JsonUpdateCustomTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/JsonUpdateCustomTest.kt
@@ -30,7 +30,7 @@ class JsonUpdateCustomTest : JsonTestBase() {
 
     @Test
     fun canUpdateCustom() {
-        val parsed: Updatable = unquotedLenient.parse("""{d:{a:42},d:{a:43}}""")
+        val parsed: Updatable = default.parse("""{"d":{"a":"42"},"d":{"a":43}}""")
         assertEquals(Data(43), parsed.d)
     }
 

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.*
 
 class SerializerByTypeTest {
 
-    val unquoted = Json { unquotedPrint = true }
+    val json = Json { }
 
     @Serializable
     data class Box<out T>(val a: T)
@@ -51,8 +51,8 @@ class SerializerByTypeTest {
     fun testGenericParameter() {
         val b = Box(42)
         val serial = serializerByTypeToken(IntBoxToken)
-        val s = unquoted.stringify(serial, b)
-        assertEquals("{a:42}", s)
+        val s = json.stringify(serial, b)
+        assertEquals("""{"a":42}""", s)
     }
 
     @Test
@@ -60,8 +60,8 @@ class SerializerByTypeTest {
         val myArr = arrayOf("a", "b", "c")
         val token = myArr::class.java
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myArr)
-        assertEquals("[a,b,c]", s)
+        val s = json.stringify(serial, myArr)
+        assertEquals("""["a","b","c"]""", s)
     }
 
     @Test
@@ -73,8 +73,8 @@ class SerializerByTypeTest {
             override fun getActualTypeArguments(): Array<Type> = arrayOf(String::class.java)
         }
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myArr)
-        assertEquals("[a,b,c]", s)
+        val s = json.stringify(serial, myArr)
+        assertEquals("""["a","b","c"]""", s)
     }
 
 
@@ -83,8 +83,8 @@ class SerializerByTypeTest {
         val myArr = arrayOf("a", "b", "c")
         val token = typeTokenOf<Array<String>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myArr)
-        assertEquals("[a,b,c]", s)
+        val s = json.stringify(serial, myArr)
+        assertEquals("""["a","b","c"]""", s)
     }
 
     @Test
@@ -92,8 +92,8 @@ class SerializerByTypeTest {
         val myList = listOf("a", "b", "c")
         val token = typeTokenOf<List<String>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myList)
-        assertEquals("[a,b,c]", s)
+        val s = json.stringify(serial, myList)
+        assertEquals("""["a","b","c"]""", s)
     }
 
     @Test
@@ -101,8 +101,8 @@ class SerializerByTypeTest {
         val mySet = setOf("a", "b", "c", "c")
         val token = typeTokenOf<Set<String>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, mySet)
-        assertEquals("[a,b,c]", s)
+        val s = json.stringify(serial, mySet)
+        assertEquals("""["a","b","c"]""", s)
     }
 
     @Test
@@ -110,8 +110,8 @@ class SerializerByTypeTest {
         val myMap = mapOf("a" to Data(listOf("c"), Box(6)))
         val token = typeTokenOf<Map<String, Data>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myMap)
-        assertEquals("{a:{l:[c],b:{a:6}}}", s)
+        val s = json.stringify(serial, myMap)
+        assertEquals("""{"a":{"l":["c"],"b":{"a":6}}}""", s)
     }
 
     @Test
@@ -119,7 +119,7 @@ class SerializerByTypeTest {
         val myList = listOf(listOf(listOf(1, 2, 3)), listOf())
         val token = typeTokenOf<List<List<List<Int>>>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myList)
+        val s = json.stringify(serial, myList)
         assertEquals("[[[1,2,3]],[]]", s)
     }
 
@@ -128,7 +128,7 @@ class SerializerByTypeTest {
         val myList = arrayOf(arrayOf(arrayOf(1, 2, 3)), arrayOf())
         val token = typeTokenOf<Array<Array<Array<Int>>>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myList)
+        val s = json.stringify(serial, myList)
         assertEquals("[[[1,2,3]],[]]", s)
     }
 
@@ -137,7 +137,7 @@ class SerializerByTypeTest {
         val myList = arrayOf(listOf(arrayOf(1, 2, 3)), listOf())
         val token = typeTokenOf<Array<List<Array<Int>>>>()
         val serial = serializerByTypeToken(token)
-        val s = unquoted.stringify(serial, myList)
+        val s = json.stringify(serial, myList)
         assertEquals("[[[1,2,3]],[]]", s)
     }
 
@@ -145,13 +145,13 @@ class SerializerByTypeTest {
     fun testGenericInHolder() {
         val b = Data(listOf("a", "b", "c"), Box(42))
         val serial = serializerByTypeToken(Data::class.java)
-        val s = unquoted.stringify(serial, b)
-        assertEquals("{l:[a,b,c],b:{a:42}}", s)
+        val s = json.stringify(serial, b)
+        assertEquals("""{"l":["a","b","c"],"b":{"a":42}}""", s)
     }
 
     @Test
     fun testOverriddenSerializer() {
-        val foo = unquoted.parse<WithCustomDefault>("9")
+        val foo = json.parse<WithCustomDefault>("9")
         assertEquals(9, foo.n)
     }
 
@@ -159,8 +159,8 @@ class SerializerByTypeTest {
     fun testNamedCompanion() {
         val namedCompanion = WithNamedCompanion(1)
         val serial = serializerByTypeToken(WithNamedCompanion::class.java)
-        val s = unquoted.stringify(serial, namedCompanion)
-        assertEquals("{a:1}", s)
+        val s = json.stringify(serial, namedCompanion)
+        assertEquals("""{"a":1}""", s)
     }
 
     @Test


### PR DESCRIPTION
Only tests are affected.
The point is to reduce the scope of further reviews