### PR TITLE
[API stabilization] Encoder and Decoder

### DIFF
--- a/formats/config/src/main/kotlin/kotlinx/serialization/config/ConfigReader.kt
+++ b/formats/config/src/main/kotlin/kotlinx/serialization/config/ConfigReader.kt
@@ -6,16 +6,16 @@ package kotlinx.serialization.config
 
 import com.typesafe.config.*
 import kotlinx.serialization.*
-import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
+import kotlinx.serialization.CompositeDecoder.Companion.DECODE_DONE
 
 private val SerialKind.listLike get() = this == StructureKind.LIST || this is PolymorphicKind
 private val SerialKind.objLike get() = this == StructureKind.CLASS || this == StructureKind.OBJECT
 
 /**
  * Allows [deserialization][parse]
- * of [Config] object from popular Lighbend/config library into Kotlin objects.
+ * of [Config] object from popular Lightbend/config library into Kotlin objects.
  *
  * [Config] object represents "Human-Optimized Config Object Notation" —
  * [HOCON][https://github.com/lightbend/config#using-hocon-the-json-superset].
@@ -32,11 +32,11 @@ public class ConfigParser(
     public inline fun <reified T : Any> parse(conf: Config): T = parse(conf, context.getContextualOrDefault())
 
     public fun <T> parse(conf: Config, deserializer: DeserializationStrategy<T>): T =
-        ConfigReader(conf).decode(deserializer)
+        ConfigReader(conf).decodeSerializableValue(deserializer)
 
 
     private abstract inner class ConfigConverter<T> : TaggedDecoder<T>() {
-        override val context: SerialModule
+        override val serializersModule: SerialModule
             get() = this@ConfigParser.context
 
         abstract fun getTaggedConfigValue(tag: T): ConfigValue
@@ -84,7 +84,7 @@ public class ConfigParser(
                     return ind
                 }
             }
-            return READ_DONE
+            return DECODE_DONE
         }
 
         private fun composeName(parentName: String, childName: String) =
@@ -131,7 +131,7 @@ public class ConfigParser(
 
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             ind++
-            return if (ind > list.size - 1) READ_DONE else ind
+            return if (ind > list.size - 1) DECODE_DONE else ind
         }
 
         override fun getTaggedConfigValue(tag: Int): ConfigValue = list[tag]
@@ -163,7 +163,7 @@ public class ConfigParser(
 
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             ind++
-            return if (ind >= indexSize) READ_DONE else ind
+            return if (ind >= indexSize) CompositeDecoder.DECODE_DONE else ind
         }
 
         override fun getTaggedConfigValue(tag: Int): ConfigValue {

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedDecoder.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedDecoder.kt
@@ -92,12 +92,4 @@ internal abstract class ProtobufTaggedDecoder : ProtobufTaggedBase(), Decoder, C
             decodeNull()
         }
     }
-
-    override fun decodeUnit() {
-        error("Should not be called")
-    }
-
-    override fun decodeUnitElement(descriptor: SerialDescriptor, index: Int) {
-        error("Should not be called")
-    }
 }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
@@ -129,12 +129,4 @@ internal abstract class ProtobufTaggedEncoder : ProtobufTaggedBase(), Encoder, C
         pushTag(descriptor.getTag(index))
         encodeNullableSerializableValue(serializer, value)
     }
-
-    override fun encodeUnit() {
-        error("Should not be called")
-    }
-
-    override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int) {
-        error("Should not be called")
-    }
 }

--- a/integration-test/src/commonTest/kotlin/sample/BasicTypesSerializationTest.kt
+++ b/integration-test/src/commonTest/kotlin/sample/BasicTypesSerializationTest.kt
@@ -137,7 +137,7 @@ class BasicTypesSerializationTest {
             inp.skipWhitespace(',')
             val name = inp.nextUntil(':', '}')
             if (name.isEmpty())
-                return READ_DONE
+                return CompositeDecoder.DECODE_DONE
             val index = desc.getElementIndexOrThrow(name)
             inp.expect(':')
             return index
@@ -228,11 +228,11 @@ class BasicTypesSerializationTest {
         // serialize to string
         val sb = StringBuilder()
         val out = KeyValueOutput(sb)
-        out.encode(TypesUmbrella.serializer(), data)
+        out.encodeSerializableValue(TypesUmbrella.serializer(), data)
         // deserialize from string
         val str = sb.toString()
         val inp = KeyValueInput(Parser(StringReader(str)))
-        val other = inp.decode(TypesUmbrella.serializer())
+        val other = inp.decodeSerializableValue(TypesUmbrella.serializer())
         // assert we've got it back from string
         assertEquals(data, other)
         assertNotSame(data, other)

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -10,6 +10,7 @@ public abstract interface class kotlinx/serialization/BinaryFormat : kotlinx/ser
 
 public abstract interface class kotlinx/serialization/CompositeDecoder {
 	public static final field Companion Lkotlinx/serialization/CompositeDecoder$Companion;
+	public static final field DECODE_DONE I
 	public static final field READ_ALL I
 	public static final field READ_DONE I
 	public static final field UNKNOWN_NAME I
@@ -29,15 +30,15 @@ public abstract interface class kotlinx/serialization/CompositeDecoder {
 	public abstract fun decodeSerializableElement (Lkotlinx/serialization/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun decodeShortElement (Lkotlinx/serialization/SerialDescriptor;I)S
 	public abstract fun decodeStringElement (Lkotlinx/serialization/SerialDescriptor;I)Ljava/lang/String;
-	public abstract fun decodeUnitElement (Lkotlinx/serialization/SerialDescriptor;I)V
 	public abstract fun endStructure (Lkotlinx/serialization/SerialDescriptor;)V
-	public abstract fun getContext ()Lkotlinx/serialization/modules/SerialModule;
+	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	public abstract fun getUpdateMode ()Lkotlinx/serialization/UpdateMode;
 	public abstract fun updateNullableSerializableElement (Lkotlinx/serialization/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun updateSerializableElement (Lkotlinx/serialization/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class kotlinx/serialization/CompositeDecoder$Companion {
+	public static final field DECODE_DONE I
 	public static final field READ_ALL I
 	public static final field READ_DONE I
 	public static final field UNKNOWN_NAME I
@@ -70,9 +71,8 @@ public abstract interface class kotlinx/serialization/CompositeEncoder {
 	public abstract fun encodeSerializableElement (Lkotlinx/serialization/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public abstract fun encodeShortElement (Lkotlinx/serialization/SerialDescriptor;IS)V
 	public abstract fun encodeStringElement (Lkotlinx/serialization/SerialDescriptor;ILjava/lang/String;)V
-	public abstract fun encodeUnitElement (Lkotlinx/serialization/SerialDescriptor;I)V
 	public abstract fun endStructure (Lkotlinx/serialization/SerialDescriptor;)V
-	public abstract fun getContext ()Lkotlinx/serialization/modules/SerialModule;
+	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	public abstract fun shouldEncodeElementDefault (Lkotlinx/serialization/SerialDescriptor;I)Z
 }
 
@@ -115,8 +115,7 @@ public abstract interface class kotlinx/serialization/Decoder {
 	public abstract fun decodeSerializableValue (Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
 	public abstract fun decodeShort ()S
 	public abstract fun decodeString ()Ljava/lang/String;
-	public abstract fun decodeUnit ()V
-	public abstract fun getContext ()Lkotlinx/serialization/modules/SerialModule;
+	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	public abstract fun getUpdateMode ()Lkotlinx/serialization/UpdateMode;
 	public abstract fun updateNullableSerializableValue (Lkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun updateSerializableValue (Lkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
@@ -133,7 +132,6 @@ public final class kotlinx/serialization/Decoder$DefaultImpls {
 }
 
 public final class kotlinx/serialization/DecodingKt {
-	public static final fun decode (Lkotlinx/serialization/Decoder;Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
 	public static final fun decodeStructure (Lkotlinx/serialization/Decoder;Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
@@ -162,8 +160,7 @@ public abstract interface class kotlinx/serialization/Encoder {
 	public abstract fun encodeSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public abstract fun encodeShort (S)V
 	public abstract fun encodeString (Ljava/lang/String;)V
-	public abstract fun encodeUnit ()V
-	public abstract fun getContext ()Lkotlinx/serialization/modules/SerialModule;
+	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 }
 
 public final class kotlinx/serialization/Encoder$DefaultImpls {
@@ -177,7 +174,6 @@ public final class kotlinx/serialization/Encoder$DefaultImpls {
 }
 
 public final class kotlinx/serialization/EncodingKt {
-	public static final fun encode (Lkotlinx/serialization/Encoder;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public static final fun encodeStructure (Lkotlinx/serialization/Encoder;Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)V
 }
 
@@ -202,10 +198,14 @@ public final class kotlinx/serialization/Mapper {
 
 public final class kotlinx/serialization/MigrationsKt {
 	public static final fun compiledSerializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
+	public static final fun decode (Lkotlinx/serialization/Decoder;)Ljava/lang/Object;
+	public static final fun decode (Lkotlinx/serialization/Decoder;Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
 	public static final fun dump (Lkotlinx/serialization/BinaryFormat;Ljava/lang/Object;)[B
 	public static final fun dump (Lkotlinx/serialization/BinaryFormat;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)[B
 	public static final fun dumps (Lkotlinx/serialization/BinaryFormat;Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun dumps (Lkotlinx/serialization/BinaryFormat;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun encode (Lkotlinx/serialization/Encoder;Ljava/lang/Object;)V
+	public static final fun encode (Lkotlinx/serialization/Encoder;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerialModule;Ljava/lang/Object;)Lkotlinx/serialization/KSerializer;
 	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerialModule;Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun getList (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
@@ -554,11 +554,9 @@ public abstract class kotlinx/serialization/encoding/AbstractDecoder : kotlinx/s
 	public final fun decodeShortElement (Lkotlinx/serialization/SerialDescriptor;I)S
 	public fun decodeString ()Ljava/lang/String;
 	public final fun decodeStringElement (Lkotlinx/serialization/SerialDescriptor;I)Ljava/lang/String;
-	public fun decodeUnit ()V
-	public final fun decodeUnitElement (Lkotlinx/serialization/SerialDescriptor;I)V
 	public fun decodeValue ()Ljava/lang/Object;
 	public fun endStructure (Lkotlinx/serialization/SerialDescriptor;)V
-	public fun getContext ()Lkotlinx/serialization/modules/SerialModule;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	public fun getUpdateMode ()Lkotlinx/serialization/UpdateMode;
 	public fun updateNullableSerializableElement (Lkotlinx/serialization/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun updateNullableSerializableValue (Lkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
@@ -599,10 +597,8 @@ public abstract class kotlinx/serialization/encoding/AbstractEncoder : kotlinx/s
 	public final fun encodeShortElement (Lkotlinx/serialization/SerialDescriptor;IS)V
 	public fun encodeString (Ljava/lang/String;)V
 	public final fun encodeStringElement (Lkotlinx/serialization/SerialDescriptor;ILjava/lang/String;)V
-	public fun encodeUnit ()V
-	public final fun encodeUnitElement (Lkotlinx/serialization/SerialDescriptor;I)V
 	public fun encodeValue (Ljava/lang/Object;)V
-	public fun getContext ()Lkotlinx/serialization/modules/SerialModule;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	public fun shouldEncodeElementDefault (Lkotlinx/serialization/SerialDescriptor;I)Z
 }
 
@@ -1222,14 +1218,11 @@ public abstract class kotlinx/serialization/internal/TaggedDecoder : kotlinx/ser
 	protected fun decodeTaggedNull (Ljava/lang/Object;)Ljava/lang/Void;
 	protected fun decodeTaggedShort (Ljava/lang/Object;)S
 	protected fun decodeTaggedString (Ljava/lang/Object;)Ljava/lang/String;
-	protected fun decodeTaggedUnit (Ljava/lang/Object;)V
 	protected fun decodeTaggedValue (Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun decodeUnit ()V
-	public final fun decodeUnitElement (Lkotlinx/serialization/SerialDescriptor;I)V
 	public fun endStructure (Lkotlinx/serialization/SerialDescriptor;)V
-	public fun getContext ()Lkotlinx/serialization/modules/SerialModule;
 	protected final fun getCurrentTag ()Ljava/lang/Object;
 	protected final fun getCurrentTagOrNull ()Ljava/lang/Object;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	protected abstract fun getTag (Lkotlinx/serialization/SerialDescriptor;I)Ljava/lang/Object;
 	public fun getUpdateMode ()Lkotlinx/serialization/UpdateMode;
 	protected final fun popTag ()Ljava/lang/Object;
@@ -1284,15 +1277,12 @@ public abstract class kotlinx/serialization/internal/TaggedEncoder : kotlinx/ser
 	protected fun encodeTaggedNull (Ljava/lang/Object;)V
 	protected fun encodeTaggedShort (Ljava/lang/Object;S)V
 	protected fun encodeTaggedString (Ljava/lang/Object;Ljava/lang/String;)V
-	protected fun encodeTaggedUnit (Ljava/lang/Object;)V
 	protected fun encodeTaggedValue (Ljava/lang/Object;Ljava/lang/Object;)V
-	public final fun encodeUnit ()V
-	public final fun encodeUnitElement (Lkotlinx/serialization/SerialDescriptor;I)V
 	protected fun endEncode (Lkotlinx/serialization/SerialDescriptor;)V
 	public final fun endStructure (Lkotlinx/serialization/SerialDescriptor;)V
-	public fun getContext ()Lkotlinx/serialization/modules/SerialModule;
 	protected final fun getCurrentTag ()Ljava/lang/Object;
 	protected final fun getCurrentTagOrNull ()Ljava/lang/Object;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerialModule;
 	protected abstract fun getTag (Lkotlinx/serialization/SerialDescriptor;I)Ljava/lang/Object;
 	protected final fun popTag ()Ljava/lang/Object;
 	protected final fun pushTag (Ljava/lang/Object;)V

--- a/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
@@ -35,13 +35,13 @@ public class ContextSerializer<T : Any>(
 
     public override fun serialize(encoder: Encoder, value: T) {
         val clz = value::class
-        val serializer = encoder.context.getContextual(clz) ?: fallbackSerializer ?: serializableClass.serializerNotRegistered()
+        val serializer = encoder.serializersModule.getContextual(clz) ?: fallbackSerializer ?: serializableClass.serializerNotRegistered()
         @Suppress("UNCHECKED_CAST")
         encoder.encodeSerializableValue(serializer as SerializationStrategy<T>, value)
     }
 
     public override fun deserialize(decoder: Decoder): T {
-        val serializer = decoder.context.getContextual(serializableClass) ?: fallbackSerializer ?: serializableClass.serializerNotRegistered()
+        val serializer = decoder.serializersModule.getContextual(serializableClass) ?: fallbackSerializer ?: serializableClass.serializerNotRegistered()
         return decoder.decodeSerializableValue(serializer)
     }
 }

--- a/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Encoding.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.*
  * To be more specific, serialization transforms a value into a sequence of "here is an int, here is
  * a double, here a list of strings and here is another object that is a nested int", while encoding
  * transforms this sequence into a format-specific commands such as "insert opening curly bracket
- * for a nested object start, insert a name of the value and the value separated with colon for an int etc."
+ * for a nested object start, insert a name of the value, and the value separated with colon for an int etc."
  *
  * The symmetric interface for the deserialization process is [Decoder].
  *
@@ -30,10 +30,10 @@ import kotlin.reflect.*
  * If a class is represented as a single [primitive][PrimitiveKind] value in its serialized form,
  * then one of the `encode*` methods (e.g. [encodeInt]) can be used directly.
  *
- * ### Serialization. Structured types
+ * ### Serialization. Structured types.
  *
  * If a class is represented as a structure or has multiple values in its serialized form,
- * `encode*` methods are not that helpful, because they do not allow to work with collection types or establish structure boundaries.
+ * `encode*` methods are not that helpful, because they do not allow working with collection types or establish structure boundaries.
  * All these capabilities are delegated to the [CompositeEncoder] interface with a more specific API surface.
  * To denote a structure start, [beginStructure] should be used.
  * ```
@@ -77,11 +77,11 @@ import kotlin.reflect.*
  * This serializer does not know anything about the underlying storage and will work with any properly-implemented encoder.
  * JSON, for example, writes an opening bracket `{` during the `beginStructure` call, writes 'stringValue` key along
  * with its value in `encodeStringElement` and writes the closing bracket `}` during the `endStructure`.
- * XML would do the roughly the same, but with different separators and structures, while ProtoBuf
+ * XML would do roughly the same, but with different separators and structures, while ProtoBuf
  * machinery could be completely different.
  * In any case, all these parsing details are encapsulated by an encoder.
  *
- * ### Encoder implementation
+ * ### Encoder implementation.
  *
  * While being strictly typed, an underlying format can transform actual types in the way it wants.
  * For example, a format can support only string types and encode/decode all primitives in a string form:
@@ -100,7 +100,7 @@ public interface Encoder {
      * Context of the current serialization process, including contextual and polymorphic serialization and,
      * potentially, a format-specific configuration.
      */
