### PR TITLE
Add CBOR major type 2 (byte string) support

### DIFF
--- a/docs/cbor_byte_string.md
+++ b/docs/cbor_byte_string.md
@@ -1,0 +1,29 @@
+Per [RFC 7049] [2.1 Major Types], CBOR supports the following data types:
+
+- Major type 0: an unsigned integer
+- Major type 1: a negative integer
+- **Major type 2: a byte string**
+- Major type 3: a text string
+- **Major type 4: an array of data items**
+- Major type 5: a map of pairs of data items
+- Major type 6: optional semantic tagging of other major types
+- Major type 7: floating-point numbers and simple data types that need no content, as well as the "break" stop code
+
+By default, `ByteArray`s are encoded/decoded as **major type 4**.
+When **major type 2** is desired, then the `@ByteString` annotation can be used.
+
+For example:
+
+```kotlin
+@Serializable
+data class Data(
+    @ByteString
+    val a: ByteArray, // CBOR Major type 2
+
+    val b: ByteArray  // CBOR Major type 4
+)
+```
+
+
+[RFC 7049]: https://tools.ietf.org/html/rfc7049
+[2.1 Major Types]: https://tools.ietf.org/html/rfc7049#section-2.1

--- a/docs/runtime_usage.md
+++ b/docs/runtime_usage.md
@@ -158,6 +158,9 @@ It has `UpdateMode.BANNED` by default. As Json, Cbor supports omitting default v
 **Note**: CBOR, unlike JSON, supports maps with non-trivial keys,
 and Kotlin maps are serialized as CBOR maps, but some parsers (like `jackson-dataformat-cbor`) don't support this.
 
+`ByteArray`s are serialized as either major type 4: an array of data items (default), or major type 2: a byte string.
+See [CBOR byte string](cbor_byte_string.md) document for details.
+
 ### Protobuf
 
 Because protobuf relies on serial ids of fields, called 'tags', you have to provide this information,

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/ByteString.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/ByteString.kt
@@ -1,0 +1,25 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Specifies that a [ByteArray] shall be encoded/decoded as CBOR major type 2: a byte string.
+ * For types other than [ByteArray], [ByteString] will have no effect.
+ *
+ * Example usage:
+ *
+ * ```
+ * @Serializable
+ * data class Data(
+ *     @ByteString
+ *     val a: ByteArray, // CBOR major type 2: a byte string.
+ *
+ *     val b: ByteArray  // CBOR major type 4: an array of data items.
+ * )
+ * ```
+ *
+ * See [RFC 7049 2.1. Major Types](https://tools.ietf.org/html/rfc7049#section-2.1).
+ */
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+public annotation class ByteString

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborWriterTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborWriterTest.kt
@@ -23,10 +23,12 @@ class CbrWriterTest {
             listOf("a", "b"),
             mapOf(1 to true, 2 to false),
             Simple("lol"),
-            listOf(Simple("kek"))
+            listOf(Simple("kek")),
+            HexConverter.parseHexBinary("cafe"),
+            HexConverter.parseHexBinary("cafe")
         )
         assertEquals(
-            "bf637374726d48656c6c6f2c20776f726c64216169182a686e756c6c61626c65f6646c6973749f61616162ff636d6170bf01f502f4ff65696e6e6572bf6161636c6f6cff6a696e6e6572734c6973749fbf6161636b656bffffff",
+            "bf637374726d48656c6c6f2c20776f726c64216169182a686e756c6c61626c65f6646c6973749f61616162ff636d6170bf01f502f4ff65696e6e6572bf6161636c6f6cff6a696e6e6572734c6973749fbf6161636b656bffff6a62797465537472696e6742cafe696279746541727261799f383521ffff",
             Cbor.encodeToHexString(TypesUmbrella.serializer(), test)
         )
     }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/SampleClasses.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/SampleClasses.kt
@@ -17,8 +17,42 @@ data class TypesUmbrella(
         val list: List<String>,
         val map: Map<Int, Boolean>,
         val inner: Simple,
-        val innersList: List<Simple>
-)
+        val innersList: List<Simple>,
+        @ByteString val byteString: ByteArray,
+        val byteArray: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as TypesUmbrella
+
+        if (str != other.str) return false
+        if (i != other.i) return false
+        if (nullable != other.nullable) return false
+        if (list != other.list) return false
+        if (map != other.map) return false
+        if (inner != other.inner) return false
+        if (innersList != other.innersList) return false
+        if (!byteString.contentEquals(other.byteString)) return false
+        if (!byteArray.contentEquals(other.byteArray)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = str.hashCode()
+        result = 31 * result + i
+        result = 31 * result + (nullable?.hashCode() ?: 0)
+        result = 31 * result + list.hashCode()
+        result = 31 * result + map.hashCode()
+        result = 31 * result + inner.hashCode()
+        result = 31 * result + innersList.hashCode()
+        result = 31 * result + byteString.contentHashCode()
+        result = 31 * result + byteArray.contentHashCode()
+        return result
+    }
+}
 
 @Serializable
 data class NumberTypesUmbrella(


### PR DESCRIPTION
Adds support for CBOR major type 2 (byte string).

Per [RFC 7049 2.1. Major Types](https://tools.ietf.org/html/rfc7049#section-2.1), when describing **Major type 3: a text string**:

> The format of this type is identical to that of byte strings (major type 2), that is, as with major type 2, the length gives the number of bytes.

As such, this byte string implementation piggybacks on the existing text string support, so both share decoding logic. Additionally, this PR builds on #846 which added support for decoding indefinite length byte strings. Since **text string** and **byte string** share decoding logic, both gain the indefinite length decoding support.

Closes #842.