### PR TITLE
Mark JsonEncoder and JsonDecoder unstable for inheritance

### DIFF
--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonDecoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonDecoder.kt
@@ -44,6 +44,13 @@ import kotlinx.serialization.encoding.updateModeDeprecated
  *     }
  * }
  * ```
+ *
+ * ### Not stable for inheritance
+ *
+ * `JsonDecoder` interface is not stable for inheritance in 3rd party libraries, as new methods
+ * might be added to this interface or contracts of the existing methods can be changed.
+ * Accepting this interface in your API methods, casting [Decoder] to [JsonDecoder] and invoking its
+ * methods is considered stable.
  */
 public interface JsonDecoder : Decoder, CompositeDecoder {
     /**

--- a/runtime/commonMain/src/kotlinx/serialization/json/JsonEncoder.kt
+++ b/runtime/commonMain/src/kotlinx/serialization/json/JsonEncoder.kt
@@ -42,6 +42,13 @@ import kotlinx.serialization.encoding.*
  *     }
  * }
  * ```
+ *
+ * ### Not stable for inheritance
+ *
+ * `JsonEncoder` interface is not stable for inheritance in 3rd party libraries, as new methods
+ * might be added to this interface or contracts of the existing methods can be changed.
+ * Accepting this interface in your API methods, casting [Encoder] to [JsonEncoder] and invoking its
+ * methods is considered stable.
  */
 public interface JsonEncoder : Encoder, CompositeEncoder {
     /**


### PR DESCRIPTION
Most of the users only use its stable methods and should not implement it directly, while we still want to have an opportunity to evolve it in the future, add new methods etc. E.g. the potential future addition could be 'decodeRawJson(): String' method for #1058