-    public val context: SerialModule
+    public val serializersModule: SerialModule
 
     /**
      * Notifies the encoder that value of a nullable type that is
@@ -125,9 +125,6 @@ public interface Encoder {
      * Encodes `null` value.
      */
     public fun encodeNull()
-
-    // Not documented.
-    public fun encodeUnit()
 
     /**
      * Encodes a boolean value.
@@ -226,7 +223,6 @@ public interface Encoder {
      *     composite.encodeStringElement(descriptor, 0, value.stringValue) // Serialize actual value
      *     composite.endStructure(descriptor) // Closing bracket
      * }
-     *
      * ```
      */
     @Suppress("DEPRECATION_ERROR", "RemoveRedundantSpreadOperator")
@@ -303,7 +299,7 @@ public interface CompositeEncoder {
      * Context of the current serialization process, including contextual and polymorphic serialization and,
      * potentially, a format-specific configuration.
      */
-    public val context: SerialModule
+    public val serializersModule: SerialModule
 
     /**
      * Denotes the end of the structure associated with current encoder.
@@ -325,9 +321,6 @@ public interface CompositeEncoder {
      * ```
      */
     public fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = true
-
-    // Not documented, was reworked
-    public fun encodeUnitElement(descriptor: SerialDescriptor, index: Int)
 
     /**
      * Encodes a boolean [value] associated with an element at the given [index] in [serial descriptor][descriptor].
@@ -413,17 +406,6 @@ public interface CompositeEncoder {
     public fun encodeNonSerializableElement(descriptor: SerialDescriptor, index: Int, value: Any) {
     }
 }
-
-/**
- * Alias for [Encoder.encodeSerializableValue]
- */
-public fun <T : Any?> Encoder.encode(strategy: SerializationStrategy<T>, value: T): Unit =
-    encodeSerializableValue(strategy, value)
-
-/**
- * Reified version of [Encoder.encodeSerializableValue]
- */
-public inline fun <reified T : Any> Encoder.encode(obj: T): Unit = encode(serializer(), obj)
 
 /**
  * Begins a structure, encodes it using the given [block] and ends it.

--- a/runtime/commonMain/src/kotlinx/serialization/KSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/KSerializer.kt
@@ -153,7 +153,7 @@ public interface DeserializationStrategy<T> {
      *     var list: List<String>? = null
      *     loop@ while (true) {
      *         when (val index = decodeElementIndex(descriptor)) {
-     *             READ_DONE -> break@loop
+     *             DECODE_DONE -> break@loop
      *             0 -> {
      *                 // Decode 'int' property as Int
      *                 int = decodeIntElement(descriptor, index = 0)

--- a/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
@@ -246,3 +246,27 @@ public fun <T : Any> BinaryFormat.load(raw: ByteArray): T = noImpl()
     ReplaceWith("decodeFromHexString<T>(hex)"), DeprecationLevel.ERROR
 )
 public fun <T : Any> BinaryFormat.loads(hex: String): T = noImpl()
+
+@Deprecated(
+    "This method was deprecated during serialization 1.0 API stabilization",
+    ReplaceWith("decodeSerializableValue(deserializer)"), DeprecationLevel.ERROR
+) // TODO make internal when migrations are removed
+public fun <T : Any?> Decoder.decode(deserializer: DeserializationStrategy<T>): T = noImpl()
+
+@Deprecated(
+    "This method was deprecated during serialization 1.0 API stabilization",
+    ReplaceWith("decodeSerializableValue<T>(serializer())"), DeprecationLevel.ERROR
+) // TODO make internal when migrations are removed
+public fun <T : Any> Decoder.decode(): T = noImpl()
+
+@Deprecated(
+    "This method was deprecated during serialization 1.0 API stabilization",
+    ReplaceWith("encodeSerializableValue(strategy, value)"), DeprecationLevel.ERROR
+) // TODO make internal when migrations are removed
+public fun <T : Any?> Encoder.encode(strategy: SerializationStrategy<T>, value: T): Unit = noImpl()
+
+@Deprecated(
+    "This method was deprecated during serialization 1.0 API stabilization",
+    ReplaceWith("encodeSerializableValue<T>(serializer(), value)"), DeprecationLevel.ERROR
+) // TODO make internal when migrations are removed
+public fun <T : Any> Encoder.encode(obj: T): Unit = noImpl()

--- a/runtime/commonMain/src/kotlinx/serialization/encoding/AbstractDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/encoding/AbstractDecoder.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.modules.*
  * See [Decoder] documentation for information about each particular `decode*` method.
  */
 public abstract class AbstractDecoder : Decoder, CompositeDecoder {
-    override val context: SerialModule
+    override val serializersModule: SerialModule
         get() = EmptyModule
 
     @Suppress("DEPRECATION")
@@ -29,8 +29,6 @@ public abstract class AbstractDecoder : Decoder, CompositeDecoder {
 
     override fun decodeNotNullMark(): Boolean = true
     override fun decodeNull(): Nothing? = null
-    override fun decodeUnit(): Unit = Unit.serializer().deserialize(this)
-
     override fun decodeBoolean(): Boolean = decodeValue() as Boolean
     override fun decodeByte(): Byte = decodeValue() as Byte
     override fun decodeShort(): Short = decodeValue() as Short
@@ -63,7 +61,6 @@ public abstract class AbstractDecoder : Decoder, CompositeDecoder {
     override fun endStructure(descriptor: SerialDescriptor) {
     }
 
-    final override fun decodeUnitElement(descriptor: SerialDescriptor, index: Int): Unit = decodeUnit()
     final override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean = decodeBoolean()
     final override fun decodeByteElement(descriptor: SerialDescriptor, index: Int): Byte = decodeByte()
     final override fun decodeShortElement(descriptor: SerialDescriptor, index: Int): Short = decodeShort()

--- a/runtime/commonMain/src/kotlinx/serialization/encoding/AbstractEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/encoding/AbstractEncoder.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.modules.*
  * See [Encoder] documentation for information about each particular `encode*` method.
  */
 public abstract class AbstractEncoder : Encoder, CompositeEncoder {
-    override val context: SerialModule
+    override val serializersModule: SerialModule
         get() = EmptyModule
 
     // do not update signature here because new signature is called by the plugin;
@@ -49,10 +49,6 @@ public abstract class AbstractEncoder : Encoder, CompositeEncoder {
         throw SerializationException("'null' is not supported by default")
     }
 
-    override fun encodeUnit() {
-        Unit.serializer().serialize(this, Unit)
-    }
-
     override fun encodeBoolean(value: Boolean): Unit = encodeValue(value)
     override fun encodeByte(value: Byte): Unit = encodeValue(value)
     override fun encodeShort(value: Short): Unit = encodeValue(value)
@@ -65,7 +61,6 @@ public abstract class AbstractEncoder : Encoder, CompositeEncoder {
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int): Unit = encodeValue(index)
 
     // Delegating implementation of CompositeEncoder
-    final override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int) { if (encodeElement(descriptor, index)) encodeUnit() }
     final override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) { if (encodeElement(descriptor, index)) encodeBoolean(value) }
     final override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte) { if (encodeElement(descriptor, index)) encodeByte(value) }
     final override fun encodeShortElement(descriptor: SerialDescriptor, index: Int, value: Short) { if (encodeElement(descriptor, index)) encodeShort(value) }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -42,7 +42,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
 
         mainLoop@ while (true) {
             when (val index = decodeElementIndex(descriptor)) {
-                CompositeDecoder.READ_DONE -> {
+                CompositeDecoder.DECODE_DONE -> {
                     break@mainLoop
                 }
                 0 -> {
@@ -56,7 +56,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
                 else -> throw SerializationException(
                     "Invalid index in polymorphic deserialization of " +
                             (klassName ?: "unknown class") +
-                            "\n Expected 0, 1 or READ_DONE(-1), but found $index"
+                            "\n Expected 0, 1 or DECODE_DONE(-1), but found $index"
                 )
             }
         }
@@ -80,7 +80,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
     public open fun findPolymorphicSerializer(
         decoder: CompositeDecoder,
         klassName: String
-    ): DeserializationStrategy<out T> = decoder.context.getPolymorphic(baseClass, klassName)
+    ): DeserializationStrategy<out T> = decoder.serializersModule.getPolymorphic(baseClass, klassName)
         ?: throwSubtypeNotRegistered(klassName, baseClass)
 
 
@@ -93,7 +93,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
         encoder: Encoder,
         value: T
     ): SerializationStrategy<T> =
-        encoder.context.getPolymorphic(baseClass, value) ?: throwSubtypeNotRegistered(value::class, baseClass)
+        encoder.serializersModule.getPolymorphic(baseClass, value) ?: throwSubtypeNotRegistered(value::class, baseClass)
 }
 
 private fun throwSubtypeNotRegistered(subClassName: String, baseClass: KClass<*>): Nothing =

--- a/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
@@ -5,7 +5,6 @@
 package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
-import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlin.reflect.*
 
 @InternalSerializationApi
@@ -30,7 +29,7 @@ public sealed class AbstractCollectionSerializer<Element, Collection, Builder> :
         } else {
             while (true) {
                 val index = compositeDecoder.decodeElementIndex(descriptor)
-                if (index == READ_DONE) break
+                if (index == CompositeDecoder.DECODE_DONE) break
                 readElement(compositeDecoder, startIndex + index, builder)
             }
         }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -6,11 +6,6 @@ package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
 import kotlinx.serialization.modules.*
