### PR TITLE
Incorrect ReplaceWith expression for deprecated function json 

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonMigrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonMigrations.kt
@@ -323,7 +323,7 @@ public fun JsonLiteral(value: Any?): JsonPrimitive = noImpl()
 
 @Deprecated(
     "json function deprecated for removal to be consistent with a standard library",
-    replaceWith = ReplaceWith("buildJsonObject"),
+    replaceWith = ReplaceWith("buildJsonObject(init)"),
     level = DeprecationLevel.ERROR
 )
 public fun json(init: JsonObjectBuilder.() -> Unit): JsonObject = noImpl()


### PR DESCRIPTION
To reproduce write as test:
```kotlin
@Test
fun testSome() {
    json {
        "a" to "b"
    }
}
```
and apply `Replace with` quick fix in the `Intellij IDEA` for the `json` function call.
Produced code will be the following:
```kotlin
@Test
fun testSome() {
    {
        "a" to "b"
    }
}
```

This PR fixes the first case in [KT-40230](https://youtrack.jetbrains.com/issue/KT-40230)