### PR TITLE
Fix typos and grammar in formats.md

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -530,7 +530,7 @@ A decoder needs to implements more substance.
   in the `elementIndex` variable. See 
   the [Hand-written composite serializer](serializers.md#hand-written-composite-serializer) section 
   on how it ends up being used.
-* [beginStructure][Decoder.beginStructure] &must; returns a new instance of the `ListDecoder`, so that
+* [beginStructure][Decoder.beginStructure] &mdash; returns a new instance of the `ListDecoder`, so that
   each structure that is being recursively decoded keeps track of its own `elementIndex` state separately.  
 
 ```kotlin
@@ -676,9 +676,9 @@ Project(name=kotlinx.serialization, owner=User(name=kotlin), votes=9000)
  
 ### Adding collection support
 
-This basic format, so far, cannot property represent collections. In encodes them, but it does not keep
-track on how many elements are there in the collection or where it ends, so it cannot properly decode them.
-First, let us add propers support for collections to the encoder by implementing the 
+This basic format, so far, cannot properly represent collections. In encodes them, but it does not keep
+track of how many elements are there in the collection or where it ends, so it cannot properly decode them.
+First, let us add proper support for collections to the encoder by implementing the 
 [Encoder.beginCollection] function. The `beginCollection` function takes a collection size as a parameter, 
 so we encode it to add it to the result. 
 Our encoder implementation does not keep any state, so it just returns `this` from the `beginCollection` function.
@@ -716,7 +716,7 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 -->
 
 The decoder, for our case, needs to only implement the [CompositeDecoder.decodeCollectionSize] function
-in addition the previous code.
+in addition to the previous code.
 
 > The formats that store collection size in advance have to return `true` from `decodeSequentially`.
 


### PR DESCRIPTION
Fixes a few minor typos/grammar things that I noticed while reading the documentation.