-
-internal const val unitDeprecated =
-    "This method is deprecated with no replacement. Unit is encoded as an empty object and does not require a dedicated method. " +
-            "To migrate, just remove your own implementation of this method"
-
 /*
  * These classes are intended to be used only within the kotlinx.serialization.
  * They neither do have stable API, not internal invariants and are changed without any warnings.
@@ -24,7 +19,7 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
      */
     protected abstract fun SerialDescriptor.getTag(index: Int): Tag
 
-    override val context: SerialModule
+    override val serializersModule: SerialModule
         get() = EmptyModule
 
     // ---- API ----
@@ -34,8 +29,6 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
     protected open fun encodeTaggedNotNullMark(tag: Tag) {}
     protected open fun encodeTaggedNull(tag: Tag): Unit = throw SerializationException("null is not supported")
 
-    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
-    protected open fun encodeTaggedUnit(tag: Tag): Unit = encodeTaggedValue(tag, Unit)
     protected open fun encodeTaggedInt(tag: Tag, value: Int): Unit = encodeTaggedValue(tag, value)
     protected open fun encodeTaggedByte(tag: Tag, value: Byte): Unit = encodeTaggedValue(tag, value)
     protected open fun encodeTaggedShort(tag: Tag, value: Short): Unit = encodeTaggedValue(tag, value)
