### PR TITLE
Retreive serializer for non-serializable enum on JVM

### DIFF
--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -810,6 +810,7 @@ public final class kotlinx/serialization/internal/EnumSerializer : kotlinx/seria
 	public synthetic fun patch (Lkotlinx/serialization/encoding/Decoder;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Enum;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class kotlinx/serialization/internal/FloatArrayBuilder : kotlinx/serialization/internal/PrimitiveArrayBuilder {

--- a/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -44,7 +44,6 @@ public inline fun <reified T> serializer(): KSerializer<T> {
 public fun serializer(type: KType): KSerializer<Any?> {
     fun serializerByKTypeImpl(type: KType): KSerializer<Any> {
         val rootClass = type.kclass()
-
         val typeArguments = type.arguments
             .map { requireNotNull(it.type) { "Star projections in type arguments are not allowed, but had $type" } }
         return when {

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Enums.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Enums.kt
@@ -47,10 +47,9 @@ internal class EnumDescriptor(
     }
 }
 
-// Used for enums that are not explicitly serializable
-@Deprecated(level = DeprecationLevel.ERROR, message = "For plugin-generated code, " +
-        "should not be used directly. For the custom serializers please report your use-case to project issues, so proper public API could be introduced instead")
-public class EnumSerializer<T : Enum<T>>(
+// Used for enums that are not explicitly serializable by the plugin
+@PublishedApi
+internal class EnumSerializer<T : Enum<T>>(
     serialName: String,
     private val values: Array<T>
 ) : KSerializer<T> {
@@ -78,4 +77,6 @@ public class EnumSerializer<T : Enum<T>>(
         }
         return values[index]
     }
+
+    override fun toString(): String = "kotlinx.serialization.internal.EnumSerializer<${descriptor.serialName}>"
 }

--- a/runtime/commonTest/src/kotlinx/serialization/test/TestHelpers.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/test/TestHelpers.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.internal.EnumSerializer
 import kotlin.test.*
 
 @Suppress("TestFunctionName")
-inline fun <reified E : Enum<E>> EnumSerializer(serialName: String): EnumSerializer<E> =
+internal inline fun <reified E : Enum<E>> EnumSerializer(serialName: String): EnumSerializer<E> =
     EnumSerializer(serialName, enumValues())
 
 

--- a/runtime/jvmMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/runtime/jvmMain/src/kotlinx/serialization/internal/Platform.kt
@@ -43,18 +43,31 @@ internal actual fun <T : Any> KClass<T>.constructSerializerForGivenTypeArgs(vara
     // Check whether it's serializable object
     findObjectSerializer(jClass)?.let { return it }
     // Search for default serializer if no serializer is defined in companion object.
-    return try {
+    val default = try {
         jClass.declaredClasses.singleOrNull { it.simpleName == ("\$serializer") }
             ?.getField("INSTANCE")?.get(null) as? KSerializer<T>
     } catch (e: NoSuchFieldException) {
         null
     }
+
+    if (default != null) return default
+    // Fallback: enum without @Serializable annotation as last resort
+    return createEnumSerializer()
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T : Any> KClass<T>.createEnumSerializer(): KSerializer<T>? {
+    if (!Enum::class.java.isAssignableFrom(java)) return null
+    val enum = java
+    val constants = enum.enumConstants
+    return EnumSerializer(enum.canonicalName, constants as Array<out Enum<*>>) as? KSerializer<T>
 }
 
 private fun <T : Any> findObjectSerializer(jClass: Class<T>): KSerializer<T>? {
     // Check it is an object without using kotlin-reflect
-    val field = jClass.declaredFields.singleOrNull { it.name == "INSTANCE" && it.type == jClass && Modifier.isStatic(it.modifiers) }
-        ?: return null
+    val field =
+        jClass.declaredFields.singleOrNull { it.name == "INSTANCE" && it.type == jClass && Modifier.isStatic(it.modifiers) }
+            ?: return null
     // Retrieve its instance and call serializer()
     val instance = field.get(null)
     val method =

--- a/runtime/jvmMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/runtime/jvmMain/src/kotlinx/serialization/internal/Platform.kt
@@ -57,7 +57,7 @@ internal actual fun <T : Any> KClass<T>.constructSerializerForGivenTypeArgs(vara
 
 @Suppress("UNCHECKED_CAST")
 private fun <T : Any> KClass<T>.createEnumSerializer(): KSerializer<T>? {
-    if (!Enum::class.java.isAssignableFrom(java)) return null
+    if (!Enum::class.java.isAssignableFrom(this.java)) return null
     val enum = java
     val constants = enum.enumConstants
     return EnumSerializer(enum.canonicalName, constants as Array<out Enum<*>>) as? KSerializer<T>

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -185,4 +185,12 @@ class SerializerByTypeTest {
         val superType = base::class.java.genericSuperclass!!
         return (superType as ParameterizedType).actualTypeArguments.first()!!
     }
+
+    enum class Foo
+
+    @Test
+    fun testNonSerializableEnum() {
+        val serializer = serializer<Foo>()
+        assertTrue { serializer.descriptor.kind is SerialKind.ENUM }
+    }
 }

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -191,6 +191,6 @@ class SerializerByTypeTest {
     @Test
     fun testNonSerializableEnum() {
         val serializer = serializer<Foo>()
-        assertTrue { serializer.descriptor.kind is SerialKind.ENUM }
+        assertTrue(serializer.descriptor.kind is SerialKind.ENUM)
     }
 }


### PR DESCRIPTION
On the rest of the platforms this feature is blocked by KT-14743 (or plugin intrinsics). Anyway, providing the best possible user-experience only on the biggest platform is better than provide nothing, but consistently

Fixes #913