### PR TITLE
Add handling of the project property that allows to disable cross-compilation

### DIFF
--- a/gradle/native-targets.gradle
+++ b/gradle/native-targets.gradle
@@ -2,12 +2,70 @@
  * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+/**
+ * Specifies what subset of Native targets to build
+ *
+ * ALL — all possible for compilation
+ * HOST — host-specific ones, without cross compilation (e.g. do not build linuxX64 on macOS host)
+ * SINGLE — only for current OS (to import into IDEA / quickly run tests)
+ * DISABLED — disable all Native targets (useful with Kotlin compiler built from sources)
+ *
+ * For HOST mode, all targets are still listed in .module file, so HOST mode is useful for release process.
+ */
+enum NativeState { ALL, HOST, SINGLE, DISABLED }
+
+def getNativeState(String description) {
+    if (description == null) return NativeState.SINGLE
+    switch(description.toLowerCase()) {
+        case 'all':
+        case 'true':
+            return NativeState.ALL
+        case 'host':
+            return NativeState.HOST
+        case 'disabled':
+            return NativeState.DISABLED
+        // 'single', 'false', etc
+        default:
+            return NativeState.SINGLE
+    }
+}
+
 project.ext.ideaActive = System.getProperty('idea.active') == 'true'
-project.ext.deployMode = property('native.deploy') == 'true'
-project.ext.singleTargetMode = project.ext.ideaActive || !project.ext.deployMode
+project.ext.nativeState = getNativeState(property('native.deploy'))
+project.ext.singleTargetMode = project.ext.ideaActive || (project.ext.nativeState == NativeState.SINGLE)
 
 project.ext.nativeMainSets = []
 project.ext.nativeTestSets = []
+
+/**
+ * Disables compilation but leaves the target in .module file
+ */
+def disableCompilation(targets) {
+    configure(targets) {
+        compilations.all {
+            cinterops.all { project.tasks[interopProcessingTaskName].enabled = false }
+            compileKotlinTask.enabled = false
+        }
+        binaries.all { linkTask.enabled = false }
+
+        mavenPublication { publicationToDisable ->
+            tasks.withType(AbstractPublishToMaven).all {
+                onlyIf { publication != publicationToDisable }
+            }
+            tasks.withType(GenerateModuleMetadata).all {
+                onlyIf { publication.get() != publicationToDisable }
+            }
+        }
+    }
+}
+
+def getHostName() {
+    def target = System.getProperty("os.name")
+    if (target == 'Linux') return 'linux'
+    if (target.startsWith('Windows')) return 'windows'
+    if (target.startsWith('Mac')) return 'macos'
+    return 'unknown'
+}
 
 kotlin {
     targets {
@@ -15,10 +73,6 @@ kotlin {
         def linuxEnabled = manager.isEnabled(presets.linuxX64.konanTarget)
         def macosEnabled = manager.isEnabled(presets.macosX64.konanTarget)
         def winEnabled = manager.isEnabled(presets.mingwX64.konanTarget)
-
-        project.ext.isLinuxHost = linuxEnabled
-        project.ext.isMacosHost = macosEnabled
-        project.ext.isWinHost = winEnabled
 
         def ideaPreset = presets.linuxX64
         if (macosEnabled) ideaPreset = presets.macosX64
@@ -33,6 +87,8 @@ kotlin {
     }
 
     targets {
+        if (project.ext.nativeState == NativeState.DISABLED) return
+
         if (project.ext.singleTargetMode) {
             fromPreset(project.ext.ideaPreset, 'native')
         } else {
@@ -59,7 +115,16 @@ kotlin {
             addTarget(presets.mingwX64)
             addTarget(presets.mingwX86)
         }
+
+        if (project.ext.nativeState == NativeState.HOST) {
+            // linux targets that can cross-compile on all three hosts
+            def linuxCrossCompileTargets = [linuxX64, linuxArm32Hfp, linuxArm64]
+            if (getHostName() != "linux") {
+                disableCompilation(linuxCrossCompileTargets)
+            }
+        }
     }
+
 
     sourceSets {
         nativeMain { dependsOn commonMain }


### PR DESCRIPTION
without removing targets from module file.

This is needed to reduce amount of time wasted during release process (linux targets are built and uploaded three times, because they're available on all hosts)