### PR TITLE
Minor fix on serializers module docs

### DIFF
--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -884,7 +884,7 @@ class this serializer is defined for is fetched automatically via the `reified` 
 
 ```kotlin
 private val module = SerializersModule { 
-    contextual(DateAsLongSerializer)
+    contextual(Date::class, DateAsLongSerializer)
 }
 ``` 
 


### PR DESCRIPTION
I think that actually the `contextual` fun needs the class to deserialize to as is 1st parameter