### PR TITLE
Do not provide default implementation for serializersModule in Abstra…

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -445,7 +445,6 @@ public abstract class kotlinx/serialization/encoding/AbstractDecoder : kotlinx/s
 	public final fun decodeStringElement (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Ljava/lang/String;
 	public fun decodeValue ()Ljava/lang/Object;
 	public fun endStructure (Lkotlinx/serialization/descriptors/SerialDescriptor;)V
-	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public fun getUpdateMode ()Lkotlinx/serialization/UpdateMode;
 	public fun updateNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun updateNullableSerializableValue (Lkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;
@@ -488,7 +487,6 @@ public abstract class kotlinx/serialization/encoding/AbstractEncoder : kotlinx/s
 	public final fun encodeStringElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILjava/lang/String;)V
 	public fun encodeValue (Ljava/lang/Object;)V
 	public fun endStructure (Lkotlinx/serialization/descriptors/SerialDescriptor;)V
-	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public fun shouldEncodeElementDefault (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Z
 }
 

--- a/core/commonMain/src/kotlinx/serialization/encoding/AbstractDecoder.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/AbstractDecoder.kt
@@ -16,8 +16,6 @@ import kotlinx.serialization.modules.*
  */
 @ExperimentalSerializationApi
 public abstract class AbstractDecoder : Decoder, CompositeDecoder {
-    override val serializersModule: SerializersModule
-        get() = EmptySerializersModule
 
     @Suppress("DEPRECATION")
     @Deprecated(updateModeDeprecated, level = DeprecationLevel.ERROR)

--- a/core/commonMain/src/kotlinx/serialization/encoding/AbstractEncoder.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/AbstractEncoder.kt
@@ -16,8 +16,6 @@ import kotlinx.serialization.modules.*
  */
 @ExperimentalSerializationApi
 public abstract class AbstractEncoder : Encoder, CompositeEncoder {
-    override val serializersModule: SerializersModule
-        get() = EmptySerializersModule
 
     // do not update signature here because new signature is called by the plugin;
     // and clients that have old signature would not be called.

--- a/core/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 import kotlinx.serialization.internal.*
+import kotlinx.serialization.modules.*
 import kotlin.test.*
 
 /*
@@ -19,6 +20,8 @@ class BasicTypesSerializationTest {
 
     // KeyValue Input/Output
     class KeyValueOutput(private val sb: StringBuilder) : AbstractEncoder() {
+        override val serializersModule: SerializersModule = EmptySerializersModule
+
         override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
             sb.append('{')
             return this
@@ -53,6 +56,8 @@ class BasicTypesSerializationTest {
     }
 
     class KeyValueInput(private val inp: Parser) : AbstractDecoder() {
+        override val serializersModule: SerializersModule = EmptySerializersModule
+
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             inp.expectAfterWhiteSpace('{')
             return this

--- a/core/jvmTest/src/kotlinx/serialization/SerializationMethodInvocationOrderTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/SerializationMethodInvocationOrderTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization
 
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 import org.junit.Test
 import kotlin.test.*
 
@@ -41,6 +42,8 @@ class SerializationMethodInvocationOrderTest {
 
     class Out : AbstractEncoder() {
         var step = 0
+
+        override val serializersModule: SerializersModule = EmptySerializersModule
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
             when (step) {
@@ -111,6 +114,8 @@ class SerializationMethodInvocationOrderTest {
 
     class Inp : AbstractDecoder() {
         var step = 0
+
+        override val serializersModule: SerializersModule = EmptySerializersModule
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             when (step) {

--- a/core/jvmTest/src/kotlinx/serialization/SerializeFlatTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/SerializeFlatTest.kt
@@ -6,6 +6,7 @@ package kotlinx.serialization
 
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 import org.junit.Test
 import kotlin.test.*
 
@@ -197,6 +198,8 @@ class SerializeFlatTest() {
     class Out(private val name: String) : AbstractEncoder() {
         var step = 0
 
+        override val serializersModule: SerializersModule = EmptySerializersModule
+
         override fun beginStructure(
             descriptor: SerialDescriptor
         ): CompositeEncoder {
@@ -246,6 +249,8 @@ class SerializeFlatTest() {
 
     class Inp(private val name: String) : AbstractDecoder() {
         var step = 0
+
+        override val serializersModule: SerializersModule = EmptySerializersModule
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             checkDesc(name, descriptor)

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -438,11 +438,14 @@ overriding `encodeValue` in [AbstractEncoder].
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 -->
 
 ```kotlin
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -504,9 +507,12 @@ in a _serial_ order.
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -536,6 +542,8 @@ A decoder needs to implements more substance.
 ```kotlin
 class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
     private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
     
@@ -607,9 +615,12 @@ its support by returning `true` from the [CompositeDecoder.decodeSequentially] f
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -628,6 +639,8 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 ```kotlin
 class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
     private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
     
@@ -687,11 +700,14 @@ Our encoder implementation does not keep any state, so it just returns `this` fr
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 -->
 
 ```kotlin
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -723,6 +739,8 @@ in addition to the previous code.
 ```kotlin
 class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
 
@@ -789,9 +807,12 @@ of "null indicator", telling whether the upcoming value is null or is not null.
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -823,6 +844,8 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 
 class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
+    
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
 
@@ -898,11 +921,13 @@ import kotlinx.serialization.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 import java.io.*
 -->
 
 ```kotlin            
 class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun encodeBoolean(value: Boolean) = output.writeByte(if (value) 1 else 0)
     override fun encodeByte(value: Byte) = output.writeByte(value.toInt())
     override fun encodeShort(value: Short) = output.writeShort(value.toInt())
@@ -939,7 +964,7 @@ The decoder implementation mirrors encoder's implementation overriding all the p
 ```kotlin 
 class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
-
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun decodeBoolean(): Boolean = input.readByte().toInt() != 0
     override fun decodeByte(): Byte = input.readByte()
     override fun decodeShort(): Short = input.readShort()
@@ -1035,6 +1060,7 @@ being serialized, so we fetch the builtin [KSerializer] instance for `ByteArray`
 import kotlinx.serialization.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.modules.*
 import kotlinx.serialization.encoding.*
 import java.io.*
 -->
@@ -1053,6 +1079,7 @@ a size of up to 254 bytes.
 
 <!--- INCLUDE
 class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun encodeBoolean(value: Boolean) = output.writeByte(if (value) 1 else 0)
     override fun encodeByte(value: Byte) = output.writeByte(value.toInt())
     override fun encodeShort(value: Short) = output.writeShort(value.toInt())
@@ -1108,7 +1135,7 @@ inline fun <reified T> encodeTo(output: DataOutput, value: T) = encodeTo(output,
 
 class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
-
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun decodeBoolean(): Boolean = input.readByte().toInt() != 0
     override fun decodeByte(): Byte = input.readByte()
     override fun decodeShort(): Short = input.readShort()

--- a/formats/json/commonTest/src/kotlinx/serialization/UnknownElementIndexTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/UnknownElementIndexTest.kt
@@ -15,7 +15,7 @@ class UnknownElementIndexTest {
     data class Holder(val c: Choices)
 
     class MalformedReader : AbstractDecoder() {
-        override val serializersModule: SerializersModule =EmptySerializersModule
+        override val serializersModule: SerializersModule = EmptySerializersModule
 
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             return UNKNOWN_NAME

--- a/formats/json/commonTest/src/kotlinx/serialization/UnknownElementIndexTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/UnknownElementIndexTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.*
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -14,6 +15,8 @@ class UnknownElementIndexTest {
     data class Holder(val c: Choices)
 
     class MalformedReader : AbstractDecoder() {
+        override val serializersModule: SerializersModule =EmptySerializersModule
+
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             return UNKNOWN_NAME
         }

--- a/guide/example/example-formats-08.kt
+++ b/guide/example/example-formats-08.kt
@@ -4,9 +4,12 @@ package example.exampleFormats08
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)

--- a/guide/example/example-formats-09.kt
+++ b/guide/example/example-formats-09.kt
@@ -4,9 +4,12 @@ package example.exampleFormats09
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -23,6 +26,8 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 
 class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
     private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
     

--- a/guide/example/example-formats-10.kt
+++ b/guide/example/example-formats-10.kt
@@ -4,9 +4,12 @@ package example.exampleFormats10
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -23,6 +26,8 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 
 class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
     private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
     

--- a/guide/example/example-formats-11.kt
+++ b/guide/example/example-formats-11.kt
@@ -4,9 +4,12 @@ package example.exampleFormats11
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -28,6 +31,8 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 
 class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
 

--- a/guide/example/example-formats-12.kt
+++ b/guide/example/example-formats-12.kt
@@ -4,9 +4,12 @@ package example.exampleFormats12
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 
 class ListEncoder : AbstractEncoder() {
     val list = mutableListOf<Any>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun encodeValue(value: Any) {
         list.add(value)
@@ -31,6 +34,8 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 
 class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
+    
+    override val serializersModule: SerializersModule = EmptySerializersModule
 
     override fun decodeValue(): Any = list.removeFirst()
 

--- a/guide/example/example-formats-13.kt
+++ b/guide/example/example-formats-13.kt
@@ -5,9 +5,11 @@ import kotlinx.serialization.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
 import java.io.*
 
 class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun encodeBoolean(value: Boolean) = output.writeByte(if (value) 1 else 0)
     override fun encodeByte(value: Byte) = output.writeByte(value.toInt())
     override fun encodeShort(value: Short) = output.writeShort(value.toInt())
@@ -37,7 +39,7 @@ inline fun <reified T> encodeTo(output: DataOutput, value: T) = encodeTo(output,
 
 class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
-
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun decodeBoolean(): Boolean = input.readByte().toInt() != 0
     override fun decodeByte(): Byte = input.readByte()
     override fun decodeShort(): Short = input.readShort()

--- a/guide/example/example-formats-14.kt
+++ b/guide/example/example-formats-14.kt
@@ -4,11 +4,13 @@ package example.exampleFormats14
 import kotlinx.serialization.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.modules.*
 import kotlinx.serialization.encoding.*
 import java.io.*
 
 private val byteArraySerializer = serializer<ByteArray>()
 class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun encodeBoolean(value: Boolean) = output.writeByte(if (value) 1 else 0)
     override fun encodeByte(value: Byte) = output.writeByte(value.toInt())
     override fun encodeShort(value: Short) = output.writeShort(value.toInt())
@@ -59,7 +61,7 @@ inline fun <reified T> encodeTo(output: DataOutput, value: T) = encodeTo(output,
 
 class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
-
+    override val serializersModule: SerializersModule = EmptySerializersModule
     override fun decodeBoolean(): Boolean = input.readByte().toInt() != 0
     override fun decodeByte(): Byte = input.readByte()
     override fun decodeShort(): Short = input.readShort()

--- a/integration-test/src/commonTest/kotlin/sample/BasicTypesSerializationTest.kt
+++ b/integration-test/src/commonTest/kotlin/sample/BasicTypesSerializationTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.encoding.AbstractDecoder
 import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.modules.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -122,6 +123,9 @@ class BasicTypesSerializationTest {
 
     @OptIn(ExperimentalSerializationApi::class)
     class KeyValueOutput(val sb: StringBuilder) : AbstractEncoder() {
+
+        override val serializersModule: SerializersModule = EmptySerializersModule
+
         override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
             sb.append('{')
             return this
@@ -156,6 +160,9 @@ class BasicTypesSerializationTest {
     }
 
     class KeyValueInput(val inp: Parser) : AbstractDecoder() {
+
+        override val serializersModule: SerializersModule = EmptySerializersModule
+
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
             inp.expectAfterWhiteSpace('{')
             return this


### PR DESCRIPTION
…ctEncoder and AbstractDecoder

This default is not reasonable, never wanted and potentially error-prone