@@ -62,9 +55,6 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
 
     final override fun encodeNotNullMark(): Unit = encodeTaggedNotNullMark(currentTag)
     final override fun encodeNull(): Unit = encodeTaggedNull(popTag())
-
-    @Suppress("DEPRECATION_ERROR")
-    final override fun encodeUnit(): Unit = UnitSerializer.serialize(this, Unit)
     final override fun encodeBoolean(value: Boolean): Unit = encodeTaggedBoolean(popTag(), value)
     final override fun encodeByte(value: Byte): Unit = encodeTaggedByte(popTag(), value)
     final override fun encodeShort(value: Short): Unit = encodeTaggedShort(popTag(), value)
@@ -106,10 +96,6 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
      * Format-specific replacement for [endStructure], because latter is overridden to manipulate tag stack.
      */
     protected open fun endEncode(descriptor: SerialDescriptor) {}
-
-    @Suppress("DEPRECATION_ERROR")
-    final override fun encodeUnitElement(descriptor: SerialDescriptor, index: Int): Unit =
-        encodeTaggedUnit(descriptor.getTag(index))
 
     final override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean): Unit =
         encodeTaggedBoolean(descriptor.getTag(index), value)
@@ -187,7 +173,7 @@ public abstract class NamedValueEncoder(protected val rootName: String = "") : T
 @InternalSerializationApi
 public abstract class TaggedDecoder<Tag : Any?> : Decoder,
     CompositeDecoder {
-    override val context: SerialModule
+    override val serializersModule: SerialModule
         get() = EmptyModule
 
     @Suppress("DEPRECATION")
@@ -205,9 +191,6 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder,
     protected open fun decodeTaggedNotNullMark(tag: Tag): Boolean = true
     protected open fun decodeTaggedNull(tag: Tag): Nothing? = null
 
-    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
-    @Suppress("DEPRECATION_ERROR")
-    protected open fun decodeTaggedUnit(tag: Tag): Unit = UnitSerializer.deserialize(this)
     protected open fun decodeTaggedBoolean(tag: Tag): Boolean = decodeTaggedValue(tag) as Boolean
     protected open fun decodeTaggedByte(tag: Tag): Byte = decodeTaggedValue(tag) as Byte
     protected open fun decodeTaggedShort(tag: Tag): Short = decodeTaggedValue(tag) as Short
@@ -229,9 +212,6 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder,
     final override fun decodeNotNullMark(): Boolean = decodeTaggedNotNullMark(currentTag)
     final override fun decodeNull(): Nothing? = null
 
-    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
-    @Suppress("DEPRECATION_ERROR")
-    final override fun decodeUnit(): Unit = UnitSerializer.deserialize(this)
     final override fun decodeBoolean(): Boolean = decodeTaggedBoolean(popTag())
     final override fun decodeByte(): Byte = decodeTaggedByte(popTag())
     final override fun decodeShort(): Short = decodeTaggedShort(popTag())
@@ -259,11 +239,6 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder,
     override fun endStructure(descriptor: SerialDescriptor) {
         // Nothing
     }
-
-    @Deprecated(message = unitDeprecated, level = DeprecationLevel.ERROR)
-    @Suppress("DEPRECATION_ERROR")
-    final override fun decodeUnitElement(descriptor: SerialDescriptor, index: Int): Unit =
-        decodeTaggedUnit(descriptor.getTag(index))
 
     final override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean =
         decodeTaggedBoolean(descriptor.getTag(index))

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
@@ -43,7 +43,7 @@ public sealed class KeyValueSerializer<K, V, R>(
         var value: Any? = NULL
         mainLoop@ while (true) {
             when (val idx = composite.decodeElementIndex(descriptor)) {
-                CompositeDecoder.READ_DONE -> {
+                CompositeDecoder.DECODE_DONE -> {
                     break@mainLoop
                 }
                 0 -> {
@@ -163,7 +163,7 @@ public class TripleSerializer<A, B, C>(
         var c: Any? = NULL
         mainLoop@ while (true) {
             when (val index = composite.decodeElementIndex(descriptor)) {
-                CompositeDecoder.READ_DONE -> {
+                CompositeDecoder.DECODE_DONE -> {
                     break@mainLoop
                 }
                 0 -> {

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -61,7 +61,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
             WriteMode.OBJ,
             arrayOfNulls(WriteMode.values().size)
         )
-        encoder.encode(serializer, value)
+        encoder.encodeSerializableValue(serializer, value)
         return result.toString()
     }
 
@@ -73,7 +73,7 @@ public sealed class Json(internal val configuration: JsonConfiguration) : String
     public final override fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, string: String): T {
         val reader = JsonReader(string)
         val input = StreamingJsonDecoder(this, WriteMode.OBJ, reader)
-        val result = input.decode(deserializer)
+        val result = input.decodeSerializableValue(deserializer)
         if (!reader.isDone) { error("Reader has not consumed the whole input: $reader") }
         return result
     }

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonParametricSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonParametricSerializer.kt
@@ -76,7 +76,7 @@ public abstract class JsonParametricSerializer<T : Any>(private val baseClass: K
     @OptIn(UnsafeSerializationApi::class)
     final override fun serialize(encoder: Encoder, value: T) {
         val actualSerializer =
-            encoder.context.getPolymorphic(baseClass, value)
+            encoder.serializersModule.getPolymorphic(baseClass, value)
                     ?: value::class.serializerOrNull()
                     ?: throwSubtypeNotRegistered(value::class, baseClass)
         @Suppress("UNCHECKED_CAST")

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -20,7 +20,7 @@ internal class StreamingJsonDecoder internal constructor(
     @JvmField internal val reader: JsonReader
 ) : JsonDecoder, AbstractDecoder() {
 
-    public override val context: SerialModule = json.context
+    public override val serializersModule: SerialModule = json.context
     private var currentIndex = -1
     private val configuration = json.configuration
 
@@ -85,7 +85,7 @@ internal class StreamingJsonDecoder internal constructor(
                     0 -> 0
                     1 -> 1
                     else -> {
-                        CompositeDecoder.READ_DONE
+                        CompositeDecoder.DECODE_DONE
                     }
                 }
             }
@@ -103,7 +103,7 @@ internal class StreamingJsonDecoder internal constructor(
         }
         return if (!reader.canBeginValue) {
             reader.require(tokenClass != TC_COMMA) { "Unexpected trailing comma" }
-            CompositeDecoder.READ_DONE
+            CompositeDecoder.DECODE_DONE
         } else {
             ++currentIndex
         }
@@ -159,7 +159,7 @@ internal class StreamingJsonDecoder internal constructor(
                 reader.require(reader.canBeginValue, reader.currentPosition) { "Unexpected trailing comma" }
             }
         }
-        return CompositeDecoder.READ_DONE
+        return CompositeDecoder.DECODE_DONE
     }
 
     private fun decodeListIndex(tokenClass: Byte): Int {
@@ -169,7 +169,7 @@ internal class StreamingJsonDecoder internal constructor(
         }
         return if (!reader.canBeginValue) {
             reader.require(tokenClass != TC_COMMA) { "Unexpected trailing comma" }
-            CompositeDecoder.READ_DONE
+            CompositeDecoder.DECODE_DONE
         } else {
             ++currentIndex
         }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -22,7 +22,7 @@ internal class StreamingJsonEncoder(
         modeReuseCache: Array<JsonEncoder?>
     ) : this(Composer(output, json), json, mode, modeReuseCache)
 
-    public override val context: SerialModule = json.context
+    public override val serializersModule: SerialModule = json.context
     private val configuration = json.configuration
 
     // Forces serializer to wrap all values into quotes

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonOutput.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonOutput.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.*
 internal fun <T> Json.writeJson(value: T, serializer: SerializationStrategy<T>): JsonElement {
     lateinit var result: JsonElement
     val encoder = JsonTreeEncoder(this) { result = it }
-    encoder.encode(serializer, value)
+    encoder.encodeSerializableValue(serializer, value)
     return result
 }
 
@@ -23,7 +23,7 @@ private sealed class AbstractJsonTreeEncoder(
     val nodeConsumer: (JsonElement) -> Unit
 ) : NamedValueEncoder(), JsonEncoder {
 
-    final override val context: SerialModule
+    final override val serializersModule: SerialModule
         get() = json.context
 
     @JvmField

--- a/runtime/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
@@ -4,7 +4,6 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlinx.serialization.encoding.*
 import kotlin.test.*
 
@@ -62,7 +61,7 @@ class BasicTypesSerializationTest {
             inp.skipWhitespace(',')
             val name = inp.nextUntil(':', '}')
             if (name.isEmpty())
-                return READ_DONE
+                return CompositeDecoder.DECODE_DONE
             val index = descriptor.getElementIndexOrThrow(name)
             inp.expect(':')
             return index
@@ -153,11 +152,11 @@ class BasicTypesSerializationTest {
         // serialize to string
         val sb = StringBuilder()
         val out = KeyValueOutput(sb)
-        out.encode(TypesUmbrella.serializer(), umbrellaInstance)
+        out.encodeSerializableValue(TypesUmbrella.serializer(), umbrellaInstance)
         // deserialize from string
         val str = sb.toString()
         val inp = KeyValueInput(Parser(StringReader(str)))
-        val other = inp.decode(TypesUmbrella.serializer())
+        val other = inp.decodeSerializableValue(TypesUmbrella.serializer())
         // assert we've got it back from string
         assertEquals(umbrellaInstance, other)
         assertNotSame(umbrellaInstance, other)

--- a/runtime/commonTest/src/kotlinx/serialization/TaggedTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/TaggedTest.kt
@@ -4,7 +4,6 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlinx.serialization.test.*
 import kotlin.test.*
 import kotlinx.serialization.internal.*
@@ -36,7 +35,7 @@ class TaggedTest {
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             // js doesn't generate code for .decodeSequentially for the sake of keeping output small
             if (!isJs()) throw AssertionError("Should not be called in this test due to support of decodeSequentially")
-            return if (i == collected.tagList.size) READ_DONE else i++
+            return if (i == collected.tagList.size) CompositeDecoder.DECODE_DONE else i++
         }
 
         override fun decodeTaggedValue(tag: Int?): Any {
@@ -49,9 +48,9 @@ class TaggedTest {
     fun testTagged() {
         val collector = Collector()
         val data = DataWithId(1, "2")
-        collector.encode(DataWithId.serializer(), data)
+        collector.encodeSerializableValue(DataWithId.serializer(), data)
         assertEquals(mapOf(1 to 1, 2 to "2", null to Unit, 42 to true), collector.tagList, "see all tags properly")
-        val obj = Emitter(collector).decode(DataWithId.serializer())
+        val obj = Emitter(collector).decodeSerializableValue(DataWithId.serializer())
         assertEquals(obj, data, "read tags back")
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/UnknownElementIndexTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/UnknownElementIndexTest.kt
@@ -25,7 +25,7 @@ class UnknownElementIndexTest {
     @Test
     fun testCompilerComplainsAboutIncorrectIndex() {
         assertFailsWith(UnknownFieldException::class) {
-            MalformedReader().decode(Holder.serializer())
+            MalformedReader().decodeSerializableValue(Holder.serializer())
         }
     }
 

--- a/runtime/commonTest/src/kotlinx/serialization/features/BinaryPayloadExampleTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/BinaryPayloadExampleTest.kt
@@ -34,7 +34,7 @@ class BinaryPayloadExampleTest {
                 var res: ByteArray? = null // need to read nullable non-optional properties
                 loop@ while (true) {
                     when (val i = dec.decodeElementIndex(descriptor)) {
-                        CompositeDecoder.READ_DONE -> break@loop
+                        CompositeDecoder.DECODE_DONE -> break@loop
                         0 -> req = InternalHexConverter.parseHexBinary(dec.decodeStringElement(descriptor, i))
                         1 -> res = InternalHexConverter.parseHexBinary(dec.decodeStringElement(descriptor, i))
                         else -> throw SerializationException("Unknown index $i")

--- a/runtime/commonTest/src/kotlinx/serialization/features/GenericCustomSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/GenericCustomSerializerTest.kt
@@ -51,7 +51,7 @@ class CheckedDataSerializer<T : Any>(private val dataSerializer: KSerializer<T>)
         lateinit var sum: ByteArray
         loop@ while (true) {
             when (val i = inp.decodeElementIndex(descriptor)) {
-                CompositeDecoder.READ_DONE -> break@loop
+                CompositeDecoder.DECODE_DONE -> break@loop
                 0 -> data = inp.decodeSerializableElement(descriptor, i, dataSerializer)
                 1 -> sum = InternalHexConverter.parseHexBinary(inp.decodeStringElement(descriptor, i))
                 else -> throw SerializationException("Unknown index $i")

--- a/runtime/commonTest/src/kotlinx/serialization/json/MapLikeSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/MapLikeSerializerTest.kt
@@ -40,7 +40,7 @@ class MapLikeSerializerTest : JsonTestBase() {
             var value: String? = null
             mainLoop@ while (true) {
                 when (val idx = composite.decodeElementIndex(descriptor)) {
-                    CompositeDecoder.READ_DONE -> {
+                    CompositeDecoder.DECODE_DONE -> {
                         break@mainLoop
                     }
                     0 -> {

--- a/runtime/jsMain/src/kotlinx/serialization/DynamicObjectParser.kt
+++ b/runtime/jsMain/src/kotlinx/serialization/DynamicObjectParser.kt
@@ -4,7 +4,6 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
@@ -52,10 +51,10 @@ public class DynamicObjectParser @OptIn(UnstableDefault::class) constructor(
      * Deserializes given [obj] from dynamic form to type [T] using [deserializer].
      */
     public fun <T> parse(obj: dynamic, deserializer: DeserializationStrategy<T>): T =
-        DynamicInput(obj).decode(deserializer)
+        DynamicInput(obj).decodeSerializableValue(deserializer)
 
     private open inner class DynamicInput(val obj: dynamic) : NamedValueDecoder() {
-        override val context: SerialModule
+        override val serializersModule: SerialModule
             get() = this@DynamicObjectParser.context
 
         override fun composeName(parentName: String, childName: String): String = childName
@@ -67,7 +66,7 @@ public class DynamicObjectParser @OptIn(UnstableDefault::class) constructor(
                 val name = descriptor.getTag(pos++)
                 if (obj[name] !== undefined) return pos - 1
             }
-            return READ_DONE
+            return CompositeDecoder.DECODE_DONE
         }
 
         override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
@@ -141,7 +140,7 @@ public class DynamicObjectParser @OptIn(UnstableDefault::class) constructor(
                 val name = keys[i] as String
                 if (this.obj[name] !== undefined) return pos
             }
-            return READ_DONE
+            return CompositeDecoder.DECODE_DONE
         }
 
         override fun getByTag(tag: String): dynamic {
@@ -160,7 +159,7 @@ public class DynamicObjectParser @OptIn(UnstableDefault::class) constructor(
                 val o = obj[++pos]
                 if (o !== undefined) return pos
             }
-            return READ_DONE
+            return CompositeDecoder.DECODE_DONE
         }
     }
 }

--- a/runtime/jsMain/src/kotlinx/serialization/DynamicObjectSerializer.kt
+++ b/runtime/jsMain/src/kotlinx/serialization/DynamicObjectSerializer.kt
@@ -42,11 +42,11 @@ public class DynamicObjectSerializer @OptIn(UnstableDefault::class) constructor(
     public fun <T> serialize(strategy: SerializationStrategy<T>, obj: T): dynamic {
         if (strategy.descriptor.kind is PrimitiveKind || strategy.descriptor.kind is UnionKind.ENUM_KIND) {
             val serializer = DynamicPrimitiveEncoder(configuration)
-            serializer.encode(strategy, obj)
+            serializer.encodeSerializableValue(strategy, obj)
             return serializer.result
         }
         val serializer = DynamicObjectEncoder(configuration, encodeNullAsUndefined)
-        serializer.encode(strategy, obj)
+        serializer.encodeSerializableValue(strategy, obj)
         return serializer.result
     }
 

--- a/runtime/jvmTest/src/kotlinx/serialization/SerializationMethodInvocationOrderTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/SerializationMethodInvocationOrderTest.kt
@@ -17,11 +17,11 @@ class SerializationMethodInvocationOrderTest {
     @Test
     fun testRec() {
         val out = Out()
-        out.encode(serializer(), Container(Data("s1", 42)))
+        out.encodeSerializableValue(serializer(), Container(Data("s1", 42)))
         out.done()
 
         val inp = Inp()
-        inp.decode(serializer<Container>())
+        inp.decodeSerializableValue(serializer<Container>())
         inp.done()
     }
 

--- a/runtime/jvmTest/src/kotlinx/serialization/SerializeFlatTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/SerializeFlatTest.kt
@@ -87,7 +87,7 @@ object CustomSerializer : KSerializer<Custom> {
         val value1 = decoder.decodeStringElement(descriptor, 0)
         if (decoder.decodeElementIndex(descriptor) != 1) throw java.lang.IllegalStateException()
         val value2 = decoder.decodeIntElement(descriptor, 1)
-        if (decoder.decodeElementIndex(descriptor) != CompositeDecoder.READ_DONE) throw java.lang.IllegalStateException()
+        if (decoder.decodeElementIndex(descriptor) != CompositeDecoder.DECODE_DONE) throw java.lang.IllegalStateException()
         decoder.endStructure(descriptor)
         return Custom(value1, value2)
     }
@@ -110,11 +110,11 @@ class SerializeFlatTest() {
     @Test
     fun testData() {
         val out = Out("Data")
-        out.encode(serializer(), Data("s1", 42))
+        out.encodeSerializableValue(serializer(), Data("s1", 42))
         out.done()
 
         val inp = Inp("Data")
-        val data = inp.decode(serializer<Data>())
+        val data = inp.decodeSerializableValue(serializer<Data>())
         inp.done()
         assert(data.value1 == "s1" && data.value2 == 42)
     }
@@ -122,11 +122,11 @@ class SerializeFlatTest() {
     @Test
     fun testDataExplicit() {
         val out = Out("DataExplicit")
-        out.encode(serializer(), DataExplicit("s1", 42))
+        out.encodeSerializableValue(serializer(), DataExplicit("s1", 42))
         out.done()
 
         val inp = Inp("DataExplicit")
-        val data = inp.decode(serializer<DataExplicit>())
+        val data = inp.decodeSerializableValue(serializer<DataExplicit>())
         inp.done()
         assert(data.value1 == "s1" && data.value2 == 42)
     }
@@ -137,11 +137,11 @@ class SerializeFlatTest() {
         val reg = Reg()
         reg.value1 = "s1"
         reg.value2 = 42
-        out.encode(serializer(), reg)
+        out.encodeSerializableValue(serializer(), reg)
         out.done()
 
         val inp = Inp("Reg")
-        val data = inp.decode(serializer<Reg>())
+        val data = inp.decodeSerializableValue(serializer<Reg>())
         inp.done()
         assert(data.value1 == "s1" && data.value2 == 42)
     }
@@ -149,11 +149,11 @@ class SerializeFlatTest() {
     @Test
     fun testNames() {
         val out = Out("Names")
-        out.encode(serializer(), Names("s1", 42))
+        out.encodeSerializableValue(serializer(), Names("s1", 42))
         out.done()
 
         val inp = Inp("Names")
-        val data = inp.decode(serializer<Names>())
+        val data = inp.decodeSerializableValue(serializer<Names>())
         inp.done()
         assert(data.custom1 == "s1" && data.custom2 == 42)
     }
@@ -161,11 +161,11 @@ class SerializeFlatTest() {
     @Test
     fun testCustom() {
         val out = Out("Custom")
-        out.encode(CustomSerializer, Custom("s1", 42))
+        out.encodeSerializableValue(CustomSerializer, Custom("s1", 42))
         out.done()
 
         val inp = Inp("Custom")
-        val data = inp.decode(CustomSerializer)
+        val data = inp.decodeSerializableValue(CustomSerializer)
         inp.done()
         assert(data._value1 == "s1" && data._value2 == 42)
     }
@@ -173,11 +173,11 @@ class SerializeFlatTest() {
     @Test
     fun testExternalData() {
         val out = Out("ExternalData")
-        out.encode(ExternalSerializer, ExternalData("s1", 42))
+        out.encodeSerializableValue(ExternalSerializer, ExternalData("s1", 42))
         out.done()
 
         val inp = Inp("ExternalData")
-        val data = inp.decode(ExternalSerializer)
+        val data = inp.decodeSerializableValue(ExternalSerializer)
         inp.done()
         assert(data.value1 == "s1" && data.value2 == 42)
     }

--- a/runtime/jvmTest/src/kotlinx/serialization/privateclasstest/PrivateDataOutOfKotlinXSerializationPackageTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/privateclasstest/PrivateDataOutOfKotlinXSerializationPackageTest.kt
@@ -36,11 +36,11 @@ class PrivateClassOutOfSerializationLibraryPackageTest {
     @Test
     fun testDataPrivate() {
         val out = Out("privateclasstest.DataPrivate")
-        out.encode(serializer(), DataPrivate("s1", 42))
+        out.encodeSerializableValue(serializer(), DataPrivate("s1", 42))
         out.done()
 
         val inp = Inp("privateclasstest.DataPrivate")
-        val data = inp.decode(serializer<DataPrivate>())
+        val data = inp.decodeSerializableValue(serializer<DataPrivate>())
         inp.done()
         assert(data.value1 == "s1" && data.value2 == 42)
     }


### PR DESCRIPTION
    * Deprecate potentially dangerous extensions
    * Rename context to serializersModule to align with modules rework
    * Remove decode/encodeUnit
    * Rename READ_DONE to DECODE_DONE