### PR TITLE
Rework publish-mpp-root-module-in-platform.gradle

### DIFF
--- a/gradle/publish-mpp-root-module-in-platform.gradle
+++ b/gradle/publish-mpp-root-module-in-platform.gradle
@@ -8,28 +8,33 @@
  * metadata can still get the platform artifact and transitive dependencies from the POM
  * (see details in https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
  */
-project.ext.publishPlatformArtifactsInRootModule = { platformPublication ->
+project.ext.publishPlatformArtifactsInRootModule = { MavenPublication platformPublication ->
     afterEvaluate {
-        def platformPomBuilder = null
+        XmlProvider platformXml = null
 
-        platformPublication.pom.withXml { platformPomBuilder = asString() }
+        platformPublication.pom.withXml { platformXml = it }
 
         publishing.publications.kotlinMultiplatform {
-            platformPublication.artifacts.forEach {
-                artifact(it)
-            }
-
             pom.withXml {
-                def pomStringBuilder = asString()
-                pomStringBuilder.setLength(0)
-                // The platform POM needs its artifact ID replaced with the artifact ID of the root module:
-                def platformPomString = platformPomBuilder.toString()
-                platformPomString.eachLine { line ->
-                    if (!line.contains("<!--")) { // Remove the Gradle module metadata marker as it will be added anew
-                        pomStringBuilder.append(line.replace(platformPublication.artifactId, artifactId))
-                        pomStringBuilder.append("\n")
-                    }
-                }
+                Node root = asNode()
+                // Remove the original content and add the content from the platform POM:
+                root.children().toList().each { root.remove(it as Node) }
+                platformXml.asNode().children().each { root.append(it as Node) }
+
+                // Adjust the self artifact ID, as it should match the root module's coordinates:
+                ((root.get("artifactId") as NodeList).get(0) as Node).setValue(artifactId)
+
+                // Set packaging to POM to indicate that there's no artifact:
+                root.appendNode("packaging", "pom")
+
+                // Remove the original platform dependencies and add a single dependency on the platform module:
+                Node dependencies = (root.get("dependencies") as NodeList).get(0) as Node
+                dependencies.children().toList().each { dependencies.remove(it as Node) }
+                Node singleDependency = dependencies.appendNode("dependency")
+                singleDependency.appendNode("groupId", platformPublication.groupId)
+                singleDependency.appendNode("artifactId", platformPublication.artifactId)
+                singleDependency.appendNode("version", platformPublication.version)
+                singleDependency.appendNode("scope", "compile")
             }
         }
 


### PR DESCRIPTION
* Don't duplicate the platform artifact in the root module
* Instead of copying the platform POM to the root module, generate a
  new POM for the root module that shows that there's only a single dependency
  on the platform module (foo -> foo-jvm)