### PR TITLE
Remove kotlin-stdlib from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION)) // or "stdlib-jdk8"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.0")
 }
 ```
@@ -162,7 +161,6 @@ repositories {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version" // or "kotlin-stdlib-jdk8"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.0"
 }
 ```


### PR DESCRIPTION
Remove kotlin-stdlib from README.md as the kotlin plugin adds it to the dependencies automatically since Kotlin `1.4`