### PR TITLE
Match releasing document with current TeamCity setup

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,9 +29,10 @@ To release new `<version>` of `kotlinx.serialization`:
    `git push origin dev && git push origin --tags`
 
 1. On [TeamCity integration server](https://teamcity.jetbrains.com/project.html?projectId=KotlinTools_KotlinxSerialization&tab=projectOverview):
-   * Wait until "Runtime library (Build)" configuration for committed `dev` branch passes tests.
-   * Run "Runtime library (Depoly - Train)" configuration with selected changes from `dev`.
-      * For intermediate releases, you may override version with `reverse.dep.*.system.DeployVersion` build parameter.
+   * Wait until "Runtime library (Build – Aggregated)" configuration for committed `dev` branch passes tests.
+   * Run "Runtime library (Deploy - Train)" configuration:
+     * On 'Changes' tab, select `dev` branch and corresponding commit.
+     * On 'Parameters' tab, find 'Deploy version' and fill in with `<version>`.
 
 4. In [Bintray](https://bintray.com/kotlin/kotlinx/kotlinx.serialization.runtime) admin interface:
    * Publish artifacts of the new version.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 #
 
 group=org.jetbrains.kotlinx
-version=1.0.0
+version=1.0.1-SNAPSHOT
 
 kotlin.version=1.4.10
 


### PR DESCRIPTION
(requirements on deploy version and aggregated build with tests)

Update version to SNAPSHOT

fixes #981 