### PR TITLE
Support deserialization of top-level nullable types

### DIFF
--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -131,6 +131,12 @@ public sealed class Hocon(
             return !conf.getIsNull(tag)
         }
 
+        override fun decodeNotNullMark(): Boolean {
+            // Tag might be null for top-level deserialization
+            val currentTag = currentTagOrNull ?: return !conf.isEmpty
+            return decodeTaggedNotNullMark(currentTag)
+        }
+
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
                 descriptor.kind.listLike -> ListConfigReader(conf.getList(currentTag))

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconValuesTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconValuesTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.hocon
 
 import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
 import org.junit.*
 import org.junit.Assert.*
 
@@ -77,6 +78,19 @@ class HoconValuesTest {
         val obj = deserializeConfig("i = 10, s = null", WithNullable.serializer())
         assertEquals(10, obj.i)
         assertEquals(null, obj.s)
+    }
+
+    @Test
+    fun `deserialize nullable types with nullable serializer`() {
+        val obj = deserializeConfig("i = 10, s = null", WithNullable.serializer().nullable)!!
+        assertEquals(10, obj.i)
+        assertEquals(null, obj.s)
+    }
+
+    @Test
+    fun testDeserializerTopLevelNullableType() {
+        val value = deserializeConfig("", WithNullable.serializer().nullable)
+        assertNull(value)
     }
 
     @Test

