### PR TITLE
StringIndexOutOfBoundsException when parsing empty string literal at the end of the input

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonReader.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/JsonReader.kt
@@ -241,7 +241,11 @@ internal class JsonReader(private val source: String) {
     private fun nextString(source: String, startPosition: Int) {
         tokenPosition = startPosition
         length = 0 // in buffer
-        var currentPosition = startPosition + 1
+        var currentPosition = startPosition + 1 // skip starting "
+        // except if the input ends
+        if (currentPosition >= source.length) {
+            fail("EOF", currentPosition)
+        }
         var lastPosition = currentPosition
         while (source[currentPosition] != STRING) {
             if (source[currentPosition] == STRING_ESC) {

--- a/runtime/commonTest/src/kotlinx/serialization/json/JsonParserTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/JsonParserTest.kt
@@ -76,4 +76,15 @@ class JsonParserTest : JsonTestBase() {
         val msg = e.message!!
         assertTrue(msg.contains("Expected end of the object"))
     }
+
+    @Test
+    fun testUnclosedStringLiteral() {
+        assertFailsWith<JsonDecodingException> {
+            parse("\"")
+        }
+
+        assertFailsWith<JsonDecodingException> {
+            parse("""{"id":"""")
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where an unfinished string literal at the end of the input throws a `StringIndexOutOfBoundsException` instead of a `JsonDecodingException`.

```
Json(JsonConfiguration.Stable).parse("\"")
```
throws `StringIndexOutOfBoundsException`. Similar to #704, this should be a generic decoding exception instead.