### PR TITLE
[API stabilization] JSON configuration becomes stricter

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -184,7 +184,6 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
 
     /**
      * Specifies indent string to use with [prettyPrint] mode.
-     * TODO specify whitespaces
      */
     public var prettyPrintIndent: String = conf.prettyPrintIndent
 
@@ -212,7 +211,7 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
 
     /**
      * Removes JSON specification restriction on
-     * special floating-point values such as `NaN` and `Infinity` and enables their serialization.
+     * special floating-point values such as `NaN` and `Infinity` and enables their serialization and deserialization.
      * When enabling it, please ensure that the receiving party will be able to encode and decode these special values.
      * `false` by default.
      */
@@ -228,8 +227,16 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
             "Class discriminator should not be specified when array polymorphism is specified"
         }
 
-        if (!prettyPrint) require(prettyPrintIndent == defaultIndent) {
-            "Indent should not be specified when default printing mode is used"
+        if (!prettyPrint) {
+            require(prettyPrintIndent == defaultIndent) {
+                "Indent should not be specified when default printing mode is used"
+            }
+        } else if (prettyPrintIndent != defaultIndent) {
+            // Values allowed by JSON specification as whitespaces
+            val allWhitespaces = prettyPrintIndent.all { it == ' ' || it == '\t' || it == '\r' || it == '\n' }
+            require(allWhitespaces) {
+                "Only whitespace, tab, newline and carriage return are allowed as pretty print symbols. Had $prettyPrintIndent"
+            }
         }
 
         return JsonConf(

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonElementSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonElementSerializer.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.internal.*
+import kotlinx.serialization.json.internal.JsonDecodingException
 
 /**
  * External [Serializer] object providing [SerializationStrategy] and [DeserializationStrategy] for [JsonElement].

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonExceptions.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonExceptions.kt
@@ -28,22 +28,30 @@ internal class JsonEncodingException(message: String) : JsonException(message)
 internal fun JsonDecodingException(offset: Int, message: String, input: String) =
     JsonDecodingException(offset, "$message.\n JSON input: ${input.minify(offset)}")
 
-internal fun InvalidFloatingPoint(value: Number, type: String, output: String) = JsonEncodingException(
-    "'$value' is not a valid '$type' as per JSON specification. " +
-            "You can enable 'serializeSpecialFloatingPointValues' property to serialize such values\n" +
+internal fun InvalidFloatingPoint(value: Number, output: String) = JsonEncodingException(
+    "Unexpected special floating-point value $value. By default, " +
+            "non-finite floating point values are prohibited because they do not conform JSON specification. " +
+            "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'\n" +
             "Current output: ${output.minify()}"
 )
 
-internal fun InvalidFloatingPoint(value: Number, key: String, type: String, output: String) = JsonEncodingException(
-    "'$value' with key '$key' is not a valid $type as per JSON specification. " +
-            "You can enable 'serializeSpecialFloatingPointValues' property to serialize such values.\n" +
+internal fun InvalidFloatingPointDecoded(value: Number, key: String, output: String) =
+    JsonDecodingException(-1, invalidFp(value, key, output))
+
+internal fun InvalidFloatingPoint(value: Number, key: String, output: String) =
+    JsonEncodingException(invalidFp(value, key, output))
+
+private fun invalidFp(value: Number, key: String, output: String): String {
+    return "Unexpected special floating-point value $value with key $key. By default, " +
+            "non-finite floating point values are prohibited because they do not conform JSON specification. " +
+            "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'\n" +
             "Current output: ${output.minify()}"
-)
+}
 
 internal fun UnknownKeyException(key: String, input: String) = JsonDecodingException(
     -1,
     "JSON encountered unknown key: '$key'. You can enable 'JsonBuilder.ignoreUnknownKeys' property to ignore unknown keys.\n" +
-            " JSON input: ${input.minify()}"
+            " Current input: ${input.minify()}"
 )
 
 internal fun InvalidKeyKindException(keyDescriptor: SerialDescriptor) = JsonEncodingException(

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonConf.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonConf.kt
@@ -5,17 +5,18 @@
 package kotlinx.serialization.json.internal
 
 import kotlinx.serialization.modules.*
+import kotlin.jvm.*
 
-// Mirror of the dеprecated JsonConfiguration. Not for external use.
+// Mirror of the deprecated JsonConfiguration. Not for external use.
 internal data class JsonConf(
-    public val encodeDefaults: Boolean = true,
-    public val ignoreUnknownKeys: Boolean = false,
-    public val isLenient: Boolean = false,
-    public val allowStructuredMapKeys: Boolean = false,
-    public val prettyPrint: Boolean = false,
-    public val prettyPrintIndent: String = "    ",
-    public val coerceInputValues: Boolean = false,
-    public val useArrayPolymorphism: Boolean = false,
-    public val classDiscriminator: String = "type",
-    public val allowSpecialFloatingPointValues: Boolean = false,
-    public val serializersModule: SerializersModule = EmptySerializersModule)
+    @JvmField public val encodeDefaults: Boolean = true,
+    @JvmField public val ignoreUnknownKeys: Boolean = false,
+    @JvmField public val isLenient: Boolean = false,
+    @JvmField public val allowStructuredMapKeys: Boolean = false,
+    @JvmField public val prettyPrint: Boolean = false,
+    @JvmField public val prettyPrintIndent: String = "    ",
+    @JvmField public val coerceInputValues: Boolean = false,
+    @JvmField public val useArrayPolymorphism: Boolean = false,
+    @JvmField public val classDiscriminator: String = "type",
+    @JvmField public val allowSpecialFloatingPointValues: Boolean = false,
+    @JvmField public val serializersModule: SerializersModule = EmptySerializersModule)

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
@@ -46,7 +46,7 @@ internal fun InvalidFloatingPointDecoded(value: Number, key: String, output: Str
 internal fun JsonReader.throwInvalidFloatingPointDecoded(result: Number): Nothing {
     fail("Unexpected special floating-point value $result. By default, " +
             "non-finite floating point values are prohibited because they do not conform JSON specification. " +
-            "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'")
+            "It is possible to deserialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'")
 }
 
 private fun unexpectedFpErrorMessage(value: Number, key: String, output: String): String {

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
@@ -52,7 +52,7 @@ internal fun JsonReader.throwInvalidFloatingPointDecoded(result: Number): Nothin
 private fun unexpectedFpErrorMessage(value: Number, key: String, output: String): String {
     return "Unexpected special floating-point value $value with key $key. By default, " +
             "non-finite floating point values are prohibited because they do not conform JSON specification. " +
-            "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'\n" +
+            "It is possible to deserialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'\n" +
             "Current output: ${output.minify()}"
 }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
@@ -4,9 +4,10 @@
 
 @file:Suppress("FunctionName")
 
-package kotlinx.serialization.json
+package kotlinx.serialization.json.internal
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 import kotlinx.serialization.descriptors.*
 
 /**
@@ -28,20 +29,27 @@ internal class JsonEncodingException(message: String) : JsonException(message)
 internal fun JsonDecodingException(offset: Int, message: String, input: String) =
     JsonDecodingException(offset, "$message.\n JSON input: ${input.minify(offset)}")
 
-internal fun InvalidFloatingPoint(value: Number, output: String) = JsonEncodingException(
+internal fun InvalidFloatingPointEncoded(value: Number, output: String) = JsonEncodingException(
     "Unexpected special floating-point value $value. By default, " +
             "non-finite floating point values are prohibited because they do not conform JSON specification. " +
             "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'\n" +
             "Current output: ${output.minify()}"
 )
 
+internal fun InvalidFloatingPointEncoded(value: Number, key: String, output: String) =
+    JsonEncodingException(unexpectedFpErrorMessage(value, key, output))
+
 internal fun InvalidFloatingPointDecoded(value: Number, key: String, output: String) =
-    JsonDecodingException(-1, invalidFp(value, key, output))
+    JsonDecodingException(-1, unexpectedFpErrorMessage(value, key, output))
 
-internal fun InvalidFloatingPoint(value: Number, key: String, output: String) =
-    JsonEncodingException(invalidFp(value, key, output))
+// Extension on JSON reader and fail immediately
+internal fun JsonReader.throwInvalidFloatingPointDecoded(result: Number): Nothing {
+    fail("Unexpected special floating-point value $result. By default, " +
+            "non-finite floating point values are prohibited because they do not conform JSON specification. " +
+            "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'")
+}
 
-private fun invalidFp(value: Number, key: String, output: String): String {
+private fun unexpectedFpErrorMessage(value: Number, key: String, output: String): String {
     return "Unexpected special floating-point value $value with key $key. By default, " +
             "non-finite floating point values are prohibited because they do not conform JSON specification. " +
             "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'\n" +

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonReader.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonReader.kt
@@ -4,7 +4,6 @@
 
 package kotlinx.serialization.json.internal
 
-import kotlinx.serialization.json.*
 import kotlinx.serialization.json.internal.EscapeCharMappings.ESCAPE_2_CHAR
 import kotlin.jvm.*
 import kotlin.native.concurrent.*

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -202,20 +202,14 @@ internal class StreamingJsonDecoder internal constructor(
         val result = reader.takeString().parse("float") { toFloat() }
         val specialFp = json.configuration.allowSpecialFloatingPointValues
         if (specialFp || result.isFinite()) return result
-        unexpectedFp(result)
+        reader.throwInvalidFloatingPointDecoded(result)
     }
 
     override fun decodeDouble(): Double {
         val result = reader.takeString().parse("double") { toDouble() }
         val specialFp = json.configuration.allowSpecialFloatingPointValues
         if (specialFp || result.isFinite()) return result
-        unexpectedFp(result)
-    }
-
-    private fun unexpectedFp(result: Number): Nothing {
-        reader.fail("Unexpected special floating-point value $result. By default, " +
-                "non-finite floating point values are prohibited because they do not conform JSON specification. " +
-                "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'")
+        reader.throwInvalidFloatingPointDecoded(result)
     }
 
     override fun decodeChar(): Char = reader.takeString().parse("char") { single() }

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -6,9 +6,9 @@ package kotlinx.serialization.json.internal
 
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 import kotlinx.serialization.internal.*
-import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 import kotlin.jvm.*
@@ -197,8 +197,27 @@ internal class StreamingJsonDecoder internal constructor(
     override fun decodeShort(): Short = reader.takeString().parse("short") { toShort() }
     override fun decodeInt(): Int = reader.takeString().parse("int") { toInt() }
     override fun decodeLong(): Long = reader.takeString().parse("long") { toLong() }
-    override fun decodeFloat(): Float = reader.takeString().parse("float") { toFloat() }
-    override fun decodeDouble(): Double = reader.takeString().parse("double") { toDouble() }
+
+    override fun decodeFloat(): Float {
+        val result = reader.takeString().parse("float") { toFloat() }
+        val specialFp = json.configuration.allowSpecialFloatingPointValues
+        if (specialFp || result.isFinite()) return result
+        unexpectedFp(result)
+    }
+
+    override fun decodeDouble(): Double {
+        val result = reader.takeString().parse("double") { toDouble() }
+        val specialFp = json.configuration.allowSpecialFloatingPointValues
+        if (specialFp || result.isFinite()) return result
+        unexpectedFp(result)
+    }
+
+    private fun unexpectedFp(result: Number): Nothing {
+        reader.fail("Unexpected special floating-point value $result. By default, " +
+                "non-finite floating point values are prohibited because they do not conform JSON specification. " +
+                "It is possible to serialize them using 'JsonBuilder.allowSpecialFloatingPointValues = true'")
+    }
+
     override fun decodeChar(): Char = reader.takeString().parse("char") { single() }
 
     override fun decodeString(): String {

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -158,7 +158,7 @@ internal class StreamingJsonEncoder(
         // First encode value, then check, to have a prettier error message
         if (forceQuoting) encodeString(value.toString()) else composer.print(value)
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, "float", composer.sb.toString())
+            throw InvalidFloatingPoint(value, composer.sb.toString())
         }
     }
 
@@ -166,7 +166,7 @@ internal class StreamingJsonEncoder(
         // First encode value, then check, to have a prettier error message
         if (forceQuoting) encodeString(value.toString()) else composer.print(value)
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, "double", composer.sb.toString())
+            throw InvalidFloatingPoint(value, composer.sb.toString())
         }
     }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -158,7 +158,7 @@ internal class StreamingJsonEncoder(
         // First encode value, then check, to have a prettier error message
         if (forceQuoting) encodeString(value.toString()) else composer.print(value)
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, composer.sb.toString())
+            throw InvalidFloatingPointEncoded(value, composer.sb.toString())
         }
     }
 
@@ -166,7 +166,7 @@ internal class StreamingJsonEncoder(
         // First encode value, then check, to have a prettier error message
         if (forceQuoting) encodeString(value.toString()) else composer.print(value)
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, composer.sb.toString())
+            throw InvalidFloatingPointEncoded(value, composer.sb.toString())
         }
     }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -109,8 +109,21 @@ private sealed class AbstractJsonTreeDecoder(
     override fun decodeTaggedShort(tag: String) = getValue(tag).primitive("short") { int.toShort() }
     override fun decodeTaggedInt(tag: String) = getValue(tag).primitive("int") { int }
     override fun decodeTaggedLong(tag: String) = getValue(tag).primitive("long") { long }
-    override fun decodeTaggedFloat(tag: String) = getValue(tag).primitive("float") { float }
-    override fun decodeTaggedDouble(tag: String) = getValue(tag).primitive("double") { double }
+
+    override fun decodeTaggedFloat(tag: String): Float {
+        val result = getValue(tag).primitive("float") { float }
+        val specialFp = json.configuration.allowSpecialFloatingPointValues
+        if (specialFp || result.isFinite()) return result
+        throw InvalidFloatingPointDecoded(result, tag, currentObject().toString())
+    }
+
+    override fun decodeTaggedDouble(tag: String): Double {
+        val result = getValue(tag).primitive("double") { double }
+        val specialFp = json.configuration.allowSpecialFloatingPointValues
+        if (specialFp || result.isFinite()) return result
+        throw InvalidFloatingPointDecoded(result, tag, currentObject().toString())
+    }
+
     override fun decodeTaggedChar(tag: String): Char = getValue(tag).primitive("char") { content.single() }
 
     private inline fun <T: Any> JsonPrimitive.primitive(primitive: String, block: JsonPrimitive.() -> T): T {

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -53,7 +53,7 @@ private sealed class AbstractJsonTreeEncoder(
         // First encode value, then check, to have a prettier error message
         putElement(tag, JsonPrimitive(value))
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, tag, getCurrent().toString())
+            throw InvalidFloatingPointEncoded(value, tag, getCurrent().toString())
         }
     }
 
@@ -71,7 +71,7 @@ private sealed class AbstractJsonTreeEncoder(
         // First encode value, then check, to have a prettier error message
         putElement(tag, JsonPrimitive(value))
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, tag, getCurrent().toString())
+            throw InvalidFloatingPointEncoded(value, tag, getCurrent().toString())
         }
     }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -53,7 +53,7 @@ private sealed class AbstractJsonTreeEncoder(
         // First encode value, then check, to have a prettier error message
         putElement(tag, JsonPrimitive(value))
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, tag, "float", getCurrent().toString())
+            throw InvalidFloatingPoint(value, tag, getCurrent().toString())
         }
     }
 
@@ -71,7 +71,7 @@ private sealed class AbstractJsonTreeEncoder(
         // First encode value, then check, to have a prettier error message
         putElement(tag, JsonPrimitive(value))
         if (!configuration.allowSpecialFloatingPointValues && !value.isFinite()) {
-            throw InvalidFloatingPoint(value, tag, "double", getCurrent().toString())
+            throw InvalidFloatingPoint(value, tag, getCurrent().toString())
         }
     }
 

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/WriteMode.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/WriteMode.kt
@@ -6,7 +6,6 @@ package kotlinx.serialization.json.internal
 
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.InvalidKeyKindException
 import kotlin.jvm.JvmField
 
 internal enum class WriteMode(@JvmField val begin: Char, @JvmField val end: Char) {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonConfigurationTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonConfigurationTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlin.test.*
+
+class JsonConfigurationTest {
+
+    @Test
+    fun testPrettyPrint() {
+        json(true, "")
+        json(true, "\n")
+        json(true, "\r")
+        json(true, "\t")
+        json(true, " ")
+        json(true, "    ")
+        json(true, " \t\r\n\t   ")
+        assertFailsWith<IllegalArgumentException> { json(false, " ") }
+        assertFailsWith<IllegalArgumentException> { json(false, " ") }
+        assertFailsWith<IllegalArgumentException> { json(true, "f") }
+        assertFailsWith<IllegalArgumentException> { json(true, "\tf\n") }
+    }
+
+    private fun json(prettyPrint: Boolean, prettyPrintIndent: String) = Json {
+        this.prettyPrint = prettyPrint
+        this.prettyPrintIndent = prettyPrintIndent
+    }
+}

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonParserFailureModesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonParserFailureModesTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.internal.*
 import kotlin.test.*
 
 class JsonParserFailureModesTest : JsonTestBase() {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonParserTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonParserTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTransientTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTransientTest.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import kotlinx.serialization.json.internal.*
 import kotlin.test.*
 
 class JsonTransientTest : JsonTestBase() {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonUseDefaultOnNullAndUnknownTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonUseDefaultOnNullAndUnknownTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.internal.*
 import kotlin.test.*
 
 class JsonUseDefaultOnNullAndUnknownTest : JsonTestBase() {

--- a/runtime/commonTest/src/kotlinx/serialization/json/LenientTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/LenientTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.internal.*
 import kotlin.test.*
 
 class LenientTest : JsonTestBase() {

--- a/runtime/commonTest/src/kotlinx/serialization/json/SpecialFloatingPointValuesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/SpecialFloatingPointValuesTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 
@@ -46,9 +47,11 @@ class SpecialFloatingPointValuesTest : JsonTestBase() {
     }
 
     private fun test(box: Box, expected: String, useStreaming: Boolean) {
-        assertFailsWith<JsonException> { default.encodeToString(Box.serializer(), box, useStreaming) }
+        val e1 = assertFailsWith<JsonException> { default.encodeToString(Box.serializer(), box, useStreaming) }
+        assertTrue { e1.message!!.contains("Unexpected special floating-point value") }
         assertEquals(expected, json.encodeToString(Box.serializer(), box, useStreaming))
         assertEquals(box, json.decodeFromString(Box.serializer(), expected, useStreaming))
-        assertFailsWith<JsonException> { default.decodeFromString(Box.serializer(), expected, useStreaming) }
+        val e2 = assertFailsWith<JsonException> { default.decodeFromString(Box.serializer(), expected, useStreaming) }
+        assertTrue { e2.message!!.contains("Unexpected special floating-point value") }
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/SpecialFloatingPointValuesTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/SpecialFloatingPointValuesTest.kt
@@ -49,6 +49,6 @@ class SpecialFloatingPointValuesTest : JsonTestBase() {
         assertFailsWith<JsonException> { default.encodeToString(Box.serializer(), box, useStreaming) }
         assertEquals(expected, json.encodeToString(Box.serializer(), box, useStreaming))
         assertEquals(box, json.decodeFromString(Box.serializer(), expected, useStreaming))
-        assertEquals(box, default.decodeFromString(Box.serializer(), expected, useStreaming))
+        assertFailsWith<JsonException> { default.decodeFromString(Box.serializer(), expected, useStreaming) }
     }
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPolymorphismExceptionTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/polymorphic/JsonPolymorphismExceptionTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.json.polymorphic
 
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.test.*
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonArraySerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonArraySerializerTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json.serializers
 
 import kotlinx.serialization.json.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.test.*
 
 import kotlin.test.*

--- a/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonObjectSerializerTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/serializers/JsonObjectSerializerTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization.json.serializers
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 


### PR DESCRIPTION
    * Allow only whitespaces in prettyPrintIndent
    * Fail on non-finite fp on decoding if allowSpecialFloatingPointValues is disabled
    * Unify exception messages