### PR TITLE
Serializer lookup enchancements

### DIFF
--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -46,7 +46,7 @@ public sealed class Hocon(
         replaceWith = ReplaceWith("decodeFromConfig<T>(conf)")
     )
     public inline fun <reified T : Any> parse(conf: Config): T =
-        decodeFromConfig(serializersModule.getContextualOrDefault(), conf)
+        decodeFromConfig(serializersModule.serializer(), conf)
 
     @Deprecated(
         "This method was renamed to decodeFromConfig during serialization 1.0 API stabilization",
@@ -211,8 +211,8 @@ public sealed class Hocon(
  * Decodes the given [config] into a value of type [T] using a deserialize retrieved
  * from reified type parameter.
  */
-public inline fun <reified T : Any> Hocon.decodeFromConfig(config: Config): T =
-    decodeFromConfig(serializersModule.getContextualOrDefault(), config)
+public inline fun <reified T> Hocon.decodeFromConfig(config: Config): T =
+    decodeFromConfig(serializersModule.serializer(), config)
 
 /**
  * Creates an instance of [Hocon] configured from the optionally given [Hocon instance][from]

--- a/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
@@ -149,15 +149,15 @@ public fun Properties(module: SerializersModule): Properties = PropertiesImpl(mo
  * Encodes properties from given [value] to a map using serializer for reified type [T] and returns this map.
  * `null` values are omitted from the output.
  */
-public inline fun <reified T : Any> Properties.encodeToMap(value: T): Map<String, Any> =
-    encodeToMap(serializersModule.getContextualOrDefault(), value)
+public inline fun <reified T> Properties.encodeToMap(value: T): Map<String, Any> =
+    encodeToMap(serializersModule.serializer(), value)
 
 /**
  * Decodes properties from given [map], assigns them to an object using serializer for reified type [T] and returns this object.
  * [T] may contain properties of nullable types; they will be filled by non-null values from the [map], if present.
  */
-public inline fun <reified T : Any> Properties.decodeFromMap(map: Map<String, Any>): T =
-    decodeFromMap(serializersModule.getContextualOrDefault(), map)
+public inline fun <reified T> Properties.decodeFromMap(map: Map<String, Any>): T =
+    decodeFromMap(serializersModule.serializer(), map)
 
 // Migrations below
 

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/FormatConverterHelpers.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/FormatConverterHelpers.kt
@@ -65,7 +65,7 @@ inline fun <reified T : IMessage> readCompare(it: T, alwaysPrint: Boolean = fals
     val c = try {
         val msg = it.toProtobufMessage()
         val hex = msg.toHex()
-        obj = protoBuf.decodeFromHexString(hex)
+        obj = protoBuf.decodeFromHexString<T>(hex)
         obj == it
     } catch (e: Exception) {
         obj = null

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -67,6 +67,7 @@ public final class kotlinx/serialization/MigrationsKt {
 	public static final fun encode (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public static final fun encode (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public static final fun getContext (Lkotlinx/serialization/SerialFormat;)Lkotlinx/serialization/modules/SerializersModule;
+	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;)Lkotlinx/serialization/KSerializer;
 	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/Object;)Lkotlinx/serialization/KSerializer;
 	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun getList (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
@@ -175,10 +176,10 @@ public abstract interface annotation class kotlinx/serialization/Serializer : ja
 }
 
 public final class kotlinx/serialization/SerializersKt {
-	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerByTypeToken (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerOrNull (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
@@ -1834,7 +1835,6 @@ public abstract interface class kotlinx/serialization/modules/SerializersModuleC
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleKt {
-	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun getEmptySerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public static final fun overwriteWith (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/modules/SerializersModule;)Lkotlinx/serialization/modules/SerializersModule;
 	public static final fun plus (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/modules/SerializersModule;)Lkotlinx/serialization/modules/SerializersModule;

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -67,7 +67,6 @@ public final class kotlinx/serialization/MigrationsKt {
 	public static final fun encode (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public static final fun encode (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public static final fun getContext (Lkotlinx/serialization/SerialFormat;)Lkotlinx/serialization/modules/SerializersModule;
-	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;)Lkotlinx/serialization/KSerializer;
 	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/Object;)Lkotlinx/serialization/KSerializer;
 	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun getList (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;

--- a/runtime/api/kotlinx-serialization-runtime.api
+++ b/runtime/api/kotlinx-serialization-runtime.api
@@ -175,9 +175,11 @@ public abstract interface annotation class kotlinx/serialization/Serializer : ja
 }
 
 public final class kotlinx/serialization/SerializersKt {
+	public static final fun getContextualOrDefault (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerByTypeToken (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerOrNull (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 }
@@ -192,9 +194,6 @@ public abstract interface annotation class kotlinx/serialization/Transient : jav
 
 public final class kotlinx/serialization/UnknownFieldException : kotlinx/serialization/SerializationException {
 	public fun <init> (I)V
-}
-
-public abstract interface annotation class kotlinx/serialization/UnsafeSerializationApi : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class kotlinx/serialization/UnstableDefault : java/lang/annotation/Annotation {

--- a/runtime/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -216,13 +216,4 @@ public annotation class Polymorphic
 @RequiresOptIn(level = RequiresOptIn.Level.ERROR)
 public annotation class InternalSerializationApi
 
-/**
- * Public API marked with this annotation is considered unstable and unsafe for general use.
- * Instability implies inconsistent behaviour across platforms, various edge-cases and use-cases that differ from very basic ones.
- * Unsafe API should not be generally used as the first-class mechanism and **may** be used as the last-ditch effort when every other
- * ways have failed.
- */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS)
-@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
-public annotation class UnsafeSerializationApi
 

--- a/runtime/commonMain/src/kotlinx/serialization/ContextualSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/ContextualSerializer.kt
@@ -34,7 +34,6 @@ import kotlin.reflect.*
  * json.stringify(ClassWithDate("foo", Date())
  * ```
  */
-@OptIn(UnsafeSerializationApi::class)
 public class ContextualSerializer<T : Any>(
     private val serializableClass: KClass<T>,
     private val fallbackSerializer: KSerializer<T>?,

--- a/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
@@ -113,7 +113,7 @@ public annotation class SerialId @Deprecated(
 
 @Deprecated(level = DeprecationLevel.WARNING, message = "Use default parse overload instead", replaceWith = ReplaceWith("parse(objects)"))
 public inline fun <reified T : Any> StringFormat.parseList(objects: String): List<T> =
-    decodeFromString(ListSerializer(serializersModule.getContextualOrDefault<T>()), objects)
+    decodeFromString(ListSerializer(serializersModule.serializer<T>()), objects)
 
 @Deprecated(
     level = DeprecationLevel.WARNING,
@@ -121,7 +121,7 @@ public inline fun <reified T : Any> StringFormat.parseList(objects: String): Lis
     replaceWith = ReplaceWith("decodeFromString(map)")
 )
 public inline fun <reified K : Any, reified V : Any> StringFormat.parseMap(map: String): Map<K, V> =
-    decodeFromString(MapSerializer(serializersModule.getContextualOrDefault<K>(), serializersModule.getContextualOrDefault<V>()), map)
+    decodeFromString(MapSerializer(serializersModule.serializer<K>(), serializersModule.serializer<V>()), map)
 
 // ERROR migrations that affect **only** users that called these functions with named parameters
 
@@ -132,7 +132,7 @@ public inline fun <reified K : Any, reified V : Any> StringFormat.parseMap(map: 
     replaceWith = ReplaceWith("encodeToString(objects)")
 )
 public inline fun <reified T : Any> StringFormat.stringify(objects: List<T>): String =
-    encodeToString(ListSerializer(serializersModule.getContextualOrDefault<T>()), objects)
+    encodeToString(ListSerializer(serializersModule.serializer<T>()), objects)
 
 @LowPriorityInOverloadResolution
 @Deprecated(
@@ -141,9 +141,8 @@ public inline fun <reified T : Any> StringFormat.stringify(objects: List<T>): St
     replaceWith = ReplaceWith("stringify(map)")
 )
 public inline fun <reified K : Any, reified V : Any> StringFormat.stringify(map: Map<K, V>): String =
-    encodeToString(MapSerializer(serializersModule.getContextualOrDefault<K>(), serializersModule.getContextualOrDefault<V>()), map)
+    encodeToString(MapSerializer(serializersModule.serializer<K>(), serializersModule.serializer<V>()), map)
 
-@ImplicitReflectionSerializer
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
@@ -152,14 +151,20 @@ public inline fun <reified K : Any, reified V : Any> StringFormat.stringify(map:
 public fun <T : Any> SerializersModule.getContextualOrDefault(klass: KClass<T>): KSerializer<T> =
     getContextual(klass) ?: klass.serializer()
 
-@ImplicitReflectionSerializer
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
-    replaceWith = ReplaceWith("getContextualOrDefault<T>()")
+    replaceWith = ReplaceWith("serializer<T>()")
 )
 public fun <T : Any> SerializersModule.getContextualOrDefault(value: T): KSerializer<T> =
     getContextual(value::class)?.cast() ?: value::class.serializer().cast()
+
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
+    replaceWith = ReplaceWith("serializer<T>()")
+)
+public fun <T : Any> SerializersModule.getContextualOrDefault(): KSerializer<T> = noImpl()
 
 @Suppress("UNUSED", "DeprecatedCallableAddReplaceWith")
 @Deprecated(

--- a/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
@@ -159,13 +159,6 @@ public fun <T : Any> SerializersModule.getContextualOrDefault(klass: KClass<T>):
 public fun <T : Any> SerializersModule.getContextualOrDefault(value: T): KSerializer<T> =
     getContextual(value::class)?.cast() ?: value::class.serializer().cast()
 
-@Deprecated(
-    level = DeprecationLevel.ERROR,
-    message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
-    replaceWith = ReplaceWith("serializer<T>()")
-)
-public fun <T : Any> SerializersModule.getContextualOrDefault(): KSerializer<T> = noImpl()
-
 @Suppress("UNUSED", "DeprecatedCallableAddReplaceWith")
 @Deprecated(
     message = "Top-level polymorphic descriptor is deprecated, use descriptor from the instance of PolymorphicSerializer or" +

--- a/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
@@ -145,15 +145,15 @@ public inline fun <reified K : Any, reified V : Any> StringFormat.stringify(map:
 
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
-    replaceWith = ReplaceWith("getContextual(klass) ?: klass.serializer()")
+    message = "This method is deprecated for removal. Please use reified serializer<T>() instead",
+    replaceWith = ReplaceWith("serializer<T>()")
 )
 public fun <T : Any> SerializersModule.getContextualOrDefault(klass: KClass<T>): KSerializer<T> =
-    getContextual(klass) ?: klass.serializer()
+    noImpl()
 
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
+    message = "This method is deprecated for removal. Please use reified serializer<T>() instead",
     replaceWith = ReplaceWith("serializer<T>()")
 )
 public fun <T : Any> SerializersModule.getContextualOrDefault(value: T): KSerializer<T> =

--- a/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Migrations.kt
@@ -144,9 +144,8 @@ public inline fun <reified K : Any, reified V : Any> StringFormat.stringify(map:
     encodeToString(MapSerializer(serializersModule.getContextualOrDefault<K>(), serializersModule.getContextualOrDefault<V>()), map)
 
 @ImplicitReflectionSerializer
-@OptIn(UnsafeSerializationApi::class)
 @Deprecated(
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.ERROR,
     message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
     replaceWith = ReplaceWith("getContextual(klass) ?: klass.serializer()")
 )
@@ -154,9 +153,8 @@ public fun <T : Any> SerializersModule.getContextualOrDefault(klass: KClass<T>):
     getContextual(klass) ?: klass.serializer()
 
 @ImplicitReflectionSerializer
-@OptIn(UnsafeSerializationApi::class)
 @Deprecated(
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.ERROR,
     message = "This method is deprecated for removal. Please use reified getContextualOrDefault<T>() instead",
     replaceWith = ReplaceWith("getContextualOrDefault<T>()")
 )

--- a/runtime/commonMain/src/kotlinx/serialization/SerialFormat.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/SerialFormat.kt
@@ -64,15 +64,15 @@ public interface StringFormat : SerialFormat {
 /**
  * Serializes and encodes the given [value] to string using serializer retrieved from the reified type parameter.
  */
-public inline fun <reified T : Any> StringFormat.encodeToString(value: T): String =
-    encodeToString(serializersModule.getContextualOrDefault(), value)
+public inline fun <reified T> StringFormat.encodeToString(value: T): String =
+    encodeToString(serializersModule.serializer(), value)
 
 /**
  * Decodes and deserializes the given [string] to to the value of type [T] using deserializer
  * retrieved from the reified type parameter.
  */
-public inline fun <reified T : Any> StringFormat.decodeFromString(string: String): T =
-    decodeFromString(serializersModule.getContextualOrDefault(), string)
+public inline fun <reified T> StringFormat.decodeFromString(string: String): T =
+    decodeFromString(serializersModule.serializer(), string)
 
 
 /**
@@ -103,8 +103,8 @@ public fun <T> BinaryFormat.decodeFromHexString(deserializer: DeserializationStr
  * only applies transformation to the resulting array. It is recommended to use for debugging and
  * testing purposes.
  */
-public inline fun <reified T : Any> BinaryFormat.encodeToHexString(value: T): String =
-    encodeToHexString(serializersModule.getContextualOrDefault(), value)
+public inline fun <reified T> BinaryFormat.encodeToHexString(value: T): String =
+    encodeToHexString(serializersModule.serializer(), value)
 
 /**
  * Decodes byte array from the given [hex] string and the decodes and deserializes it
@@ -112,19 +112,19 @@ public inline fun <reified T : Any> BinaryFormat.encodeToHexString(value: T): St
  *
  * This method is a counterpart to [encodeToHexString]
  */
-public inline fun <reified T : Any> BinaryFormat.decodeFromHexString(hex: String): T =
-    decodeFromHexString(serializersModule.getContextualOrDefault(), hex)
+public inline fun <reified T> BinaryFormat.decodeFromHexString(hex: String): T =
+    decodeFromHexString(serializersModule.serializer(), hex)
 
 /**
  * Serializes and encodes the given [value] to byte array using serializer
  * retrieved from the reified type parameter.
  */
-public inline fun <reified T : Any> BinaryFormat.encodeToByteArray(value: T): ByteArray =
-    encodeToByteArray(serializersModule.getContextualOrDefault(), value)
+public inline fun <reified T> BinaryFormat.encodeToByteArray(value: T): ByteArray =
+    encodeToByteArray(serializersModule.serializer(), value)
 
 /**
  * Decodes and deserializes the given [byte array][bytes] to to the value of type [T] using deserializer
  * retrieved from the reified type parameter.
  */
-public inline fun <reified T : Any> BinaryFormat.decodeFromByteArray(bytes: ByteArray): T =
-    decodeFromByteArray(serializersModule.getContextualOrDefault(), bytes)
+public inline fun <reified T> BinaryFormat.decodeFromByteArray(bytes: ByteArray): T =
+    decodeFromByteArray(serializersModule.serializer(), bytes)

--- a/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -8,10 +8,8 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
-import kotlinx.serialization.builtins.MapEntrySerializer
-import kotlinx.serialization.builtins.TripleSerializer
-import kotlinx.serialization.builtins.PairSerializer
 import kotlinx.serialization.internal.*
+import kotlinx.serialization.modules.*
 import kotlin.jvm.*
 import kotlin.reflect.*
 
@@ -40,43 +38,56 @@ public inline fun <reified T> serializer(): KSerializer<T> {
  * json.encodeToString(serializer, map)
  * ```
  */
-@OptIn(UnsafeSerializationApi::class)
 public fun serializer(type: KType): KSerializer<Any?> {
-    fun serializerByKTypeImpl(type: KType): KSerializer<Any> {
-        val rootClass = type.kclass()
-        val typeArguments = type.arguments
-            .map { requireNotNull(it.type) { "Star projections in type arguments are not allowed, but had $type" } }
-        return when {
-            typeArguments.isEmpty() -> rootClass.serializer()
-            else -> {
-                val serializers = typeArguments
-                    .map(::serializer)
-                // Array is not supported, see KT-32839
-                when (rootClass) {
-                    List::class, MutableList::class, ArrayList::class -> ArrayListSerializer(serializers[0])
-                    HashSet::class -> HashSetSerializer(serializers[0])
-                    Set::class, MutableSet::class, LinkedHashSet::class -> LinkedHashSetSerializer(serializers[0])
-                    HashMap::class -> HashMapSerializer(serializers[0], serializers[1])
-                    Map::class, MutableMap::class, LinkedHashMap::class -> LinkedHashMapSerializer(serializers[0], serializers[1])
-                    Map.Entry::class -> MapEntrySerializer(serializers[0], serializers[1])
-                    Pair::class -> PairSerializer(serializers[0], serializers[1])
-                    Triple::class -> TripleSerializer(serializers[0], serializers[1], serializers[2])
-                    else -> {
-                        if (isReferenceArray(rootClass)) {
-                            return ArraySerializer<Any, Any?>(typeArguments[0].classifier as KClass<Any>, serializers[0]).cast()
-                        }
-                        requireNotNull(rootClass.constructSerializerForGivenTypeArgs(*serializers.toTypedArray())) {
-                            "Can't find a method to construct serializer for type ${rootClass.simpleName}. " +
-                                    "Make sure this class is marked as @Serializable or provide serializer explicitly."
-                        }
-                    }
-                }
-            }
-        }.cast()
-    }
+    val result = EmptySerializersModule.serializerByKTypeImpl(type)
+    return if (type.isMarkedNullable) result.nullable else result.cast()
+}
 
+@PublishedApi
+internal fun SerializersModule.serializer(type: KType): KSerializer<Any?> {
     val result = serializerByKTypeImpl(type)
     return if (type.isMarkedNullable) result.nullable else result.cast()
+}
+
+private fun SerializersModule.serializerByKTypeImpl(type: KType): KSerializer<Any> {
+    val rootClass = type.kclass()
+    val typeArguments = type.arguments
+        .map { requireNotNull(it.type) { "Star projections in type arguments are not allowed, but had $type" } }
+    return when {
+        typeArguments.isEmpty() -> getContextual(rootClass) ?: rootClass.serializer()
+        else -> builtinSerializer(typeArguments, rootClass)
+    }.cast()
+}
+
+private fun SerializersModule.builtinSerializer(
+    typeArguments: List<KType>,
+    rootClass: KClass<Any>
+): KSerializer<out Any> {
+    val serializers = typeArguments
+        .map(::serializer)
+    // Array is not supported, see KT-32839
+    return when (rootClass) {
+        List::class, MutableList::class, ArrayList::class -> ArrayListSerializer(serializers[0])
+        HashSet::class -> HashSetSerializer(serializers[0])
+        Set::class, MutableSet::class, LinkedHashSet::class -> LinkedHashSetSerializer(serializers[0])
+        HashMap::class -> HashMapSerializer(serializers[0], serializers[1])
+        Map::class, MutableMap::class, LinkedHashMap::class -> LinkedHashMapSerializer(
+            serializers[0],
+            serializers[1]
+        )
+        Map.Entry::class -> MapEntrySerializer(serializers[0], serializers[1])
+        Pair::class -> PairSerializer(serializers[0], serializers[1])
+        Triple::class -> TripleSerializer(serializers[0], serializers[1], serializers[2])
+        else -> {
+            if (isReferenceArray(rootClass)) {
+                return ArraySerializer<Any, Any?>(typeArguments[0].classifier as KClass<Any>, serializers[0]).cast()
+            }
+            requireNotNull(rootClass.constructSerializerForGivenTypeArgs(*serializers.toTypedArray())) {
+                "Can't find a method to construct serializer for type ${rootClass.simpleName}. " +
+                        "Make sure this class is marked as @Serializable or provide serializer explicitly."
+            }
+        }
+    }
 }
 
 /**
@@ -92,7 +103,7 @@ public fun serializer(type: KType): KSerializer<Any?> {
  *
  * @throws SerializationException if serializer can't be found.
  */
-@UnsafeSerializationApi
+@InternalSerializationApi
 public fun <T : Any> KClass<T>.serializer(): KSerializer<T> = serializerOrNull() ?: serializerNotRegistered()
 
 /**
@@ -104,7 +115,7 @@ public fun <T : Any> KClass<T>.serializer(): KSerializer<T> = serializerOrNull()
  * This API is not guaranteed to work consistent across different platforms or
  * to work in cases that slightly differ from "plain @Serializable class".
  */
-@UnsafeSerializationApi
+@InternalSerializationApi
 public fun <T : Any> KClass<T>.serializerOrNull(): KSerializer<T>? =
     compiledSerializerImpl() ?: builtinSerializerOrNull()
 

--- a/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -15,37 +15,24 @@ import kotlin.jvm.*
 import kotlin.reflect.*
 
 /**
- * Creates a serializer for the provided reified type [T] with support of user-defined generic classes.
- * This method is a reified version of `serializer(KType)`
- *
- * Example of usage:
- * ```
- * val map = mapOf(1 to listOf(listOf("1")))
- * json.encodeToString(serializer(), map)
- * ```
+ * Retrieves a serializer for the given type [T].
+ * This method is a reified version of `serializer(KType)`.
  */
 public inline fun <reified T> serializer(): KSerializer<T> {
     return serializer(typeOf<T>()).cast()
 }
 
 /**
- * Attempts to retrieve a serializer from the current module and, if not found,
- * fallbacks to [serializer] method
+ * Retrieves serializer for the given type [T] from the current [SerializersModule] and,
+ * if not found, fallbacks to plain [serializer] method.
  */
-public inline fun <reified T> SerializersModule.getContextualOrDefault(): KSerializer<T> {
+public inline fun <reified T> SerializersModule.serializer(): KSerializer<T> {
     return serializer(typeOf<T>()).cast()
 }
 
 /**
- * Creates a serializer for the given [type] with support of user-defined generic classes.
+ * Creates a serializer for the given [type].
  * [type] argument can be obtained with experimental [typeOf] method.
- *
- * Example of usage:
- * ```
- * val map = mapOf(1 to listOf(listOf("1")))
- * val serializer = serializer(typeOf<Map<Int, List<List<String>>>>())
- * json.encodeToString(serializer, map)
- * ```
  */
 public fun serializer(type: KType): KSerializer<Any?> {
     val result = EmptySerializersModule.serializerByKTypeImpl(type)
@@ -53,7 +40,9 @@ public fun serializer(type: KType): KSerializer<Any?> {
 }
 
 /**
- * Attempts to retrieve a serializer from the current module using the given [type] and, if not found, fallbacks to [serializer] method
+ * Retrieves serializer for the given [type] from the current [SerializersModule] and,
+ * if not found, fallbacks to plain [serializer] method.
+ * [type] argument can be obtained with experimental [typeOf] method.
  */
 public fun SerializersModule.serializer(type: KType): KSerializer<Any?> {
     val kclass = type.kclass()

--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -130,8 +130,8 @@ public fun Json(from: Json = Json.Default, builderAction: JsonBuilder.() -> Unit
  *
  * @throws [SerializationException] if the given value cannot be serialized to JSON.
  */
-public inline fun <reified T : Any> Json.encodeToJsonElement(value: T): JsonElement {
-    return encodeToJsonElement(serializersModule.getContextualOrDefault(), value)
+public inline fun <reified T> Json.encodeToJsonElement(value: T): JsonElement {
+    return encodeToJsonElement(serializersModule.serializer(), value)
 }
 
 /**
@@ -140,8 +140,8 @@ public inline fun <reified T : Any> Json.encodeToJsonElement(value: T): JsonElem
  *
  * @throws [SerializationException] if the given JSON string is malformed or cannot be deserialized to the value of type [T].
  */
-public inline fun <reified T : Any> Json.decodeFromJsonElement(json: JsonElement): T =
-    decodeFromJsonElement(serializersModule.getContextualOrDefault(), json)
+public inline fun <reified T> Json.decodeFromJsonElement(json: JsonElement): T =
+    decodeFromJsonElement(serializersModule.serializer(), json)
 
 /**
  * Builder of the [Json] instance provided by `Json` factory function.

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonContentPolymorphicSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonContentPolymorphicSerializer.kt
@@ -75,7 +75,6 @@ public abstract class JsonContentPolymorphicSerializer<T : Any>(private val base
     override val descriptor: SerialDescriptor =
         buildSerialDescriptor("JsonContentPolymorphicSerializer<${baseClass.simpleName}>", PolymorphicKind.SEALED)
 
-    @OptIn(UnsafeSerializationApi::class)
     final override fun serialize(encoder: Encoder, value: T) {
         val actualSerializer =
             encoder.serializersModule.getPolymorphic(baseClass, value)

--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -53,20 +53,6 @@ public sealed class SerializersModule {
 public val EmptySerializersModule: SerializersModule = SerialModuleImpl(emptyMap(), emptyMap(), emptyMap(), emptyMap())
 
 /**
- * Attempts to retrieve a serializer from the current module and, if not found, fallbacks to [serializer] method
- */
-public inline fun <reified T : Any> SerializersModule.getContextualOrDefault(): KSerializer<T> =
-    getContextual(T::class) ?: serializer(typeOf<T>()).cast()
-
-/**
- * Attempts to retrieve a serializer from the current module using the given [type] and, if not found, fallbacks to [serializer] method
- */
-public fun <T : Any> SerializersModule.getContextualOrDefault(type: KType): KSerializer<T> {
-    val kclass = type.kclass()
-    return (getContextual(kclass) ?: serializer(type)).cast()
-}
-
-/**
  * Returns a combination of two serial modules
  *
  * If serializer for some class presents in both modules, a [SerializerAlreadyRegisteredException] is thrown.

--- a/runtime/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -55,14 +55,12 @@ public val EmptySerializersModule: SerializersModule = SerialModuleImpl(emptyMap
 /**
  * Attempts to retrieve a serializer from the current module and, if not found, fallbacks to [serializer] method
  */
-@OptIn(UnsafeSerializationApi::class)
 public inline fun <reified T : Any> SerializersModule.getContextualOrDefault(): KSerializer<T> =
     getContextual(T::class) ?: serializer(typeOf<T>()).cast()
 
 /**
  * Attempts to retrieve a serializer from the current module using the given [type] and, if not found, fallbacks to [serializer] method
  */
-@OptIn(UnsafeSerializationApi::class)
 public fun <T : Any> SerializersModule.getContextualOrDefault(type: KType): KSerializer<T> {
     val kclass = type.kclass()
     return (getContextual(kclass) ?: serializer(type)).cast()

--- a/runtime/commonTest/src/kotlinx/serialization/TypeOfSerializerLookupTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/TypeOfSerializerLookupTest.kt
@@ -165,14 +165,14 @@ class TypeOfSerializerLookupTest : JsonTestBase() {
     @Test
     fun testContextualLookupNullable() {
         val module = SerializersModule { contextual(CustomIntSerializer(true).cast<Int>()) }
-        val serializer = module.getContextualOrDefault<List<List<Int?>>>()
+        val serializer = module.serializer<List<List<Int?>>>()
         assertEquals("[[41]]", Json.encodeToString(serializer, listOf(listOf<Int?>(null))))
     }
 
     @Test
     fun testContextualLookupNonNullable() {
         val module = SerializersModule { contextual(CustomIntSerializer(false).cast<Int>()) }
-        val serializer = module.getContextualOrDefault<List<List<Int?>>>()
+        val serializer = module.serializer<List<List<Int?>>>()
         assertEquals("[[null]]", Json.encodeToString(serializer, listOf(listOf<Int?>(null))))
     }
 

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -15,7 +15,7 @@ abstract class JsonTestBase {
     protected val lenient = Json { isLenient = true; ignoreUnknownKeys = true; allowSpecialFloatingPointValues = true }
 
     internal inline fun <reified T : Any> Json.encodeToString(value: T, useStreaming: Boolean): String {
-        val serializer = serializersModule.getContextualOrDefault<T>()
+        val serializer = serializersModule.serializer<T>()
         return encodeToString(serializer, value, useStreaming)
     }
 
@@ -29,7 +29,7 @@ abstract class JsonTestBase {
     }
 
     internal inline fun <reified T : Any> Json.decodeFromString(source: String, useStreaming: Boolean): T {
-        val deserializer = serializersModule.getContextualOrDefault<T>()
+        val deserializer = serializersModule.serializer<T>()
         return decodeFromString(deserializer, source, useStreaming)
     }
 

--- a/runtime/jsMain/src/kotlinx/serialization/Dynamics.kt
+++ b/runtime/jsMain/src/kotlinx/serialization/Dynamics.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.builtins.LongAsStringSerializer
 import kotlinx.serialization.internal.DynamicObjectParser
 import kotlinx.serialization.internal.DynamicObjectSerializer
 import kotlinx.serialization.json.*
-import kotlinx.serialization.modules.*
 
 /**
  * Converts native JavaScript objects into Kotlin ones, verifying their types.
@@ -44,7 +43,7 @@ public fun <T> Json.decodeFromDynamic(deserializer: DeserializationStrategy<T>, 
  * A reified version of [decodeFromDynamic].
  */
 public inline fun <reified T> Json.decodeFromDynamic(dynamic: dynamic): T =
-    decodeFromDynamic(serializersModule.getContextualOrDefault(), dynamic)
+    decodeFromDynamic(serializersModule.serializer(), dynamic)
 
 /**
  * Converts Kotlin data structures to plain Javascript objects
@@ -72,5 +71,5 @@ public fun <T> Json.encodeToDynamic(serializer: SerializationStrategy<T>, value:
 /**
  * A reified version of [encodeToDynamic].
  */
-public inline fun <reified T : Any> Json.encodeToDynamic(value: T): dynamic =
-    encodeToDynamic(serializersModule.getContextualOrDefault(), value)
+public inline fun <reified T> Json.encodeToDynamic(value: T): dynamic =
+    encodeToDynamic(serializersModule.serializer(), value)

--- a/runtime/jsTest/src/kotlinx/serialization/DynamicSerializerTest.kt
+++ b/runtime/jsTest/src/kotlinx/serialization/DynamicSerializerTest.kt
@@ -99,7 +99,7 @@ class DynamicSerializerTest {
         serializer: SerializationStrategy<T>? = null,
         noinline assertions: ((T, dynamic) -> Unit)? = null
     ) {
-        val effectiveSerializer = serializer ?: EmptySerializersModule.getContextualOrDefault<T>()
+        val effectiveSerializer = serializer ?: EmptySerializersModule.serializer<T>()
         val serialized = Json.encodeToDynamic(effectiveSerializer, data)
         assertions?.invoke(data, serialized)
         assertEquals(

--- a/runtime/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
+++ b/runtime/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
@@ -3,10 +3,13 @@
  */
 @file:JvmMultifileClass
 @file:JvmName("SerializersKt")
+@file:Suppress("UNCHECKED_CAST")
+
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.internal.*
+import kotlinx.serialization.modules.*
 import java.lang.reflect.*
 import kotlin.reflect.*
 
@@ -18,59 +21,81 @@ import kotlin.reflect.*
  * For application-level serialization, it is recommended to use `serializer<T>()` instead as it is aware of
  * Kotlin-specific type information, such as nullability, sealed classes and object.
  */
-@Suppress("UNCHECKED_CAST")
-@OptIn(UnsafeSerializationApi::class)
-public fun serializer(type: Type): KSerializer<Any> = when (type) {
-    // TODO stabilize for Spring
+public fun serializer(type: Type): KSerializer<Any> = EmptySerializersModule.getContextualOrDefault(type)
+
+/**
+ * Retrieves serializer for the given reflective Java [type] using
+ * [contextual][SerializersModule.getContextual] lookup and fallback to reflective construction.
+ *
+ * [getContextualOrDefault] is intended to be used as an interoperability layer for libraries like GSON and Retrofit,
+ * that operate with reflective Java [Type] and cannot use [typeOf].
+ * Serializers is looked up in the contextual serializers of the module and then constructed reflectively.
+ *
+ * For application-level serialization, it is recommended to use `serializer<T>()` instead as it is aware of
+ * Kotlin-specific type information, such as nullability, sealed classes and object.
+ */
+public fun SerializersModule.getContextualOrDefault(type: Type): KSerializer<Any> = when (type) {
     is GenericArrayType -> {
-        val eType = type.genericComponentType.let {
-            when (it) {
-                is WildcardType -> it.upperBounds.first()
-                else -> it
-            }
-        }
-        val serializer = serializer(eType)
-        val kclass = when (eType) {
-            is ParameterizedType -> (eType.rawType as Class<*>).kotlin
-            is KClass<*> -> eType
-            else -> throw IllegalStateException("unsupported type in GenericArray: ${eType::class}")
-        } as KClass<Any>
-        ArraySerializer(kclass, serializer) as KSerializer<Any>
+        genericArraySerializer(type)
     }
-    is Class<*> -> if (!type.isArray) {
-        (type.kotlin as KClass<Any>).serializer<Any>()
-    } else {
-        val eType: Class<*> = type.componentType
-        val s = serializer(eType)
-        val arraySerializer = ArraySerializer(eType.kotlin as KClass<Any>, s)
-        arraySerializer as KSerializer<Any>
-    }
+    is Class<*> -> typeSerializer(type)
     is ParameterizedType -> {
         val rootClass = (type.rawType as Class<*>)
         val args = (type.actualTypeArguments)
         when {
-            List::class.java.isAssignableFrom(rootClass) -> ListSerializer(serializer(args[0])) as KSerializer<Any>
-            Set::class.java.isAssignableFrom(rootClass) -> SetSerializer(serializer(args[0])) as KSerializer<Any>
+            List::class.java.isAssignableFrom(rootClass) -> ListSerializer(getContextualOrDefault(args[0])) as KSerializer<Any>
+            Set::class.java.isAssignableFrom(rootClass) -> SetSerializer(getContextualOrDefault(args[0])) as KSerializer<Any>
             Map::class.java.isAssignableFrom(rootClass) -> MapSerializer(
-                serializer(args[0]),
-                serializer(args[1])
+                getContextualOrDefault(args[0]),
+                getContextualOrDefault(args[1])
             ) as KSerializer<Any>
             Map.Entry::class.java.isAssignableFrom(rootClass) -> MapEntrySerializer(
-                serializer(args[0]),
-                serializer(args[1])
+                getContextualOrDefault(args[0]),
+                getContextualOrDefault(args[1])
             ) as KSerializer<Any>
 
             else -> {
                 // probably we should deprecate this method because it can't differ nullable vs non-nullable types
                 // since it uses Java TypeToken, not Kotlin one
-                val varargs = args.map { serializer(it) as KSerializer<Any?> }.toTypedArray()
+                val varargs = args.map { getContextualOrDefault(it) as KSerializer<Any?> }.toTypedArray()
                 (rootClass.kotlin.constructSerializerForGivenTypeArgs(*varargs) as? KSerializer<Any>)
-                        ?: (rootClass.kotlin as KClass<Any>).serializer()
+                    ?: contextualOrReflective(rootClass.kotlin as KClass<Any>)
             }
         }
     }
-    is WildcardType -> serializer(type.upperBounds.first())
+    is WildcardType -> getContextualOrDefault(type.upperBounds.first())
     else -> throw IllegalArgumentException("typeToken should be an instance of Class<?>, GenericArray, ParametrizedType or WildcardType, but actual type is $type ${type::class}")
+}
+
+private fun SerializersModule.typeSerializer(type: Class<*>): KSerializer<Any> {
+    return if (!type.isArray) {
+        contextualOrReflective(type.kotlin as KClass<Any>)
+    } else {
+        val eType: Class<*> = type.componentType
+        val s = getContextualOrDefault(eType)
+        val arraySerializer = ArraySerializer(eType.kotlin as KClass<Any>, s)
+        arraySerializer as KSerializer<Any>
+    }
+}
+
+private fun SerializersModule.genericArraySerializer(type: GenericArrayType): KSerializer<Any> {
+    val eType = type.genericComponentType.let {
+        when (it) {
+            is WildcardType -> it.upperBounds.first()
+            else -> it
+        }
+    }
+    val serializer = getContextualOrDefault(eType)
+    val kclass = when (eType) {
+        is ParameterizedType -> (eType.rawType as Class<*>).kotlin
+        is KClass<*> -> eType
+        else -> throw IllegalStateException("unsupported type in GenericArray: ${eType::class}")
+    } as KClass<Any>
+    return ArraySerializer(kclass, serializer) as KSerializer<Any>
+}
+
+private fun <T: Any> SerializersModule.contextualOrReflective(kClass: KClass<T>): KSerializer<T> {
+    return getContextual(kClass) ?: kClass.serializer()
 }
 
 @Deprecated("Deprecated during serialization 1.0 API stabilization", ReplaceWith("serializer(type)"), level = DeprecationLevel.ERROR)

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -211,7 +211,7 @@ class SerializerByTypeTest {
     @Test
     fun testContextualLookup() {
         val module = SerializersModule { contextual(CustomIntSerializer) }
-        val serializer = module.getContextualOrDefault(typeTokenOf<List<List<Int>>>())
+        val serializer = module.serializer(typeTokenOf<List<List<Int>>>())
         assertEquals("[[42]]", Json.encodeToString(serializer, listOf(listOf(1))))
     }
 }

--- a/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/runtime/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.builtins.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
 import org.junit.Test
 import java.lang.reflect.*
 import kotlin.test.*
@@ -190,7 +191,27 @@ class SerializerByTypeTest {
 
     @Test
     fun testNonSerializableEnum() {
+        // Works only on JVM righ tnow
         val serializer = serializer<Foo>()
         assertTrue(serializer.descriptor.kind is SerialKind.ENUM)
+    }
+
+    object CustomIntSerializer : KSerializer<Int> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("CIS", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: Int) {
+            encoder.encodeInt(42)
+        }
+
+        override fun deserialize(decoder: Decoder): Int {
+            TODO()
+        }
+    }
+
+    @Test
+    fun testContextualLookup() {
+        val module = SerializersModule { contextual(CustomIntSerializer) }
+        val serializer = module.getContextualOrDefault(typeTokenOf<List<List<Int>>>())
+        assertEquals("[[42]]", Json.encodeToString(serializer, listOf(listOf(1))))
     }
 }


### PR DESCRIPTION
    * Lookup contextual serializer recursively in getcontextualOrDefault to give consistent experience when contextual type is nested in generic type argument
    * Provide getContextualOrDefault(javaType) for the same purpose
    * Get rid of UnsafeSerializationApi

Fixed #802
Fixes #803