### PR TITLE
[API stabilization] SerialDescriptorBuilder

### DIFF
--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/CustomizedSerializableTestClasses.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/CustomizedSerializableTestClasses.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.protobuf
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 
 @Serializable
 data class A(@ProtoId(1) val b: B)

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/CustomizedSerializableTestClasses.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/CustomizedSerializableTestClasses.kt
@@ -22,7 +22,7 @@ object BSerializer : KSerializer<B> {
         return B(decoder.decodeInt())
     }
 
-    override val descriptor: SerialDescriptor = PrimitiveDescriptor("B", PrimitiveKind.INT)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("B", PrimitiveKind.INT)
 }
 
 @Serializable

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufMissingFieldsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufMissingFieldsTest.kt
@@ -5,7 +5,7 @@
 package kotlinx.serialization.protobuf
 
 import kotlinx.serialization.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.descriptors.*
 import kotlin.test.*
 
 class ProtobufMissingFieldsTest {

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufMissingFieldsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufMissingFieldsTest.kt
@@ -87,10 +87,10 @@ class ProtobufMissingFieldsTest {
     )
 
     class ItemPlatformSerializer : KSerializer<ItemPlatform> {
-
-        override val descriptor: SerialDescriptor = SerialDescriptor("ItemPlatform", UnionKind.ENUM_KIND) {
+        @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("ItemPlatform", UnionKind.ENUM_KIND) {
             enumValues<ItemPlatform>().forEach {
-                element(it.name, SerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
+                element(it.name, buildSerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
             }
         }
 
@@ -106,9 +106,10 @@ class ProtobufMissingFieldsTest {
 
     class ItemContextSerializer : KSerializer<ItemContext> {
 
-        override val descriptor: SerialDescriptor = SerialDescriptor("ItemContext", UnionKind.ENUM_KIND) {
+        @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("ItemContext", UnionKind.ENUM_KIND) {
             enumValues<ItemContext>().forEach {
-                element(it.name, SerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
+                element(it.name, buildSerialDescriptor("$serialName.${it.name}", StructureKind.OBJECT))
             }
         }
 

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/PolymorphicWithJvmClassTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/PolymorphicWithJvmClassTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.protobuf
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.modules.SerializersModule
 
 import org.junit.Test

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/PolymorphicWithJvmClassTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/PolymorphicWithJvmClassTest.kt
@@ -19,7 +19,7 @@ class PolymorphicWithJvmClassTest {
 
     @Serializer(forClass = Date::class)
     object DateSerializer : KSerializer<Date> {
-        override val descriptor: SerialDescriptor = PrimitiveDescriptor("java.util.Date", PrimitiveKind.STRING)
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.util.Date", PrimitiveKind.STRING)
 
         // Consider wrapping in ThreadLocal if serialization may happen in multiple threads
         private val df: DateFormat = SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS").apply {

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -197,6 +197,11 @@ public final class kotlinx/serialization/Mapper {
 }
 
 public final class kotlinx/serialization/MigrationsKt {
+	public static final fun PrimitiveDescriptor (Ljava/lang/String;Lkotlinx/serialization/PrimitiveKind;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun SerialDescriptor (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun SerialDescriptor (Ljava/lang/String;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
+	public static synthetic fun SerialDescriptor$default (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/SerialDescriptor;
+	public static synthetic fun SerialDescriptor$default (Ljava/lang/String;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/SerialDescriptor;
 	public static final fun compiledSerializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun decode (Lkotlinx/serialization/Decoder;)Ljava/lang/Object;
 	public static final fun decode (Lkotlinx/serialization/Decoder;Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
@@ -499,9 +504,9 @@ public final class kotlinx/serialization/builtins/LongAsStringSerializer : kotli
 	public synthetic fun serialize (Lkotlinx/serialization/Encoder;Ljava/lang/Object;)V
 }
 
-public final class kotlinx/serialization/descriptors/SerialDescriptorBuilder {
+public final class kotlinx/serialization/descriptors/ClassSerialDescriptorBuilder {
 	public final fun element (Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;Z)V
-	public static synthetic fun element$default (Lkotlinx/serialization/descriptors/SerialDescriptorBuilder;Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;ZILjava/lang/Object;)V
+	public static synthetic fun element$default (Lkotlinx/serialization/descriptors/ClassSerialDescriptorBuilder;Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;ZILjava/lang/Object;)V
 	public final fun getAnnotations ()Ljava/util/List;
 	public final fun getSerialName ()Ljava/lang/String;
 	public final fun isNullable ()Z
@@ -512,11 +517,16 @@ public final class kotlinx/serialization/descriptors/SerialDescriptorBuilder {
 	public final fun setNullable (Z)V
 }
 
-public final class kotlinx/serialization/descriptors/SerialDescriptorBuilderKt {
-	public static final fun PrimitiveDescriptor (Ljava/lang/String;Lkotlinx/serialization/PrimitiveKind;)Lkotlinx/serialization/SerialDescriptor;
-	public static final fun SerialDescriptor (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
-	public static synthetic fun SerialDescriptor$default (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/SerialDescriptor;
+public final class kotlinx/serialization/descriptors/SerialDescriptorsKt {
+	public static final fun PrimitiveSerialDescriptor (Ljava/lang/String;Lkotlinx/serialization/PrimitiveKind;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun buildClassSerialDescriptor (Ljava/lang/String;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
+	public static synthetic fun buildClassSerialDescriptor$default (Ljava/lang/String;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun buildSerialDescriptor (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
 	public static final fun getNullable (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun listSerialDescriptor (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun mapSerialDescriptor (Lkotlinx/serialization/SerialDescriptor;Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun serialDescriptor (Lkotlin/reflect/KType;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun setSerialDescriptor (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
 }
 
 public abstract class kotlinx/serialization/encoding/AbstractDecoder : kotlinx/serialization/CompositeDecoder, kotlinx/serialization/Decoder {
@@ -835,19 +845,6 @@ public final class kotlinx/serialization/internal/HashMapSerializer : kotlinx/se
 	public synthetic fun collectionSize (Ljava/lang/Object;)I
 	public fun getDescriptor ()Lkotlinx/serialization/SerialDescriptor;
 	public synthetic fun insertKeyValuePair (Ljava/util/Map;ILjava/lang/Object;Ljava/lang/Object;)V
-	public synthetic fun toBuilder (Ljava/lang/Object;)Ljava/lang/Object;
-	public synthetic fun toResult (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class kotlinx/serialization/internal/HashSetSerializer : kotlinx/serialization/internal/ListLikeSerializer {
-	public fun <init> (Lkotlinx/serialization/KSerializer;)V
-	public synthetic fun builder ()Ljava/lang/Object;
-	public synthetic fun builderSize (Ljava/lang/Object;)I
-	public synthetic fun checkCapacity (Ljava/lang/Object;I)V
-	public synthetic fun collectionIterator (Ljava/lang/Object;)Ljava/util/Iterator;
-	public synthetic fun collectionSize (Ljava/lang/Object;)I
-	public fun getDescriptor ()Lkotlinx/serialization/SerialDescriptor;
-	public synthetic fun insert (Ljava/lang/Object;ILjava/lang/Object;)V
 	public synthetic fun toBuilder (Ljava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun toResult (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -330,26 +330,6 @@ public final class kotlinx/serialization/SerialDescriptor$DefaultImpls {
 	public static fun isNullable (Lkotlinx/serialization/SerialDescriptor;)Z
 }
 
-public final class kotlinx/serialization/SerialDescriptorBuilder {
-	public final fun element (Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;Z)V
-	public static synthetic fun element$default (Lkotlinx/serialization/SerialDescriptorBuilder;Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;ZILjava/lang/Object;)V
-	public final fun getAnnotations ()Ljava/util/List;
-	public final fun getSerialName ()Ljava/lang/String;
-	public final fun isNullable ()Z
-	public final fun listDescriptor (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
-	public final fun mapDescriptor (Lkotlinx/serialization/SerialDescriptor;Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
-	public final fun setAnnotations (Ljava/util/List;)V
-	public final fun setDescriptor (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
-	public final fun setNullable (Z)V
-}
-
-public final class kotlinx/serialization/SerialDescriptorBuilderKt {
-	public static final fun PrimitiveDescriptor (Ljava/lang/String;Lkotlinx/serialization/PrimitiveKind;)Lkotlinx/serialization/SerialDescriptor;
-	public static final fun SerialDescriptor (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
-	public static synthetic fun SerialDescriptor$default (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/SerialDescriptor;
-	public static final fun getNullable (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
-}
-
 public final class kotlinx/serialization/SerialDescriptorKt {
 	public static final fun elementDescriptors (Lkotlinx/serialization/SerialDescriptor;)Ljava/util/List;
 	public static final fun elementNames (Lkotlinx/serialization/SerialDescriptor;)Ljava/util/List;
@@ -517,6 +497,26 @@ public final class kotlinx/serialization/builtins/LongAsStringSerializer : kotli
 	public synthetic fun patch (Lkotlinx/serialization/Decoder;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun serialize (Lkotlinx/serialization/Encoder;J)V
 	public synthetic fun serialize (Lkotlinx/serialization/Encoder;Ljava/lang/Object;)V
+}
+
+public final class kotlinx/serialization/descriptors/SerialDescriptorBuilder {
+	public final fun element (Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;Z)V
+	public static synthetic fun element$default (Lkotlinx/serialization/descriptors/SerialDescriptorBuilder;Ljava/lang/String;Lkotlinx/serialization/SerialDescriptor;Ljava/util/List;ZILjava/lang/Object;)V
+	public final fun getAnnotations ()Ljava/util/List;
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun isNullable ()Z
+	public final fun listDescriptor (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
+	public final fun mapDescriptor (Lkotlinx/serialization/SerialDescriptor;Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
+	public final fun setAnnotations (Ljava/util/List;)V
+	public final fun setDescriptor (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
+	public final fun setNullable (Z)V
+}
+
+public final class kotlinx/serialization/descriptors/SerialDescriptorBuilderKt {
+	public static final fun PrimitiveDescriptor (Ljava/lang/String;Lkotlinx/serialization/PrimitiveKind;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun SerialDescriptor (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/SerialDescriptor;
+	public static synthetic fun SerialDescriptor$default (Ljava/lang/String;Lkotlinx/serialization/SerialKind;[Lkotlinx/serialization/SerialDescriptor;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/SerialDescriptor;
+	public static final fun getNullable (Lkotlinx/serialization/SerialDescriptor;)Lkotlinx/serialization/SerialDescriptor;
 }
 
 public abstract class kotlinx/serialization/encoding/AbstractDecoder : kotlinx/serialization/CompositeDecoder, kotlinx/serialization/Decoder {

--- a/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
@@ -32,7 +32,7 @@ public class ContextSerializer<T : Any>(
     public constructor(serializableClass: KClass<T>) : this(serializableClass, null, EMPTY_SERIALIZER_ARRAY)
 
     public override val descriptor: SerialDescriptor =
-        SerialDescriptor("kotlinx.serialization.ContextSerializer", UnionKind.CONTEXTUAL).withContext(serializableClass)
+        buildSerialDescriptor("kotlinx.serialization.ContextSerializer", UnionKind.CONTEXTUAL).withContext(serializableClass)
 
     public override fun serialize(encoder: Encoder, value: T) {
         val clz = value::class

--- a/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ContextSerializer.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.serialization
 
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.reflect.*

--- a/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
@@ -270,3 +271,32 @@ public fun <T : Any?> Encoder.encode(strategy: SerializationStrategy<T>, value: 
     ReplaceWith("encodeSerializableValue<T>(serializer(), value)"), DeprecationLevel.ERROR
 ) // TODO make internal when migrations are removed
 public fun <T : Any> Encoder.encode(obj: T): Unit = noImpl()
+
+@Deprecated(
+    "This method was renamed to buildClassSerialDescriptor during serialization 1.0 API stabilization",
+    ReplaceWith("buildClassSerialDescriptor(serialName, *typeParameters, builderAction)"), DeprecationLevel.ERROR
+)
+public fun SerialDescriptor(
+    serialName: String,
+    vararg typeParameters: SerialDescriptor,
+    builderAction: ClassSerialDescriptorBuilder.() -> Unit = {}
+): SerialDescriptor = noImpl()
+
+@Deprecated(
+    "Builder with SerialKind was deprecated without replacement during serialization 1.0 API stabilization. " +
+            "It is possible to migrate to buildClassSerialDescriptor(...) for class-like structures." +
+            "Please file an issue with your use case if was using this builder",
+    level = DeprecationLevel.ERROR
+)
+public fun SerialDescriptor(
+    serialName: String,
+    kind: SerialKind,
+    vararg typeParameters: SerialDescriptor,
+    builderAction: ClassSerialDescriptorBuilder.() -> Unit = {}
+): SerialDescriptor = noImpl()
+
+@Deprecated(
+    "This method was renamed to PrimitiveSerialDescriptor during serialization 1.0 API stabilization",
+    ReplaceWith("PrimitiveSerialDescriptor(serialName, kind)"), DeprecationLevel.ERROR
+)
+public fun PrimitiveDescriptor(serialName: String, kind: PrimitiveKind): SerialDescriptor = noImpl()

--- a/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
@@ -66,11 +66,11 @@ import kotlin.reflect.*
  */
 public class PolymorphicSerializer<T : Any>(override val baseClass: KClass<T>) : AbstractPolymorphicSerializer<T>() {
     public override val descriptor: SerialDescriptor =
-        SerialDescriptor("kotlinx.serialization.Polymorphic", PolymorphicKind.OPEN) {
+        buildSerialDescriptor("kotlinx.serialization.Polymorphic", PolymorphicKind.OPEN) {
             element("type", String.serializer().descriptor)
             element(
                 "value",
-                SerialDescriptor("kotlinx.serialization.Polymorphic<${baseClass.simpleName}>", UnionKind.CONTEXTUAL)
+                buildSerialDescriptor("kotlinx.serialization.Polymorphic<${baseClass.simpleName}>", UnionKind.CONTEXTUAL)
             )
         }.withContext(baseClass)
 }

--- a/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Polymorphic.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.reflect.*

--- a/runtime/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.reflect.*

--- a/runtime/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -75,10 +75,10 @@ public class SealedClassSerializer<T : Any>(
     subclassSerializers: Array<KSerializer<out T>>
 ) : AbstractPolymorphicSerializer<T>() {
 
-    override val descriptor: SerialDescriptor = SerialDescriptor(serialName, PolymorphicKind.SEALED) {
+    override val descriptor: SerialDescriptor = buildSerialDescriptor(serialName, PolymorphicKind.SEALED) {
         element("type", String.serializer().descriptor)
         val elementDescriptor =
-            SerialDescriptor("kotlinx.serialization.Sealed<${baseClass.simpleName}>", UnionKind.CONTEXTUAL) {
+            buildSerialDescriptor("kotlinx.serialization.Sealed<${baseClass.simpleName}>", UnionKind.CONTEXTUAL) {
                 subclassSerializers.forEach {
                     val d = it.descriptor
                     element(d.serialName, d)

--- a/runtime/commonMain/src/kotlinx/serialization/SerialDescriptor.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SerialDescriptor.kt
@@ -117,7 +117,7 @@ package kotlinx.serialization
  * }
  * ```
  *
- * For a classes that are represented as a single primitive value, [PrimitiveDescriptor] builder function can be used instead.
+ * For a classes that are represented as a single primitive value, [PrimitiveSerialDescriptor] builder function can be used instead.
  */
 public interface SerialDescriptor {
     /**

--- a/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -8,6 +8,9 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.builtins.MapEntrySerializer
+import kotlinx.serialization.builtins.TripleSerializer
+import kotlinx.serialization.builtins.PairSerializer
 import kotlinx.serialization.internal.*
 import kotlin.jvm.*
 import kotlin.reflect.*

--- a/runtime/commonMain/src/kotlinx/serialization/builtins/LongAsStringSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/builtins/LongAsStringSerializer.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.descriptors.*
  */
 public object LongAsStringSerializer : KSerializer<Long> {
     override val descriptor: SerialDescriptor =
-        PrimitiveDescriptor("kotlinx.serialization.LongAsStringSerializer", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.serialization.LongAsStringSerializer", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: Long) {
         encoder.encodeString(value.toString())

--- a/runtime/commonMain/src/kotlinx/serialization/builtins/LongAsStringSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/builtins/LongAsStringSerializer.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.builtins
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 
 
 /**

--- a/runtime/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptorBuilder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptorBuilder.kt
@@ -2,8 +2,9 @@
  * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package kotlinx.serialization
+package kotlinx.serialization.descriptors
 
+import kotlinx.serialization.*
 import kotlinx.serialization.internal.*
 
 /**

--- a/runtime/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -6,11 +6,12 @@ package kotlinx.serialization.descriptors
 
 import kotlinx.serialization.*
 import kotlinx.serialization.internal.*
+import kotlin.reflect.*
 
 /**
  * Builder for [SerialDescriptor].
  * The resulting descriptor will be uniquely identified by the given [serialName], [typeParameters] and
- * elements structure described in [builder] function.
+ * elements structure described in [builderAction] function.
  *
  * Example:
  * ```
@@ -44,16 +45,21 @@ import kotlinx.serialization.internal.*
  * ```
  */
 @Suppress("FunctionName")
-public fun SerialDescriptor(
+public fun buildClassSerialDescriptor(
     serialName: String,
-    kind: SerialKind = StructureKind.CLASS,
     vararg typeParameters: SerialDescriptor,
-    builder: SerialDescriptorBuilder.() -> Unit = {}
+    builderAction: ClassSerialDescriptorBuilder.() -> Unit = {}
 ): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
-    val sdBuilder = SerialDescriptorBuilder(serialName)
-    sdBuilder.builder()
-    return SerialDescriptorImpl(serialName, kind, sdBuilder.elementNames.size, typeParameters.toList(), sdBuilder)
+    val sdBuilder = ClassSerialDescriptorBuilder(serialName)
+    sdBuilder.builderAction()
+    return SerialDescriptorImpl(
+        serialName,
+        StructureKind.CLASS,
+        sdBuilder.elementNames.size,
+        typeParameters.toList(),
+        sdBuilder
+    )
 }
 
 /**
@@ -74,9 +80,65 @@ public fun SerialDescriptor(
  * }
  * ```
  */
-public fun PrimitiveDescriptor(serialName: String, kind: PrimitiveKind): SerialDescriptor {
+public fun PrimitiveSerialDescriptor(serialName: String, kind: PrimitiveKind): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
     return PrimitiveDescriptorSafe(serialName, kind)
+}
+
+/**
+ * Retrieves descriptor of type [T] using reified [serializer] function.
+ */
+public inline fun <reified T> serialDescriptor(): SerialDescriptor = serializer<T>().descriptor
+
+/**
+ * Retrieves descriptor of type associated with the given [KType][type]
+ */
+public fun serialDescriptor(type: KType): SerialDescriptor = serializer(type).descriptor
+
+/**
+ * Creates a descriptor for the type `List<T>` where `T` is the type associated with [elementDescriptor].
+ */
+public fun listSerialDescriptor(elementDescriptor: SerialDescriptor): SerialDescriptor {
+    return ArrayListClassDesc(elementDescriptor)
+}
+
+/**
+ * Creates a descriptor for the type `List<T>`.
+ */
+public inline fun <reified T> listSerialDescriptor(): SerialDescriptor {
+    return listSerialDescriptor(serializer<T>().descriptor)
+}
+
+/**
+ * Creates a descriptor for the type `Map<K, V>` where `K` and `V` are types
+ * associated with [keyDescriptor] and [valueDescriptor] respectively.
+ */
+public fun mapSerialDescriptor(
+    keyDescriptor: SerialDescriptor,
+    valueDescriptor: SerialDescriptor
+): SerialDescriptor {
+    return HashMapClassDesc(keyDescriptor, valueDescriptor)
+}
+
+/**
+ * Creates a descriptor for the type `Map<K, V>`.
+ */
+public inline fun <reified K, reified V> mapSerialDescriptor(): SerialDescriptor {
+    return mapSerialDescriptor(serializer<K>().descriptor, serializer<V>().descriptor)
+}
+
+/**
+ * Creates a descriptor for the type `Set<T>` where `T` is the type associated with [elementDescriptor].
+ */
+public fun setSerialDescriptor(elementDescriptor: SerialDescriptor): SerialDescriptor {
+    return HashSetClassDesc(elementDescriptor)
+}
+
+/**
+ * Creates a descriptor for the type `Set<T>`.
+ */
+public inline fun <reified T> setSerialDescriptor(): SerialDescriptor {
+    return setSerialDescriptor(serializer<T>().descriptor)
 }
 
 /**
@@ -99,12 +161,15 @@ public val SerialDescriptor.nullable: SerialDescriptor
  *
  * Please refer to [SerialDescriptor] builder function for a complete example.
  */
-public class SerialDescriptorBuilder internal constructor(
+public class ClassSerialDescriptorBuilder internal constructor(
     public val serialName: String
 ) {
-    /**
-     * Whether the resulting descriptor represents [nullable][SerialDescriptor.isNullable] type
-     */
+
+    @Deprecated(
+        "isNullable was deprecated during serialization 1.0 API stabilization. " +
+                "Please use .nullable extension on the resultin serial descriptor instead",
+        level = DeprecationLevel.ERROR
+    )
     public var isNullable: Boolean = false
 
     /**
@@ -163,56 +228,51 @@ public class SerialDescriptorBuilder internal constructor(
     }
 
 
-    /**
-     * Retrieves descriptor of type [T] using reified [serializer] function.
-     */
+    @Deprecated(
+        "Renamed to serialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("serialDescriptor<T>()")
+    )
     public inline fun <reified T> descriptor(): SerialDescriptor = serializer<T>().descriptor
 
-    /**
-     * Creates a descriptor for the type `List<T>` where `T` is the type associated with [typeDescriptor].
-     */
-    public fun listDescriptor(typeDescriptor: SerialDescriptor): SerialDescriptor {
-        return ArrayListClassDesc(typeDescriptor)
-    }
+    @Deprecated(
+        "Renamed to listSerialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("listSerialDescriptor(typeDescriptor)")
+    )
+    public fun listDescriptor(typeDescriptor: SerialDescriptor): SerialDescriptor = listSerialDescriptor(typeDescriptor)
 
-    /**
-     * Creates a descriptor for the type `List<T>`.
-     */
-    public inline fun <reified T> listDescriptor(): SerialDescriptor {
-        return listDescriptor(serializer<T>().descriptor)
-    }
+    @Deprecated(
+        "Renamed to listSerialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("listSerialDescriptor<T>()")
+    )
+    public inline fun <reified T> listDescriptor(): SerialDescriptor = listSerialDescriptor<T>()
 
-    /**
-     * Creates a descriptor for the type `Map<K, V>` where `K` and `V` are types
-     * associated with [keyDescriptor] and [valueDescriptor] respectively.
-     */
+    @Deprecated(
+        "Renamed to mapSerialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("mapSerialDescriptor(keyDescriptor, valueDescriptor)")
+    )
     public fun mapDescriptor(
         keyDescriptor: SerialDescriptor,
         valueDescriptor: SerialDescriptor
-    ): SerialDescriptor {
-        return HashMapClassDesc(keyDescriptor, valueDescriptor)
-    }
+    ): SerialDescriptor = HashMapClassDesc(keyDescriptor, valueDescriptor)
 
-    /**
-     * Creates a descriptor for the type `Map<K, V>`.
-     */
-    public inline fun <reified K, reified V> mapDescriptor(): SerialDescriptor {
-        return mapDescriptor(serializer<K>().descriptor, serializer<V>().descriptor)
-    }
+    @Deprecated(
+        "Renamed to mapSerialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("mapSerialDescriptor<K, V>()")
+    )
+    public inline fun <reified K, reified V> mapDescriptor(): SerialDescriptor =
+        mapSerialDescriptor(serializer<K>().descriptor, serializer<V>().descriptor)
 
-    /**
-     * Creates a descriptor for the type `Set<T>` where `T` is the type associated with [typeDescriptor].
-     */
-    public fun setDescriptor(typeDescriptor: SerialDescriptor): SerialDescriptor {
-        return HashSetClassDesc(typeDescriptor)
-    }
+    @Deprecated(
+        "Renamed to setSerialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("setSerialDescriptor(typeDescriptor)")
+    )
+    public fun setDescriptor(typeDescriptor: SerialDescriptor): SerialDescriptor = HashSetClassDesc(typeDescriptor)
 
-    /**
-     * Creates a descriptor for the type `Set<T>`.
-     */
-    public inline fun <reified T> setDescriptor(): SerialDescriptor {
-        return setDescriptor(serializer<T>().descriptor)
-    }
+    @Deprecated(
+        "Renamed to setSerialDescriptor() during serialization 1.0 API stabilization",
+        level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("setSerialDescriptor<T>()")
+    )
+    public inline fun <reified T> setDescriptor(): SerialDescriptor = setSerialDescriptor(serializer<T>().descriptor)
 }
 
 internal class SerialDescriptorImpl(
@@ -220,10 +280,9 @@ internal class SerialDescriptorImpl(
     override val kind: SerialKind,
     override val elementsCount: Int,
     typeParameters: List<SerialDescriptor>,
-    builder: SerialDescriptorBuilder
+    builder: ClassSerialDescriptorBuilder
 ) : SerialDescriptor {
 
-    public override val isNullable: Boolean = builder.isNullable
     public override val annotations: List<Annotation> = builder.annotations
 
     private val elementNames: Array<String> = builder.elementNames.toTypedArray()
@@ -255,3 +314,18 @@ internal class SerialDescriptorImpl(
         }
     }
 }
+
+// Counterpart of buildClassSerialDescriptor, but with kind
+@PublishedApi
+internal fun buildSerialDescriptor(
+    serialName: String,
+    kind: SerialKind,
+    vararg typeParameters: SerialDescriptor,
+    builder: ClassSerialDescriptorBuilder.() -> Unit = {}
+): SerialDescriptor {
+    require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
+    val sdBuilder = ClassSerialDescriptorBuilder(serialName)
+    sdBuilder.builder()
+    return SerialDescriptorImpl(serialName, kind, sdBuilder.elementNames.size, typeParameters.toList(), sdBuilder)
+}
+

--- a/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/CollectionSerializers.kt
@@ -249,7 +249,7 @@ public class LinkedHashSetSerializer<E>(
     level = DeprecationLevel.ERROR, message = "Use SetSerializer() instead",
     replaceWith = ReplaceWith("SetSerializer(eSerializer)", imports = ["kotlinx.serialization.builtins.SetSerializer"])
 )
-public class HashSetSerializer<E>(
+internal class HashSetSerializer<E>(
     eSerializer: KSerializer<E>
 ) : ListLikeSerializer<E, Set<E>, HashSet<E>>(eSerializer) {
 

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Enums.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Enums.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 
 /*
  * Descriptor used for explicitly serializable enums by the plugin.

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Enums.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Enums.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:Suppress("DEPRECATION_ERROR")
+
 package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
@@ -11,16 +11,15 @@ import kotlinx.serialization.descriptors.*
  * Descriptor used for explicitly serializable enums by the plugin.
  * Designed to be consistent with `EnumSerializer.descriptor` and weird plugin usage.
  */
-@InternalSerializationApi
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "For plugin-generated code")
-public class EnumDescriptor(
+@PublishedApi
+internal class EnumDescriptor(
     name: String,
     elementsCount: Int
 ) : PluginGeneratedSerialDescriptor(name, elementsCount = elementsCount) {
 
     override val kind: SerialKind = UnionKind.ENUM_KIND
     private val elementDescriptors by lazy {
-        Array(elementsCount) { SerialDescriptor(name + "." + getElementName(it), StructureKind.OBJECT) }
+        Array(elementsCount) { buildSerialDescriptor(name + "." + getElementName(it), StructureKind.OBJECT) }
     }
 
     override fun getElementDescriptor(index: Int): SerialDescriptor = elementDescriptors.getChecked(index)
@@ -54,10 +53,10 @@ public class EnumSerializer<T : Enum<T>>(
     private val values: Array<T>
 ) : KSerializer<T> {
 
-    override val descriptor: SerialDescriptor = SerialDescriptor(serialName, UnionKind.ENUM_KIND) {
+    override val descriptor: SerialDescriptor = buildSerialDescriptor(serialName, UnionKind.ENUM_KIND) {
         values.forEach {
             val fqn = "$serialName.${it.name}"
-            val enumMemberDescriptor = SerialDescriptor(fqn, StructureKind.OBJECT)
+            val enumMemberDescriptor = buildSerialDescriptor(fqn, StructureKind.OBJECT)
             element(it.name, enumMemberDescriptor)
         }
     }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.descriptors.*
  */
 @PublishedApi
 internal class ObjectSerializer<T : Any>(serialName: String, private val objectInstance: T) : KSerializer<T> {
-    override val descriptor: SerialDescriptor = SerialDescriptor(serialName, StructureKind.OBJECT)
+    override val descriptor: SerialDescriptor = buildSerialDescriptor(serialName, StructureKind.OBJECT)
 
     override fun serialize(encoder: Encoder, value: T) {
         encoder.beginStructure(descriptor).endStructure(descriptor)

--- a/runtime/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 
 /**
  * Serializer for Kotlin's singletons (denoted by `object` keyword).

--- a/runtime/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -11,10 +11,8 @@ import kotlinx.serialization.CompositeDecoder.Companion.UNKNOWN_NAME
 /**
  * Implementation that plugin uses to implement descriptors for auto-generated serializers.
  */
-// TODO get rid of the rest of the usages and make it hidden
-@InternalSerializationApi
-@Deprecated(level = DeprecationLevel.ERROR, message = "Should not be used in general code")
-public open class PluginGeneratedSerialDescriptor(
+@PublishedApi
+internal open class PluginGeneratedSerialDescriptor(
     override val serialName: String,
     private val generatedSerializer: GeneratedSerializer<*>? = null,
     final override val elementsCount: Int

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
@@ -81,7 +81,7 @@ public class MapEntrySerializer<K, V>(
     /*
      * Kind 'MAP' because it is represented in a map-like manner with "key: value" serialized directly
      */
-    override val descriptor: SerialDescriptor = SerialDescriptor("kotlin.collections.Map.Entry", StructureKind.MAP) {
+    override val descriptor: SerialDescriptor = buildSerialDescriptor("kotlin.collections.Map.Entry", StructureKind.MAP) {
         element("key", keySerializer.descriptor)
         element("value", valueSerializer.descriptor)
     }
@@ -102,7 +102,7 @@ public class PairSerializer<K, V>(
     keySerializer: KSerializer<K>,
     valueSerializer: KSerializer<V>
 ) : KeyValueSerializer<K, V, Pair<K, V>>(keySerializer, valueSerializer) {
-    override val descriptor: SerialDescriptor = SerialDescriptor("kotlin.Pair") {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("kotlin.Pair") {
         element("first", keySerializer.descriptor)
         element("second", valueSerializer.descriptor)
     }
@@ -128,7 +128,7 @@ public class TripleSerializer<A, B, C>(
     private val cSerializer: KSerializer<C>
 ) : KSerializer<Triple<A, B, C>> {
 
-    override val descriptor: SerialDescriptor = SerialDescriptor("kotlin.Triple") {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("kotlin.Triple") {
         element("first", aSerializer.descriptor)
         element("second", bSerializer.descriptor)
         element("third", cSerializer.descriptor)

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tuples.kt
@@ -6,6 +6,7 @@
 package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlin.native.concurrent.*
 
 @SharedImmutable

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElementSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElementSerializer.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.json
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.internal.*
 
 /**
@@ -24,7 +25,7 @@ import kotlinx.serialization.internal.*
 @Serializer(forClass = JsonElement::class)
 public object JsonElementSerializer : KSerializer<JsonElement> {
     override val descriptor: SerialDescriptor =
-        SerialDescriptor("kotlinx.serialization.json.JsonElement", PolymorphicKind.SEALED) {
+        buildSerialDescriptor("kotlinx.serialization.json.JsonElement", PolymorphicKind.SEALED) {
             // Resolve cyclic dependency in descriptors by late binding
             element("JsonPrimitive", defer { JsonPrimitiveSerializer.descriptor })
             element("JsonNull", defer { JsonNullSerializer.descriptor })
@@ -55,7 +56,7 @@ public object JsonElementSerializer : KSerializer<JsonElement> {
 @Serializer(forClass = JsonPrimitive::class)
 public object JsonPrimitiveSerializer : KSerializer<JsonPrimitive> {
     override val descriptor: SerialDescriptor =
-        SerialDescriptor("kotlinx.serialization.json.JsonPrimitive", PrimitiveKind.STRING)
+        buildSerialDescriptor("kotlinx.serialization.json.JsonPrimitive", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: JsonPrimitive) {
         verify(encoder)
@@ -81,7 +82,7 @@ public object JsonPrimitiveSerializer : KSerializer<JsonPrimitive> {
 public object JsonNullSerializer : KSerializer<JsonNull> {
     // technically, JsonNull is an object, but it does not call beginStructure/endStructure at all
     override val descriptor: SerialDescriptor =
-        SerialDescriptor("kotlinx.serialization.json.JsonNull", UnionKind.ENUM_KIND)
+        buildSerialDescriptor("kotlinx.serialization.json.JsonNull", UnionKind.ENUM_KIND)
 
     override fun serialize(encoder: Encoder, value: JsonNull) {
         verify(encoder)
@@ -98,7 +99,7 @@ public object JsonNullSerializer : KSerializer<JsonNull> {
 private object JsonLiteralSerializer : KSerializer<JsonLiteral> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveDescriptor("kotlinx.serialization.json.JsonLiteral", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.serialization.json.JsonLiteral", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: JsonLiteral) {
         verify(encoder)

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElementSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElementSerializer.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 
 /**

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonParametricSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonParametricSerializer.kt
@@ -72,7 +72,7 @@ public abstract class JsonParametricSerializer<T : Any>(private val baseClass: K
      * for schema generating/introspection purposes.
      */
     override val descriptor: SerialDescriptor =
-        SerialDescriptor("JsonParametricSerializer<${baseClass.simpleName}>", PolymorphicKind.OPEN)
+        buildSerialDescriptor("JsonParametricSerializer<${baseClass.simpleName}>", PolymorphicKind.OPEN)
 
     @OptIn(UnsafeSerializationApi::class)
     final override fun serialize(encoder: Encoder, value: T) {

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonParametricSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonParametricSerializer.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.reflect.*

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt
@@ -67,7 +67,7 @@ public abstract class JsonTransformingSerializer<T : Any>(
      * However, this descriptor can be overridden to achieve better representation of the resulting JSON shape
      * for schema generating or introspection purposes.
      */
-    override val descriptor: SerialDescriptor = SerialDescriptor(
+    override val descriptor: SerialDescriptor = buildSerialDescriptor(
         "JsonTransformingSerializer<${tSerializer.descriptor.serialName}>($transformationName)",
         tSerializer.descriptor.kind
     )

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.internal.*
 
 /**

--- a/runtime/commonTest/src/kotlinx/serialization/EnumSerializationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/EnumSerializationTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.serialization
 
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.JsonTestBase
 import kotlinx.serialization.test.*
 import kotlin.test.*

--- a/runtime/commonTest/src/kotlinx/serialization/EnumSerializationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/EnumSerializationTest.kt
@@ -46,9 +46,9 @@ class EnumSerializationTest : JsonTestBase() {
 
     @Serializer(WithCustom::class)
     private class CustomEnumSerializer : KSerializer<WithCustom> {
-        override val descriptor: SerialDescriptor = SerialDescriptor("WithCustom", UnionKind.ENUM_KIND) {
-            element("1", SerialDescriptor("WithCustom.1", StructureKind.OBJECT))
-            element("2", SerialDescriptor("WithCustom.2", StructureKind.OBJECT))
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("WithCustom", UnionKind.ENUM_KIND) {
+            element("1", buildSerialDescriptor("WithCustom.1", StructureKind.OBJECT))
+            element("2", buildSerialDescriptor("WithCustom.2", StructureKind.OBJECT))
         }
 
         override fun serialize(encoder: Encoder, value: WithCustom) {

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorBuilderTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorBuilderTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorBuilderTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorBuilderTest.kt
@@ -15,11 +15,11 @@ class SerialDescriptorBuilderTest {
     @SerialName("Wrapper")
     class Wrapper(val i: Int)
 
-    private val wrapperDescriptor = SerialDescriptor("Wrapper", StructureKind.CLASS) {
+    private val wrapperDescriptor = buildClassSerialDescriptor("Wrapper") {
         element("i", Int.serializer().descriptor)
     }
 
-    private val dataHolderDescriptor = SerialDescriptor("DataHolder", StructureKind.CLASS) {
+    private val dataHolderDescriptor = buildClassSerialDescriptor("DataHolder") {
         element<String>("string")
         element("nullableWrapper", wrapperDescriptor.nullable)
         element("wrapper", wrapperDescriptor)
@@ -53,9 +53,9 @@ class SerialDescriptorBuilderTest {
     class Box<T>(val value: T, val list: List<T>)
 
     class CustomBoxSerializer<T>(val typeSerializer: KSerializer<T>) {
-        val descriptor: SerialDescriptor = SerialDescriptor("Box", StructureKind.CLASS) {
+        val descriptor: SerialDescriptor = buildClassSerialDescriptor("Box") {
             element("value", typeSerializer.descriptor)
-            element("list", listDescriptor(typeSerializer.descriptor))
+            element("list", listSerialDescriptor(typeSerializer.descriptor))
         }
     }
 
@@ -73,17 +73,17 @@ class SerialDescriptorBuilderTest {
     @Test
     fun testMisconfiguration() {
         assertFailsWith<IllegalArgumentException> {
-            SerialDescriptor("a", StructureKind.CLASS) {
+            buildClassSerialDescriptor("a") {
                 element<Int>("i")
                 element<Int>("i")
             }
         }
 
-        assertFailsWith<IllegalArgumentException> { SerialDescriptor("", StructureKind.CLASS) }
-        assertFailsWith<IllegalArgumentException> { SerialDescriptor("\t", StructureKind.CLASS) }
-        assertFailsWith<IllegalArgumentException> { SerialDescriptor("   ", StructureKind.CLASS) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveDescriptor("", PrimitiveKind.STRING) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveDescriptor(" ", PrimitiveKind.STRING) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveDescriptor("\t", PrimitiveKind.STRING) }
+        assertFailsWith<IllegalArgumentException> { buildClassSerialDescriptor("") }
+        assertFailsWith<IllegalArgumentException> { buildClassSerialDescriptor("\t") }
+        assertFailsWith<IllegalArgumentException> { buildClassSerialDescriptor("   ") }
+        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("", PrimitiveKind.STRING) }
+        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor(" ", PrimitiveKind.STRING) }
+        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("\t", PrimitiveKind.STRING) }
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorEqualityTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorEqualityTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlin.test.*
 
 class SerialDescriptorEqualityTest {

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorEqualityTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorEqualityTest.kt
@@ -80,9 +80,9 @@ class SerialDescriptorEqualityTest {
     fun testCantBeComparedToUserDescriptor() {
         val typeParam = Int.serializer().descriptor
         val userDefinedWithInt =
-            SerialDescriptor("TypeParamUsedTwice", StructureKind.CLASS, typeParam) {
+            buildClassSerialDescriptor("TypeParamUsedTwice", typeParam) {
                 element("t", typeParam)
-                element("l", listDescriptor(typeParam))
+                element("l", listSerialDescriptor(typeParam))
             }
 
         val generatedWithInt = TypeParamUsedTwice.serializer(Int.serializer()).descriptor

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization
 
 import kotlinx.serialization.CompositeDecoder.Companion.UNKNOWN_NAME
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlin.test.*
 
 class SerialDescriptorSpecificationTest {

--- a/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -26,7 +26,7 @@ class SerialDescriptorSpecificationTest {
 
     private object StaticHolder {
         val userDefinedHolderDescriptor =
-            SerialDescriptor("kotlinx.serialization.SerialDescriptorSpecificationTest.Holder", StructureKind.CLASS) {
+            buildClassSerialDescriptor("kotlinx.serialization.SerialDescriptorSpecificationTest.Holder") {
                 element<Int?>("a")
                 val annotation = Holder.serializer().descriptor.findAnnotation<Id>(1)
                 element<String>("b", listOf(annotation!!), isOptional = true)
@@ -204,9 +204,9 @@ class SerialDescriptorSpecificationTest {
 
     @Test
     fun testCustomPrimitiveDescriptor() {
-        assertFailsWith<IllegalArgumentException> { PrimitiveDescriptor("kotlin.Int", PrimitiveKind.INT) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveDescriptor("Int", PrimitiveKind.INT) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveDescriptor("int", PrimitiveKind.INT) }
+        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("kotlin.Int", PrimitiveKind.INT) }
+        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("Int", PrimitiveKind.INT) }
+        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("int", PrimitiveKind.INT) }
     }
 
     private fun checkPrimitiveDescriptor(type: String, descriptor: SerialDescriptor) {

--- a/runtime/commonTest/src/kotlinx/serialization/features/BinaryPayloadExampleTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/BinaryPayloadExampleTest.kt
@@ -17,7 +17,7 @@ class BinaryPayloadExampleTest {
     class BinaryPayload(val req: ByteArray, val res: ByteArray) {
         @Serializer(forClass = BinaryPayload::class)
         companion object : KSerializer<BinaryPayload> {
-            override val descriptor: SerialDescriptor = SerialDescriptor("BinaryPayload") {
+            override val descriptor: SerialDescriptor = buildClassSerialDescriptor("BinaryPayload") {
                 element("req", ByteArraySerializer().descriptor)
                 element("res", ByteArraySerializer().descriptor)
             }

--- a/runtime/commonTest/src/kotlinx/serialization/features/BinaryPayloadExampleTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/BinaryPayloadExampleTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.features
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.Json
 import kotlin.test.Test

--- a/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.features
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*

--- a/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/ContextAndPolymorphicTest.kt
@@ -6,7 +6,7 @@ package kotlinx.serialization.features
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
-import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
@@ -35,7 +35,7 @@ class ContextAndPolymorphicTest {
     object PayloadSerializer
 
     object BinaryPayloadSerializer : KSerializer<Payload> {
-        override val descriptor: SerialDescriptor = PrimitiveDescriptor("BinaryPayload", PrimitiveKind.STRING)
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BinaryPayload", PrimitiveKind.STRING)
 
         override fun serialize(encoder: Encoder, value: Payload) {
             encoder.encodeString(InternalHexConverter.printHexBinary(value.s.encodeToByteArray()))

--- a/runtime/commonTest/src/kotlinx/serialization/features/GenericCustomSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/GenericCustomSerializerTest.kt
@@ -33,7 +33,7 @@ class CheckedData<T : Any>(val data: T, val checkSum: ByteArray) {
 
 @Serializer(forClass = CheckedData::class)
 class CheckedDataSerializer<T : Any>(private val dataSerializer: KSerializer<T>) : KSerializer<CheckedData<T>> {
-    override val descriptor: SerialDescriptor = SerialDescriptor("CheckedDataSerializer") {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("CheckedDataSerializer") {
         val dataDescriptor = dataSerializer.descriptor
         element("data", dataDescriptor)
         element("checkSum", ByteArraySerializer().descriptor)

--- a/runtime/commonTest/src/kotlinx/serialization/features/GenericCustomSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/GenericCustomSerializerTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.features
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
 import kotlin.test.*

--- a/runtime/commonTest/src/kotlinx/serialization/features/SchemaTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/SchemaTest.kt
@@ -18,9 +18,9 @@ class SchemaTest {
         @Serializer(forClass = Data1::class)
         companion object {
             // TODO removal of explicit type crashes the compiler
-            override val descriptor: SerialDescriptor = SerialDescriptor("Data1") {
-                element("l", listDescriptor<Int>(), isOptional = true)
-                element("s", descriptor<String>())
+            override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Data1") {
+                element("l", listSerialDescriptor<Int>(), isOptional = true)
+                element("s", serialDescriptor<String>())
             }
         }
     }

--- a/runtime/commonTest/src/kotlinx/serialization/features/SchemaTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/SchemaTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.features
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.test.EnumSerializer
 import kotlin.test.*

--- a/runtime/commonTest/src/kotlinx/serialization/features/SerializableWithTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/SerializableWithTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 
 object MultiplyingIntSerializer : KSerializer<Int> {
     override val descriptor: SerialDescriptor
-        get() = PrimitiveDescriptor("MultiplyingInt", PrimitiveKind.INT)
+        get() = PrimitiveSerialDescriptor("MultiplyingInt", PrimitiveKind.INT)
 
     override fun deserialize(decoder: Decoder): Int {
         return decoder.decodeInt() / 2
@@ -25,7 +25,7 @@ object MultiplyingIntSerializer : KSerializer<Int> {
 
 object DividingIntSerializer : KSerializer<Int> {
     override val descriptor: SerialDescriptor
-        get() = PrimitiveDescriptor("DividedInt", PrimitiveKind.INT)
+        get() = PrimitiveSerialDescriptor("DividedInt", PrimitiveKind.INT)
 
     override fun deserialize(decoder: Decoder): Int {
         return decoder.decodeInt() * 2

--- a/runtime/commonTest/src/kotlinx/serialization/features/SerializableWithTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/features/SerializableWithTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.features
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
@@ -25,7 +25,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     data class B(@Id(1) val value: Int)
 
     object BSerializer : KSerializer<B> {
-        override val descriptor: SerialDescriptor = PrimitiveDescriptor("B", PrimitiveKind.INT)
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("B", PrimitiveKind.INT)
         override fun serialize(encoder: Encoder, value: B) {
             encoder.encodeInt(value.value)
         }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.modules.*
 import kotlin.test.*
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonEncoderDecoderRecursiveTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonEncoderDecoderRecursiveTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlin.test.*
 
 class JsonEncoderDecoderRecursiveTest : JsonTestBase() {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonEncoderDecoderRecursiveTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonEncoderDecoderRecursiveTest.kt
@@ -123,11 +123,11 @@ class JsonEncoderDecoderRecursiveTest : JsonTestBase() {
     }
 
     private object EitherSerializer: KSerializer<Either> {
-        override val descriptor: SerialDescriptor = SerialDescriptor("Either", PolymorphicKind.SEALED) {
-            val leftDescriptor =  SerialDescriptor("Either.Left") {
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("Either", PolymorphicKind.SEALED) {
+            val leftDescriptor = buildClassSerialDescriptor("Either.Left") {
                 element<String>("errorMsg")
             }
-            val rightDescriptor =  SerialDescriptor("Either.Right") {
+            val rightDescriptor = buildClassSerialDescriptor("Either.Right") {
                 element("data", Payload.serializer().descriptor)
             }
             element("left", leftDescriptor)
@@ -176,7 +176,7 @@ class JsonEncoderDecoderRecursiveTest : JsonTestBase() {
         private const val typeNameB = "b"
 
         // TODO in builder is not suitable for recursive descriptors
-        override val descriptor: SerialDescriptor = SerialDescriptor("SealedRecursive", PolymorphicKind.SEALED) {
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("SealedRecursive", PolymorphicKind.SEALED) {
             element("a", SealedRecursive.A.serializer().descriptor)
             element("b", SealedRecursive.B.serializer().descriptor)
         }

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTreeAndMapperTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTreeAndMapperTest.kt
@@ -21,11 +21,11 @@ class JsonTreeAndMapperTest {
     }
 
     object EitherSerializer : KSerializer<Either> {
-        override val descriptor: SerialDescriptor = SerialDescriptor("Either", PolymorphicKind.SEALED) {
-            val leftDescriptor = SerialDescriptor("Either.Left") {
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("Either", PolymorphicKind.SEALED) {
+            val leftDescriptor = buildClassSerialDescriptor("Either.Left") {
                 element<String>("errorMsg")
             }
-            val rightDescriptor = SerialDescriptor("Either.Right") {
+            val rightDescriptor = buildClassSerialDescriptor("Either.Right") {
                 element("data", Payload.serializer().descriptor)
             }
             element("left", leftDescriptor)

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTreeAndMapperTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTreeAndMapperTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlin.test.*
 
 class JsonTreeAndMapperTest {

--- a/runtime/commonTest/src/kotlinx/serialization/json/MapLikeSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/MapLikeSerializerTest.kt
@@ -17,7 +17,7 @@ class MapLikeSerializerTest : JsonTestBase() {
     @Serializer(forClass = StringPair::class)
     object StringPairSerializer : KSerializer<StringPair> {
 
-        override val descriptor: SerialDescriptor = SerialDescriptor("package.StringPair", StructureKind.MAP) {
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("package.StringPair", StructureKind.MAP) {
             element<String>("a")
             element<String>("b")
         }

--- a/runtime/commonTest/src/kotlinx/serialization/json/MapLikeSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/MapLikeSerializerTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlin.test.*
 
 class MapLikeSerializerTest : JsonTestBase() {

--- a/runtime/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.PolyBase
 import kotlinx.serialization.PolyDerived
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.test.*
 import kotlin.reflect.*
 import kotlin.test.*

--- a/runtime/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
@@ -185,12 +185,12 @@ class ModuleBuildersTest {
 
     @Serializer(forClass = C::class)
     object CSerializer : KSerializer<C> {
-        override val descriptor: SerialDescriptor = SerialDescriptor("AnotherName", StructureKind.OBJECT)
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("AnotherName", StructureKind.OBJECT)
     }
 
     @Serializer(forClass = C::class)
     object CSerializer2 : KSerializer<C> {
-        override val descriptor: SerialDescriptor = SerialDescriptor("C", StructureKind.OBJECT)
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("C", StructureKind.OBJECT)
     }
 
     @Test

--- a/runtime/jsTest/src/kotlinx/serialization/DynamicParserTest.kt
+++ b/runtime/jsTest/src/kotlinx/serialization/DynamicParserTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.serialization
 
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 import kotlin.test.*

--- a/runtime/jsTest/src/kotlinx/serialization/DynamicParserTest.kt
+++ b/runtime/jsTest/src/kotlinx/serialization/DynamicParserTest.kt
@@ -52,7 +52,7 @@ class DynamicParserTest {
     data class NotDefault(val a: Int)
 
     object NDSerializer : KSerializer<NotDefault> {
-        override val descriptor = SerialDescriptor("notDefault") {
+        override val descriptor = buildClassSerialDescriptor("notDefault") {
             element<Int>("a")
         }
 

--- a/runtime/jsTest/src/kotlinx/serialization/DynamicSerializerTest.kt
+++ b/runtime/jsTest/src/kotlinx/serialization/DynamicSerializerTest.kt
@@ -1,6 +1,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.modules.EmptyModule

--- a/runtime/jsTest/src/kotlinx/serialization/DynamicSerializerTest.kt
+++ b/runtime/jsTest/src/kotlinx/serialization/DynamicSerializerTest.kt
@@ -77,7 +77,7 @@ class DynamicSerializerTest {
         @Serializer(forClass = MyFancyClass::class)
         companion object : KSerializer<MyFancyClass> {
 
-            override val descriptor: SerialDescriptor = PrimitiveDescriptor("MyFancyClass", PrimitiveKind.STRING)
+            override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("MyFancyClass", PrimitiveKind.STRING)
             override fun serialize(encoder: Encoder, value: MyFancyClass) {
                 encoder.encodeString("fancy ${value.value}")
             }

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializeJavaClassTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializeJavaClassTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 
 @Serializer(forClass = Date::class)
 object DateSerializer : KSerializer<Date> {
-    override val descriptor: SerialDescriptor = PrimitiveDescriptor("java.util.Date", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.util.Date", PrimitiveKind.STRING)
 
     // Consider wrapping in ThreadLocal if serialization may happen in multiple threads
     private val df: DateFormat = SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS").apply {

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializeJavaClassTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializeJavaClassTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.features
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import java.text.DateFormat

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.features
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.*
 import org.junit.Test
 import java.lang.reflect.*

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -26,7 +26,7 @@ class SerializerByTypeTest {
     data class WithCustomDefault(val n: Int) {
         @Serializer(forClass = WithCustomDefault::class)
         companion object {
-            override val descriptor: SerialDescriptor = PrimitiveDescriptor("WithCustomDefault", PrimitiveKind.INT)
+            override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("WithCustomDefault", PrimitiveKind.INT)
             override fun serialize(encoder: Encoder, value: WithCustomDefault) = encoder.encodeInt(value.n)
             override fun deserialize(decoder: Decoder) = WithCustomDefault(decoder.decodeInt())
         }


### PR DESCRIPTION
    * Rename file to SerialDescriptors
    * Provide top-level factories and typeOf API
    * Consistent future-proof naming of builders that allows to easily add new builders in the future
    * Remove builder with an arbitrary kind as too error-prone and incorrect anyway