### PR TITLE
Add community-supported library multiplatform YAML

### DIFF
--- a/formats/README.md
+++ b/formats/README.md
@@ -84,7 +84,7 @@ Allows serialization and deserialization of objects to and from [YAML](http://ya
 * Platform: all supported platforms
 
 Allows serialization and deserialization of objects to and from [YAML](http://yaml.org). 
-Basic serial operations have been implemented, but some features such as compound keys and polymorpic are still working in progress. 
+Basic serial operations have been implemented, but some features such as compound keys and polymorphism are still work in progress.
 
 ### CBOR
 

--- a/formats/README.md
+++ b/formats/README.md
@@ -77,6 +77,15 @@ not be available in other formats such as JSON.
 
 Allows serialization and deserialization of objects to and from [YAML](http://yaml.org).
 
+### YAML (Multiplatform)
+
+* GitHub repo: [him188/yamlkt](https://github.com/him188/yamlkt)
+* Artifact ID: `net.mamoe.yamlkt:yamlkt`
+* Platform: all supported platforms
+
+Allows serialization and deserialization of objects to and from [YAML](http://yaml.org). 
+Basic serial operations have been implemented, but some features such as compound keys and polymorpic are still working in progress. 
+
 ### CBOR
 
 * GitHub repo: [L-Briand/obor](https://github.com/L-Briand/obor)


### PR DESCRIPTION
The existing YAML library is JVM only so I created the project ['yamlkt'](https://github.com/him188/yamlkt) and implemented YAML serialization and deserialization in pure Kotlin so as to make it supporting all platforms. However it's currently in experimental stage and I am continue working on it.