### PR TITLE
[API stabilization] Exceptions rework

### DIFF
--- a/formats/properties/commonTest/src/kotlinx/serialization/PropertiesTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/PropertiesTest.kt
@@ -158,7 +158,7 @@ class PropertiesTest {
     @Test
     fun testThrowsOnIncorrectMaps() {
         val map: Map<String, Any?> = mapOf("name" to "Name")
-        assertFailsWith<MissingFieldException> {
+        assertFailsWith<SerializationException> {
             Properties.loadNullable<Data>(Data.serializer(), map)
         }
     }

--- a/integration-test/src/commonTest/kotlin/sample/JsonTest.kt
+++ b/integration-test/src/commonTest/kotlin/sample/JsonTest.kt
@@ -97,7 +97,7 @@ class JsonTest {
         val d2 = Json.decodeFromString(SerializableBase.serializer(), msg)
         assertEquals(SerializableBase(), d2)
         // no derivedState
-        assertFailsWith<MissingFieldException> { Json.decodeFromString(Derived.serializer(), msg) }
+        assertFailsWith<SerializationException> { Json.decodeFromString(Derived.serializer(), msg) }
     }
 
     @Test

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -398,9 +398,11 @@ public abstract interface annotation class kotlinx/serialization/Serializable : 
 	public abstract fun with ()Ljava/lang/Class;
 }
 
-public class kotlinx/serialization/SerializationException : java/lang/RuntimeException {
+public class kotlinx/serialization/SerializationException : java/lang/IllegalArgumentException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Throwable;)V
 }
 
 public abstract interface class kotlinx/serialization/SerializationStrategy {
@@ -474,10 +476,6 @@ public final class kotlinx/serialization/UpdateMode : java/lang/Enum {
 	public static final field UPDATE Lkotlinx/serialization/UpdateMode;
 	public static fun valueOf (Ljava/lang/String;)Lkotlinx/serialization/UpdateMode;
 	public static fun values ()[Lkotlinx/serialization/UpdateMode;
-}
-
-public final class kotlinx/serialization/UpdateNotSupportedException : kotlinx/serialization/SerializationException {
-	public fun <init> (Ljava/lang/String;)V
 }
 
 public abstract interface annotation class kotlinx/serialization/UseSerializers : java/lang/annotation/Annotation {
@@ -1505,10 +1503,6 @@ public final class kotlinx/serialization/json/JsonDecoder$DefaultImpls {
 	public static fun updateSerializableValue (Lkotlinx/serialization/json/JsonDecoder;Lkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class kotlinx/serialization/json/JsonDecodingException : kotlinx/serialization/json/JsonException {
-	public fun <init> (ILjava/lang/String;)V
-}
-
 public abstract class kotlinx/serialization/json/JsonElement {
 	public static final field Companion Lkotlinx/serialization/json/JsonElement$Companion;
 }
@@ -1572,14 +1566,6 @@ public final class kotlinx/serialization/json/JsonEncoder$DefaultImpls {
 	public static fun encodeNullableSerializableValue (Lkotlinx/serialization/json/JsonEncoder;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public static fun encodeSerializableValue (Lkotlinx/serialization/json/JsonEncoder;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public static fun shouldEncodeElementDefault (Lkotlinx/serialization/json/JsonEncoder;Lkotlinx/serialization/SerialDescriptor;I)Z
-}
-
-public final class kotlinx/serialization/json/JsonEncodingException : kotlinx/serialization/json/JsonException {
-	public fun <init> (Ljava/lang/String;)V
-}
-
-public class kotlinx/serialization/json/JsonException : kotlinx/serialization/SerializationException {
-	public fun <init> (Ljava/lang/String;)V
 }
 
 public abstract interface class kotlinx/serialization/json/JsonInput {

--- a/runtime/commonMain/src/kotlinx/serialization/KSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/KSerializer.kt
@@ -62,7 +62,7 @@ public interface KSerializer<T> : SerializationStrategy<T>, DeserializationStrat
     override val descriptor: SerialDescriptor
 
     @Deprecated(patchDeprecated, level = DeprecationLevel.ERROR)
-    override fun patch(decoder: Decoder, old: T): T = throw UpdateNotSupportedException(descriptor.serialName)
+    override fun patch(decoder: Decoder, old: T): T = throw UnsupportedOperationException("Not implemented, should not be called")
 }
 
 /**

--- a/runtime/commonMain/src/kotlinx/serialization/SerializationException.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SerializationException.kt
@@ -5,10 +5,11 @@
 package kotlinx.serialization
 
 /**
- * A generic exception indicating the problem during serialization or deserialization process.
+ * A generic exception indicating the problem in serialization or deserialization process.
  * This is a generic exception type that can be thrown during the problem at any stage of the serialization,
  * including encoding, decoding, serialization, deserialization.
- * [SerialFormat] implementors should throw the subclass of this exception at any
+ * [SerialFormat] implementors should throw subclasses of this exception at any unexpected event,
+ * whether it is a malformed input or unsupported class layout.
  */
 public open class SerializationException : IllegalArgumentException {
     /*
@@ -17,7 +18,7 @@ public open class SerializationException : IllegalArgumentException {
      * it is a serializer that does not support specific structure or an invalid input.
      * Making it IAE just aligns the implementation with this fact.
      *
-     * Another point is input validation. The most simple way to validate
+     * Another point is input validation. The simplest way to validate
      * deserialized data is `require` in `init` block:
      * ```
      * @Serializable class Foo(...) {
@@ -47,8 +48,7 @@ public open class SerializationException : IllegalArgumentException {
     public constructor(message: String?) : super(message)
 
     /**
-     * Creates an instance of [SerializationException] with the specified detail [message]
-     * and the given [cause].
+     * Creates an instance of [SerializationException] with the specified detail [message], and the given [cause].
      */
     public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
@@ -71,4 +71,4 @@ internal class MissingFieldException(fieldName: String) :
  * This exception means that data schema has changed in backwards-incompatible way.
  */
 @PublishedApi
-internal class UnknownFieldException(index: Int) : SerializationException("Unknown field for index $index")
+internal class UnknownFieldException(index: Int) : SerializationException("An unknown field for index $index")

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -52,7 +52,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     /**
      * Serializes the [value] into an equivalent JSON using the given [serializer].
      *
-     * @throws [SerializationException] if the given value can not be serializedto JSON.
+     * @throws [SerializationException] if the given value cannot be serialized to JSON.
      */
     public final override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
         val result = StringBuilder()
@@ -87,18 +87,18 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     }
 
     /**
-     * Deserializes the given [json] element into a value of type [T] using the given [deserializer].
+     * Deserializes the given [element] element into a value of type [T] using the given [deserializer].
      *
      * @throws [SerializationException] if the given JSON string cannot be deserialized to the value of type [T].
      */
-    public fun <T> decodeFromJsonElement(deserializer: DeserializationStrategy<T>, json: JsonElement): T {
-        return readJson(json, deserializer)
+    public fun <T> decodeFromJsonElement(deserializer: DeserializationStrategy<T>, element: JsonElement): T {
+        return readJson(element, deserializer)
     }
 
     /**
      * Deserializes the given JSON [string] into a corresponding [JsonElement] representation.
      *
-     * @throws [SerializationException] if given input cannot be deserialized.
+     * @throws [SerializationException] if the given JSON string is malformed and cannot be deserialized.
      */
     public fun parseToJsonElement(string: String): JsonElement {
         return decodeFromString(JsonElementSerializer, string)
@@ -131,7 +131,7 @@ public fun Json(block: JsonBuilder.() -> Unit): Json = JsonImpl(JsonBuilder().ap
  * Serializes the given [value] into an equivalent [JsonElement] using a serializer retrieved
  * from reified type parameter.
  *
- * @throws [SerializationException] if the given value cannot be serialized.
+ * @throws [SerializationException] if the given value cannot be serialized to JSON.
  */
 public inline fun <reified T : Any> Json.encodeToJsonElement(value: T): JsonElement {
     return encodeToJsonElement(context.getContextualOrDefault(), value)
@@ -141,7 +141,7 @@ public inline fun <reified T : Any> Json.encodeToJsonElement(value: T): JsonElem
  * Deserializes the given [json] element into a value of type [T] using a deserialize retrieved
  * from reified type parameter.
  *
- * @throws [SerializationException] if the given JSON string and cannot be deserialized to the value of type [T].
+ * @throws [SerializationException] if the given JSON string is malformed or cannot be deserialized to the value of type [T].
  */
 public inline fun <reified T : Any> Json.decodeFromJsonElement(tree: JsonElement): T =
     decodeFromJsonElement(context.getContextualOrDefault(), tree)

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -51,8 +51,8 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
 
     /**
      * Serializes the [value] into an equivalent JSON using the given [serializer].
-     * @throws [JsonException] if the given value can not be encoded to JSON
-     * @throws [SerializationException] if the given value cannot be serialized
+     *
+     * @throws [SerializationException] if the given value can not be serializedto JSON.
      */
     public final override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
         val result = StringBuilder()
@@ -68,8 +68,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     /**
      * Deserializes the given JSON [string] into a value of type [T] using the given [deserializer].
      *
-     * @throws [JsonException] if the given JSON string is malformed and cannot be decoded.
-     * @throws [SerializationException] if the given input cannot be deserialized.
+     * @throws [SerializationException] if the given JSON string cannot be deserialized to the value of type [T].
      */
     public final override fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, string: String): T {
         val reader = JsonReader(string)
@@ -81,8 +80,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     /**
      * Serializes the given [value] into an equivalent [JsonElement] using the given [serializer]
      *
-     * @throws [JsonException] if the given value can not be encoded.
-     * @throws [SerializationException] if the given value can not be serialized.
+     * @throws [SerializationException] if the given value cannot be serialized.
      */
     public fun <T> encodeToJsonElement(serializer: SerializationStrategy<T>, value: T): JsonElement {
         return writeJson(value, serializer)
@@ -91,8 +89,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     /**
      * Deserializes the given [json] element into a value of type [T] using the given [deserializer].
      *
-     * @throws [JsonException] if the given JSON string is malformed and cannot be decoded.
-     * @throws [SerializationException] if the given input can not be deserialized.
+     * @throws [SerializationException] if the given JSON string cannot be deserialized to the value of type [T].
      */
     public fun <T> decodeFromJsonElement(deserializer: DeserializationStrategy<T>, json: JsonElement): T {
         return readJson(json, deserializer)
@@ -101,8 +98,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     /**
      * Deserializes the given JSON [string] into a corresponding [JsonElement] representation.
      *
-     * @throws [JsonException] in case of malformed json
-     * @throws [SerializationException] if given input can not be deserialized
+     * @throws [SerializationException] if given input cannot be deserialized.
      */
     public fun parseToJsonElement(string: String): JsonElement {
         return decodeFromString(JsonElementSerializer, string)
@@ -135,8 +131,7 @@ public fun Json(block: JsonBuilder.() -> Unit): Json = JsonImpl(JsonBuilder().ap
  * Serializes the given [value] into an equivalent [JsonElement] using a serializer retrieved
  * from reified type parameter.
  *
- * @throws [JsonException] if the given value can not be encoded.
- * @throws [SerializationException] if the given value can not be serialized.
+ * @throws [SerializationException] if the given value cannot be serialized.
  */
 public inline fun <reified T : Any> Json.encodeToJsonElement(value: T): JsonElement {
     return encodeToJsonElement(context.getContextualOrDefault(), value)
@@ -146,8 +141,7 @@ public inline fun <reified T : Any> Json.encodeToJsonElement(value: T): JsonElem
  * Deserializes the given [json] element into a value of type [T] using a deserialize retrieved
  * from reified type parameter.
  *
- * @throws [JsonException] if the given JSON string is malformed and cannot be decoded.
- * @throws [SerializationException] if the given input can not be deserialized.
+ * @throws [SerializationException] if the given JSON string and cannot be deserialized to the value of type [T].
  */
 public inline fun <reified T : Any> Json.decodeFromJsonElement(tree: JsonElement): T =
     decodeFromJsonElement(context.getContextualOrDefault(), tree)

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -87,7 +87,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     }
 
     /**
-     * Deserializes the given [element] element into a value of type [T] using the given [deserializer].
+     * Deserializes the given [element] into a value of type [T] using the given [deserializer].
      *
      * @throws [SerializationException] if the given JSON string cannot be deserialized to the value of type [T].
      */
@@ -98,7 +98,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     /**
      * Deserializes the given JSON [string] into a corresponding [JsonElement] representation.
      *
-     * @throws [SerializationException] if the given JSON string is malformed and cannot be deserialized.
+     * @throws [SerializationException] if the given JSON string is malformed and cannot be deserialized.g
      */
     public fun parseToJsonElement(string: String): JsonElement {
         return decodeFromString(JsonElementSerializer, string)

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -141,28 +141,28 @@ public class JsonArray(private val content: List<JsonElement>) : JsonElement(), 
 
 /**
  * Convenience method to get current element as [JsonPrimitive]
- * @throws JsonException if current element is not a [JsonPrimitive]
+ * @throws IllegalArgumentException if current element is not a [JsonPrimitive]
  */
 public val JsonElement.jsonPrimitive: JsonPrimitive
     get() = this as? JsonPrimitive ?: error("JsonPrimitive")
 
 /**
  * Convenience method to get current element as [JsonObject]
- * @throws JsonException if current element is not a [JsonObject]
+ * @throws IllegalArgumentException if current element is not a [JsonObject]
  */
 public val JsonElement.jsonObject: JsonObject
     get() = this as? JsonObject ?: error("JsonObject")
 
 /**
  * Convenience method to get current element as [JsonArray]
- * @throws JsonException if current element is not a [JsonArray]
+ * @throws IllegalArgumentException if current element is not a [JsonArray]
  */
 public val JsonElement.jsonArray: JsonArray
     get() = this as? JsonArray ?: error("JsonArray")
 
 /**
  * Convenience method to get current element as [JsonNull]
- * @throws JsonException if current element is not a [JsonNull]
+ * @throws IllegalArgumentException if current element is not a [JsonNull]
  */
 public val JsonElement.jsonNull: JsonNull
     get() = this as? JsonNull ?: error("JsonNull")
@@ -228,8 +228,8 @@ public val JsonPrimitive.booleanOrNull: Boolean? get() = content.toBooleanStrict
 public val JsonPrimitive.contentOrNull: String? get() = if (this is JsonNull) null else content
 
 private fun JsonElement.error(element: String): Nothing =
-    throw JsonException("Element ${this::class} is not a $element")
+    throw IllegalArgumentException("Element ${this::class} is not a $element")
 
 @PublishedApi
 internal fun unexpectedJson(key: String, expected: String): Nothing =
-    throw JsonException("Element $key is not a $expected")
+    throw IllegalArgumentException("Element $key is not a $expected")

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonExceptions.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonExceptions.kt
@@ -11,18 +11,18 @@ import kotlinx.serialization.*
 /**
  * Generic exception indicating a problem with JSON serialization and deserialization.
  */
-public open class JsonException(message: String) : SerializationException(message)
+internal open class JsonException(message: String) : SerializationException(message)
 
 /**
  * Thrown when [Json] has failed to parse the given JSON string or deserialize it to a target class.
  */
-public class JsonDecodingException(offset: Int, message: String) :
+internal class JsonDecodingException(offset: Int, message: String) :
     JsonException("Unexpected JSON token at offset $offset: $message")
 
 /**
  * Thrown when [Json] has failed to create a JSON string from the given value.
  */
-public class JsonEncodingException(message: String) : JsonException(message)
+internal class JsonEncodingException(message: String) : JsonException(message)
 
 internal fun JsonDecodingException(offset: Int, message: String, input: String) =
     JsonDecodingException(offset, "$message.\n JSON input: ${input.minify(offset)}")

--- a/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -91,7 +91,7 @@ class JsonTreeTest : JsonTestBase() {
         val tree =
             JsonObject(mapOf("a" to JsonPrimitive(42), "b" to JsonArray(listOf(JsonNull)), "c" to JsonPrimitive(false)))
         assertFailsWith<NoSuchElementException> { tree.getValue("no key").jsonObject }
-        assertFailsWith<JsonException> { tree.getValue("a").jsonArray }
+        assertFailsWith<IllegalArgumentException> { tree.getValue("a").jsonArray }
         assertEquals(null, tree["no key"]?.jsonObject)
         assertEquals(null, tree["a"] as? JsonArray)
 


### PR DESCRIPTION
    * Make SerializationException descendant of IllegalArgumentException, provide full-blown constructors capabilities
    * Hide JsonException family, MissingFieldException and UnknownFieldException from public API
    * Remove obsolete UpdateNotSupportedException