### PR TITLE
Make Properties consistent with Json format and serialize enums as st…

### DIFF
--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.DECODE_DONE
 import kotlinx.serialization.internal.*
-import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 
 /**
@@ -90,9 +89,9 @@ public sealed class Hocon(
 
         override fun decodeTaggedNotNullMark(tag: T) = getTaggedConfigValue(tag).valueType() != ConfigValueType.NULL
 
-        override fun decodeTaggedEnum(tag: T, enumDescription: SerialDescriptor): Int {
+        override fun decodeTaggedEnum(tag: T, enumDescriptor: SerialDescriptor): Int {
             val s = validateAndCast<String>(tag, ConfigValueType.STRING)
-            return enumDescription.getElementIndexOrThrow(s)
+            return enumDescriptor.getElementIndexOrThrow(s)
         }
     }
 

--- a/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
@@ -63,8 +63,8 @@ public class Properties(override val serializersModule: SerializersModule = Empt
             // ignore nulls in output
         }
 
-        override fun encodeTaggedEnum(tag: String, enumDescription: SerialDescriptor, ordinal: Int) {
-            map[tag] = enumDescription.getElementName(ordinal)
+        override fun encodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor, ordinal: Int) {
+            map[tag] = enumDescriptor.getElementName(ordinal)
         }
     }
 
@@ -86,8 +86,8 @@ public class Properties(override val serializersModule: SerializersModule = Empt
             map[tag] = value
         }
 
-        override fun encodeTaggedEnum(tag: String, enumDescription: SerialDescriptor, ordinal: Int) {
-            map[tag] = enumDescription.getElementName(ordinal)
+        override fun encodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor, ordinal: Int) {
+            map[tag] = enumDescriptor.getElementName(ordinal)
         }
 
         override fun encodeTaggedNull(tag: String) {
@@ -112,10 +112,10 @@ public class Properties(override val serializersModule: SerializersModule = Empt
             return map.getValue(tag)
         }
 
-        override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int {
+        override fun decodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor): Int {
             return when (val taggedValue = map.getValue(tag)) {
                 is Int -> taggedValue
-                is String -> enumDescription.getElementIndex(taggedValue)
+                is String -> enumDescriptor.getElementIndex(taggedValue)
                 else -> throw SerializationException("Value of enum entry '$tag' is neither an Int nor a String")
             }
         }
@@ -156,10 +156,10 @@ public class Properties(override val serializersModule: SerializersModule = Empt
 
         override fun decodeTaggedValue(tag: String): Any = map.getValue(tag)!!
 
-        override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int {
+        override fun decodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor): Int {
             return when (val taggedValue = map.getValue(tag)!!) {
                 is Int -> taggedValue
-                is String -> enumDescription.getElementIndex(taggedValue)
+                is String -> enumDescriptor.getElementIndex(taggedValue)
                 else -> throw SerializationException("Value of enum entry '$tag' is neither an Int nor a String")
             }
         }

--- a/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/Properties.kt
@@ -62,6 +62,10 @@ public class Properties(override val serializersModule: SerializersModule = Empt
         override fun encodeTaggedNull(tag: String) {
             // ignore nulls in output
         }
+
+        override fun encodeTaggedEnum(tag: String, enumDescription: SerialDescriptor, ordinal: Int) {
+            map[tag] = enumDescription.getElementName(ordinal)
+        }
     }
 
     private inner class OutNullableMapper : NamedValueEncoder() {
@@ -80,6 +84,10 @@ public class Properties(override val serializersModule: SerializersModule = Empt
 
         override fun encodeTaggedValue(tag: String, value: Any) {
             map[tag] = value
+        }
+
+        override fun encodeTaggedEnum(tag: String, enumDescription: SerialDescriptor, ordinal: Int) {
+            map[tag] = enumDescription.getElementName(ordinal)
         }
 
         override fun encodeTaggedNull(tag: String) {

--- a/formats/properties/commonTest/src/kotlinx/serialization/PropertiesTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/PropertiesTest.kt
@@ -187,28 +187,16 @@ class PropertiesTest {
     }
 
     @Test
-    fun testEnum() {
-        val obj = EnumData(TestEnum.ZERO)
-        assertMappedAndRestored(
-                mapOf("data" to 0),
-                obj,
-                EnumData.serializer()
-        )
-    }
-
-    @Test
-    fun testNullableEnum() {
-        val obj = NullableEnumData(null, TestEnum.ONE)
-        assertMappedNullableAndRestored(
-                mapOf("data0" to null, "data1" to 1),
-                obj,
-                NullableEnumData.serializer()
-        )
-    }
-
-    @Test
     fun testEnumString() {
         val map = mapOf("data" to "ZERO")
+        val loaded = Properties.load(EnumData.serializer(), map)
+        assertEquals(EnumData(TestEnum.ZERO), loaded)
+    }
+
+
+    @Test
+    fun testEnumInteger() {
+        val map = mapOf("data" to 0)
         val loaded = Properties.load(EnumData.serializer(), map)
         assertEquals(EnumData(TestEnum.ZERO), loaded)
     }
@@ -216,6 +204,13 @@ class PropertiesTest {
     @Test
     fun testNullableEnumString() {
         val map = mapOf("data0" to null, "data1" to "ONE")
+        val loaded = Properties.loadNullable(NullableEnumData.serializer(), map)
+        assertEquals(NullableEnumData(null, TestEnum.ONE), loaded)
+    }
+
+    @Test
+    fun testNullableEnumInteger() {
+        val map = mapOf("data0" to null, "data1" to 1)
         val loaded = Properties.loadNullable(NullableEnumData.serializer(), map)
         assertEquals(NullableEnumData(null, TestEnum.ONE), loaded)
     }

--- a/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -44,7 +44,7 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
 
     protected open fun encodeTaggedEnum(
         tag: Tag,
-        enumDescription: SerialDescriptor,
+        enumDescriptor: SerialDescriptor,
         ordinal: Int
     ): Unit = encodeTaggedValue(tag, ordinal)
 
@@ -203,7 +203,7 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder,
     protected open fun decodeTaggedDouble(tag: Tag): Double = decodeTaggedValue(tag) as Double
     protected open fun decodeTaggedChar(tag: Tag): Char = decodeTaggedValue(tag) as Char
     protected open fun decodeTaggedString(tag: Tag): String = decodeTaggedValue(tag) as String
-    protected open fun decodeTaggedEnum(tag: Tag, enumDescription: SerialDescriptor): Int =
+    protected open fun decodeTaggedEnum(tag: Tag, enumDescriptor: SerialDescriptor): Int =
         decodeTaggedValue(tag) as Int
 
     protected open fun <T : Any?> decodeSerializableValue(deserializer: DeserializationStrategy<T>, previousValue: T?): T =

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -87,8 +87,8 @@ private sealed class AbstractJsonTreeDecoder(
 
     protected abstract fun currentElement(tag: String): JsonElement
 
-    override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
-        enumDescription.getElementIndexOrThrow(getValue(tag).content)
+    override fun decodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor): Int =
+        enumDescriptor.getElementIndexOrThrow(getValue(tag).content)
 
     override fun decodeTaggedNull(tag: String): Nothing? = null
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -80,9 +80,9 @@ private sealed class AbstractJsonTreeEncoder(
     override fun encodeTaggedString(tag: String, value: String) = putElement(tag, JsonPrimitive(value))
     override fun encodeTaggedEnum(
         tag: String,
-        enumDescription: SerialDescriptor,
+        enumDescriptor: SerialDescriptor,
         ordinal: Int
-    ) = putElement(tag, JsonPrimitive(enumDescription.getElementName(ordinal)))
+    ) = putElement(tag, JsonPrimitive(enumDescriptor.getElementName(ordinal)))
 
     override fun encodeTaggedValue(tag: String, value: Any) {
         putElement(tag, JsonPrimitive(value.toString()))


### PR DESCRIPTION
…ring literals instead of integer constants.

It seems to be legacy from initial implementation and cannot be changed later after 1.0 in a safe manner without additional flags, but for (java.lang.)Properties serializing enums as strings is the most desirable behaviour

Fixes #818