### PR TITLE
Remove new lines in deprecation warnings that break native

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -331,9 +331,9 @@ private class JsonImpl(configuration: JsonConf) : Json(configuration) {
 
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Deprecated in the favour of Json {} builder function during serialization 1.0 API stabilization.\n" +
+    message = "Deprecated in the favour of Json {} builder function during serialization 1.0 API stabilization. " +
             "In order to migrate, please replace it with Json { } builder function. JsonBuilder receiver has the same " +
-            "properties as 'JsonConfiguration' and 'context' and should be configured there.\n" +
+            "properties as 'JsonConfiguration' and 'context' and should be configured there. " +
             "Json(JsonConfiguration.Default) can be replaced with Json companion instead."
 )
 @Suppress("DEPRECATION_ERROR")
@@ -355,7 +355,7 @@ public fun Json(
  */
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Deprecated in the favour of Json.Default companion during serialization 1.0 API stabilization.\n",
+    message = "Deprecated in the favour of Json.Default companion during serialization 1.0 API stabilization.",
     replaceWith = ReplaceWith("Json")
 )
 public fun Json(
@@ -364,7 +364,7 @@ public fun Json(
 
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Deprecated in the favour of Json {} builder function during serialization 1.0 API stabilization.\n",
+    message = "Deprecated in the favour of Json {} builder function during serialization 1.0 API stabilization.",
     replaceWith = ReplaceWith("Json { allowStructuredMapKeys = true }") // stable configuration
 )
 public fun Json(
@@ -373,7 +373,7 @@ public fun Json(
 
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Deprecated in the favour of Json {} builder function during serialization 1.0 API stabilization.\n",
+    message = "Deprecated in the favour of Json {} builder function during serialization 1.0 API stabilization.",
     replaceWith = ReplaceWith("Json { serializersModule = context }")
 )
 public fun Json(

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -8,9 +8,9 @@ import kotlin.jvm.*
 
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "This class is deprecated for removal during serialization 1.0 API stabilization.\n" +
+    message = "This class is deprecated for removal during serialization 1.0 API stabilization. " +
             "For configuring Json instances, the corresponding builder function can be used instead, e.g. instead of" +
-            "'Json(JsonConfiguration.Stable.copy(isLenient = true))' 'Json { isLenient = true }' should be used.\n" +
+            "'Json(JsonConfiguration.Stable.copy(isLenient = true))' 'Json { isLenient = true }' should be used. " +
             "Instead of storing JsonConfiguration instances of the code, Json instances can be used directly:" +
             "'Json(MyJsonConfiguration.copy(prettyPrint = true))' can be replaced with 'Json(from = MyApplicationJson) { prettyPrint = true }'"
 )


### PR DESCRIPTION
Fixes issue #989 

This is arguably just a Kotlin/Native bug, but they don't seem to be working on it: https://youtrack.jetbrains.com/issue/KT-39206