### PR TITLE
Properly cache generated serializers in PluginGeneratedSerialDescript…

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'com.esotericsoftware:kryo:4.0.0'
 
     compile project(':kotlinx-serialization-core')
+    compile project(':kotlinx-serialization-json')
     compile project(':kotlinx-serialization-protobuf')
 
     // async profiler

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/CoerceInputValuesBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/CoerceInputValuesBenchmark.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 package kotlinx.benchmarks.json
 
 import kotlinx.serialization.*

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/CoerceInputValuesBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/CoerceInputValuesBenchmark.kt
@@ -1,0 +1,63 @@
+package kotlinx.benchmarks.json
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(2)
+open class CoerceInputValuesBenchmark {
+
+    // Specific benchmark to isolate effect on #1156. Remove after release of 1.0.1
+
+    @Serializable
+    class Holder(
+        val i1: Int,
+        val i2: Int,
+        val i3: Int,
+        val i4: Int,
+        val i5: Int,
+        val i6: Int,
+        val i7: Int,
+        val i8: Int,
+        val i9: Int,
+        val i10: Int
+    )
+
+    @Serializable
+    class NullableHolder(
+        val i1: Int?,
+        val i2: Int?,
+        val i3: Int?,
+        val i4: Int?,
+        val i5: Int?,
+        val i6: Int?,
+        val i7: Int?,
+        val i8: Int?,
+        val i9: Int?,
+        val i10: Int?
+    )
+
+    private val str = """{"i1":1,"i2":1,"i3":1,"i4":1,"i5":1,"i6":1,"i7":1,"i8":1,"i9":1,"i10":1}"""
+
+    private val json = Json { coerceInputValues = false }
+    private val coercingJson = Json { coerceInputValues = true }
+
+    @Benchmark
+    fun testNullableCoercing() = coercingJson.decodeFromString(NullableHolder.serializer(), str)
+
+    @Benchmark
+    fun testNullableRegular() = json.decodeFromString(NullableHolder.serializer(), str)
+
+
+    @Benchmark
+    fun testNonNullableCoercing() = coercingJson.decodeFromString(Holder.serializer(), str)
+
+    @Benchmark
+    fun testNonNullableRegular() = json.decodeFromString(Holder.serializer(), str)
+}

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/GeneratedBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/GeneratedBenchmark.kt
@@ -2,7 +2,7 @@
  * Copyright 2017-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package kotlinx.benchmarks