--- a/runtime/api/kotlinx-serialization-core.api
+++ b/runtime/api/kotlinx-serialization-core.api
@@ -1043,11 +1043,8 @@ public class kotlinx/serialization/internal/Migration : kotlinx/serialization/de
 
 public abstract class kotlinx/serialization/internal/NamedValueDecoder : kotlinx/serialization/internal/TaggedDecoder {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun composeName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	protected fun elementName (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/String;
-	protected final fun getRootName ()Ljava/lang/String;
 	public synthetic fun getTag (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/Object;
 	protected final fun getTag (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/String;
 	protected final fun nested (Ljava/lang/String;)Ljava/lang/String;
@@ -1055,11 +1052,8 @@ public abstract class kotlinx/serialization/internal/NamedValueDecoder : kotlinx
 
 public abstract class kotlinx/serialization/internal/NamedValueEncoder : kotlinx/serialization/internal/TaggedEncoder {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun composeName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	protected fun elementName (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/String;
-	protected final fun getRootName ()Ljava/lang/String;
 	public synthetic fun getTag (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/Object;
 	protected final fun getTag (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/String;
 	protected final fun nested (Ljava/lang/String;)Ljava/lang/String;
@@ -1229,7 +1223,7 @@ public abstract class kotlinx/serialization/internal/TaggedDecoder : kotlinx/ser
 	public final fun decodeIntElement (Lkotlinx/serialization/descriptors/SerialDescriptor;I)I
 	public final fun decodeLong ()J
 	public final fun decodeLongElement (Lkotlinx/serialization/descriptors/SerialDescriptor;I)J
-	public final fun decodeNotNullMark ()Z
+	public fun decodeNotNullMark ()Z
 	public final fun decodeNull ()Ljava/lang/Void;
 	public fun decodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
 	public final fun decodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;

--- a/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/internal/NullableSerializer.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.encoding.*
  * @suppress internal API
  */
 @PublishedApi
+@OptIn(ExperimentalSerializationApi::class)
 internal class NullableSerializer<T : Any>(private val serializer: KSerializer<T>) : KSerializer<T?> {
     override val descriptor: SerialDescriptor = SerialDescriptorForNullable(serializer.descriptor)
 
@@ -42,6 +43,7 @@ internal class NullableSerializer<T : Any>(private val serializer: KSerializer<T
     }
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 internal class SerialDescriptorForNullable(internal val original: SerialDescriptor) : SerialDescriptor by original {
     override val serialName: String = original.serialName + "?"
     override val isNullable: Boolean

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -78,6 +78,8 @@ private sealed class AbstractJsonTreeDecoder(
         // Nothing
     }
 
+    override fun decodeNotNullMark(): Boolean = currentObject() !is JsonNull
+
     protected open fun getValue(tag: String): JsonPrimitive {
         val currentElement = currentElement(tag)
         return currentElement as? JsonPrimitive ?: throw JsonDecodingException(

--- a/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -21,6 +21,7 @@ internal fun <T> Json.writeJson(value: T, serializer: SerializationStrategy<T>):
     return result
 }
 
+@ExperimentalSerializationApi
 private sealed class AbstractJsonTreeEncoder(
     final override val json: Json,
     val nodeConsumer: (JsonElement) -> Unit
@@ -186,9 +187,13 @@ private class JsonTreeListEncoder(json: Json, nodeConsumer: (JsonElement) -> Uni
     override fun getCurrent(): JsonElement = JsonArray(array)
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 internal inline fun <reified T : JsonElement> cast(value: JsonElement, descriptor: SerialDescriptor): T {
     if (value !is T) {
-        throw JsonDecodingException(-1, "Expected ${T::class} as the serialized body of ${descriptor.serialName}, but had ${value::class}")
+        throw JsonDecodingException(
+            -1,
+            "Expected ${T::class} as the serialized body of ${descriptor.serialName}, but had ${value::class}"
+        )
     }
     return value
 }

--- a/runtime/commonTest/src/kotlinx/serialization/json/DecodeFromJsonElementTest.kt
+++ b/runtime/commonTest/src/kotlinx/serialization/json/DecodeFromJsonElementTest.kt
@@ -1,0 +1,55 @@
+package kotlinx.serialization.json
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+class DecodeFromJsonElementTest {
+    @Serializable
+    data class A(val a: Int)
+
+    @Serializable
+    data class B(val a: A?)
+
+    @Test
+    fun testDecodeTopLevelNullable() {
+        val a = A(42)
+        val jsonElement = Json.encodeToJsonElement(a)
+        assertEquals(a, Json.decodeFromJsonElement<A?>(jsonElement))
+    }
+
+    @Test
+    fun topLevelNull() {
+        assertNull(Json.decodeFromJsonElement<A?>(JsonNull))
+    }
+
+    @Test
+    fun testInnerNullable() {
+        val b = B(A(42))
+        val json = Json.encodeToJsonElement(b)
+        assertEquals(b, Json.decodeFromJsonElement(json))
+    }
+
+    @Test
+    fun testInnerNullableNull() {
+        val b = B(null)
+        val json = Json.encodeToJsonElement(b)
+        assertEquals(b, Json.decodeFromJsonElement(json))
+    }
+
+    @Test
+    fun testPrimitive() {
+        assertEquals(42, Json.decodeFromJsonElement(JsonPrimitive(42)))
+        assertEquals(42, Json.decodeFromJsonElement<Int?>(JsonPrimitive(42)))
+        assertEquals(null, Json.decodeFromJsonElement<Int?>(JsonNull))
+    }
+
+    @Test
+    fun testNullableList() {
+        assertEquals(listOf(42), Json.decodeFromJsonElement<List<Int>?>(JsonArray(listOf(JsonPrimitive(42)))))
+        assertEquals(listOf(42), Json.decodeFromJsonElement<List<Int?>?>(JsonArray(listOf(JsonPrimitive(42)))))
+        assertEquals(listOf(42), Json.decodeFromJsonElement<List<Int?>>(JsonArray(listOf(JsonPrimitive(42)))))
+        // Nulls
+        assertEquals(null, Json.decodeFromJsonElement<List<Int>?>(JsonNull))
+        assertEquals(null, Json.decodeFromJsonElement<List<Int?>?>(JsonNull))
+    }
+}


### PR DESCRIPTION
Also, fix the same for Hocon, but do not generalize it too frequently.

Fixes #1035