### PR TITLE
No serializer message

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -43,7 +43,7 @@ public fun serializer(type: KType): KSerializer<Any?> {
         val rootClass = type.kclass()
 
         val typeArguments = type.arguments
-            .map { requireNotNull(it.type) { "Star projections are not allowed, had $it instead" } }
+            .map { requireNotNull(it.type) { "Star projections in type arguments are not allowed, but had $type" } }
         return when {
             typeArguments.isEmpty() -> rootClass.serializer()
             else -> {

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Platform.common.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Platform.common.kt
@@ -122,8 +122,8 @@ internal inline fun <T> DeserializationStrategy<*>.cast(): DeserializationStrate
 
 internal fun KClass<*>.serializerNotRegistered(): Nothing {
     throw SerializationException(
-        "Can't locate argument-less serializer for class ${simpleName}. " +
-                "For generic classes, such as lists, please provide serializer explicitly."
+        "Serializer for class '${simpleName}' is not found. " +
+            "Mark the class as @Serializable or provide the serializer explicitly."
     )
 }
 


### PR DESCRIPTION
Make it more helpful when someone tries to do `Json.encodeToString(data)` on a non-serializable class.