+package kotlinx.benchmarks.json
 
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoBaseline.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoBaseline.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 package kotlinx.benchmarks.protobuf
 
 import kotlinx.serialization.Serializable

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoBaseline.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoBaseline.kt
@@ -1,10 +1,6 @@
-/*
- * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
+package kotlinx.benchmarks.protobuf
 
-package kotlinx.benchmarks
-
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.*
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.*

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListBenchmark.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 package kotlinx.benchmarks.protobuf
 
 import kotlinx.serialization.*

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListBenchmark.kt
@@ -1,11 +1,8 @@
-/*
- * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package kotlinx.benchmarks
+package kotlinx.benchmarks.protobuf
 
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
+import kotlinx.serialization.protobuf.ProtoBuf.Default.encodeToByteArray
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.*
 
@@ -15,16 +12,16 @@ import java.util.concurrent.*
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
-open class ProtoListLikeBenchmark {
+open class ProtoListBenchmark {
 
     @Serializable
     class Holder(val a: Int, val b: Int, val c: Long, val d: Double)
 
     @Serializable
-    class HolderList(val h1: Holder, val h2: Holder, val h3: Holder, val h4: Holder, val h5: Holder)
+    class HolderList(val list: List<Holder>)
 
     private val h = Holder(1, 2, 3L, 4.0)
-    private val value = HolderList(h, h, h, h, h)
+    private val value = HolderList(listOf(h, h, h, h, h))
     private val bytes = ProtoBuf.encodeToByteArray(value)
 
     @Benchmark

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListLikeBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListLikeBenchmark.kt
@@ -1,11 +1,8 @@
-/*
- * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package kotlinx.benchmarks
+package kotlinx.benchmarks.protobuf
 
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
+import kotlinx.serialization.protobuf.ProtoBuf.Default.encodeToByteArray
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.*
 
@@ -15,16 +12,16 @@ import java.util.concurrent.*
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
-open class ProtoListBenchmark {
+open class ProtoListLikeBenchmark {
 
     @Serializable
     class Holder(val a: Int, val b: Int, val c: Long, val d: Double)
 
     @Serializable
-    class HolderList(val list: List<Holder>)
+    class HolderList(val h1: Holder, val h2: Holder, val h3: Holder, val h4: Holder, val h5: Holder)
 
     private val h = Holder(1, 2, 3L, 4.0)
-    private val value = HolderList(listOf(h, h, h, h, h))
+    private val value = HolderList(h, h, h, h, h)
     private val bytes = ProtoBuf.encodeToByteArray(value)
 
     @Benchmark

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListLikeBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoListLikeBenchmark.kt
@@ -1,8 +1,10 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 package kotlinx.benchmarks.protobuf
 
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
-import kotlinx.serialization.protobuf.ProtoBuf.Default.encodeToByteArray
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.*
 

--- a/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -34,7 +34,7 @@ internal open class PluginGeneratedSerialDescriptor(
     // don't change lazy mode: KT-32871, KT-32872
     private val indices: Map<String, Int> by lazy { buildIndices() }
     // Cache child serializers, they are not cached by the implementation for nullable types
-    private val childSerializers = generatedSerializer?.childSerializers() ?: emptyArray()
+    private val childSerializers by lazy { generatedSerializer?.childSerializers() ?: emptyArray() }
 
     // Lazy because of JS specific initialization order (#789)
     private val typeParameterDescriptors: Array<SerialDescriptor> by lazy {

--- a/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -28,11 +28,13 @@ internal open class PluginGeneratedSerialDescriptor(
 
     // Classes rarely have annotations, so we can save up a bit of allocations here
     private var classAnnotations: MutableList<Annotation>? = null
-    private var elementsOptionality = BooleanArray(elementsCount)
+    private val elementsOptionality = BooleanArray(elementsCount)
     internal val namesSet: Set<String> get() = indices.keys
 
     // don't change lazy mode: KT-32871, KT-32872
     private val indices: Map<String, Int> by lazy { buildIndices() }
+    // Cache child serializers, they are not cached by the implementation for nullable types
+    private val childSerializers = generatedSerializer?.childSerializers() ?: emptyArray()
 
     // Lazy because of JS specific initialization order (#789)
     private val typeParameterDescriptors: Array<SerialDescriptor> by lazy {
@@ -69,8 +71,7 @@ internal open class PluginGeneratedSerialDescriptor(
     }
 
     override fun getElementDescriptor(index: Int): SerialDescriptor {
-        return generatedSerializer?.childSerializers()?.get(index)?.descriptor
-                ?: throw IndexOutOfBoundsException("$serialName descriptor has only $elementsCount elements, index: $index")
+        return childSerializers.getChecked(index).descriptor
     }
 
     override fun isElementOptional(index: Int): Boolean = elementsOptionality.getChecked(index)
@@ -100,6 +101,7 @@ internal open class PluginGeneratedSerialDescriptor(
     }
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 internal inline fun <reified SD : SerialDescriptor> SD.equalsImpl(
     other: Any?,
     typeParamsAreEqual: (otherDescriptor: SD) -> Boolean
@@ -116,8 +118,8 @@ internal inline fun <reified SD : SerialDescriptor> SD.equalsImpl(
     return true
 }
 
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun SerialDescriptor.hashCodeImpl(typeParams: Array<SerialDescriptor>): Int {
+@OptIn(ExperimentalSerializationApi::class)
+internal fun SerialDescriptor.hashCodeImpl(typeParams: Array<SerialDescriptor>): Int {
     var result = serialName.hashCode()
     result = 31 * result + typeParams.contentHashCode()
     val elementDescriptors = elementDescriptors


### PR DESCRIPTION
…or in order to avoid allocation of nullable serializer and descriptor.

Also, slightly reduce bytecode size

Fixes #1156