### PR TITLE
Add serializerOrNull function for KType and Type arguments

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -101,7 +101,11 @@ public final class kotlinx/serialization/SerializersKt {
 	public static final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializerOrNull (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerOrNull (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializerOrNull (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializerOrNull (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializerOrNull (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 }
 
 public abstract interface class kotlinx/serialization/StringFormat : kotlinx/serialization/SerialFormat {

--- a/core/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
+++ b/core/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
@@ -17,15 +17,30 @@ import java.lang.reflect.*
 import kotlin.reflect.*
 
 /**
- * Constructs a serializer for the given reflective Java [type].
+ * Reflectively constructs a serializer for the given reflective Java [type].
  * [serializer] is intended to be used as an interoperability layer for libraries like GSON and Retrofit,
  * that operate with reflective Java [Type] and cannot use [typeOf].
  *
  * For application-level serialization, it is recommended to use `serializer<T>()` instead as it is aware of
- * Kotlin-specific type information, such as nullability, sealed classes and object.
+ * Kotlin-specific type information, such as nullability, sealed classes and object singletons.
+ *
+ * @throws SerializationException if serializer cannot be created (provided [type] or its type argument is not serializable).
  */
 @ExperimentalSerializationApi
 public fun serializer(type: Type): KSerializer<Any> = EmptySerializersModule.serializer(type)
+
+/**
+ * Reflectively constructs a serializer for the given reflective Java [type].
+ * [serializer] is intended to be used as an interoperability layer for libraries like GSON and Retrofit,
+ * that operate with reflective Java [Type] and cannot use [typeOf].
+ *
+ * For application-level serialization, it is recommended to use `serializer<T>()` instead as it is aware of
+ * Kotlin-specific type information, such as nullability, sealed classes and object singletons.
+ *
+ * Returns `null` if serializer cannot be created (provided [type] or its type argument is not serializable).
+ */
+@ExperimentalSerializationApi
+public fun serializerOrNull(type: Type): KSerializer<Any>? = EmptySerializersModule.serializerOrNull(type)
 
 /**
  * Retrieves serializer for the given reflective Java [type] using
@@ -36,71 +51,101 @@ public fun serializer(type: Type): KSerializer<Any> = EmptySerializersModule.ser
  *
  * For application-level serialization, it is recommended to use `serializer<T>()` instead as it is aware of
  * Kotlin-specific type information, such as nullability, sealed classes and object singletons.
+ *
+ * @throws SerializationException if serializer cannot be created (provided [type] or its type argument is not serializable).
  */
 @ExperimentalSerializationApi
-public fun SerializersModule.serializer(type: Type): KSerializer<Any> = when (type) {
-    is GenericArrayType -> {
-        genericArraySerializer(type)
-    }
-    is Class<*> -> typeSerializer(type)
-    is ParameterizedType -> {
-        val rootClass = (type.rawType as Class<*>)
-        val args = (type.actualTypeArguments)
-        when {
-            Set::class.java.isAssignableFrom(rootClass) -> SetSerializer(serializer(args[0])) as KSerializer<Any>
-            List::class.java.isAssignableFrom(rootClass) || Collection::class.java.isAssignableFrom(rootClass) -> ListSerializer(serializer(args[0])) as KSerializer<Any>
-            Map::class.java.isAssignableFrom(rootClass) -> MapSerializer(
-                serializer(args[0]),
-                serializer(args[1])
-            ) as KSerializer<Any>
-            Map.Entry::class.java.isAssignableFrom(rootClass) -> MapEntrySerializer(
-                serializer(args[0]),
-                serializer(args[1])
-            ) as KSerializer<Any>
-            Pair::class.java.isAssignableFrom(rootClass) -> PairSerializer(
-                serializer(args[0]),
-                serializer(args[1])
-            ) as KSerializer<Any>
-            Triple::class.java.isAssignableFrom(rootClass) -> TripleSerializer(
-                serializer(args[0]),
-                serializer(args[1]),
-                serializer(args[2])
-            ) as KSerializer<Any>
+public fun SerializersModule.serializer(type: Type): KSerializer<Any> =
+    serializerByJavaTypeImpl(type, failOnMissingTypeArgSerializer = true) ?: type.kclass().serializerNotRegistered()
 
-            else -> {
-                // probably we should deprecate this method because it can't differ nullable vs non-nullable types
-                // since it uses Java TypeToken, not Kotlin one
-                val varargs = args.map { serializer(it) as KSerializer<Any?> }.toTypedArray()
-                (rootClass.kotlin.constructSerializerForGivenTypeArgs(*varargs) as? KSerializer<Any>)
-                        ?: reflectiveOrContextual(rootClass.kotlin as KClass<Any>)
-            }
-        }
-    }
-    is WildcardType -> serializer(type.upperBounds.first())
-    else -> throw IllegalArgumentException("typeToken should be an instance of Class<?>, GenericArray, ParametrizedType or WildcardType, but actual type is $type ${type::class}")
-}
+/**
+ * Retrieves serializer for the given reflective Java [type] using
+ * reflective construction and [contextual][SerializersModule.getContextual] lookup for non-serializable types.
+ *
+ * [serializer] is intended to be used as an interoperability layer for libraries like GSON and Retrofit,
+ * that operate with reflective Java [Type] and cannot use [typeOf].
+ *
+ * For application-level serialization, it is recommended to use `serializer<T>()` instead as it is aware of
+ * Kotlin-specific type information, such as nullability, sealed classes and object singletons.
+ *
+ * Returns `null` if serializer cannot be created (provided [type] or its type argument is not serializable).
+ */
+@ExperimentalSerializationApi
+public fun SerializersModule.serializerOrNull(type: Type): KSerializer<Any>? =
+    serializerByJavaTypeImpl(type, failOnMissingTypeArgSerializer = false)
 
 @OptIn(ExperimentalSerializationApi::class)
-private fun SerializersModule.typeSerializer(type: Class<*>): KSerializer<Any> {
+private fun SerializersModule.serializerByJavaTypeImpl(type: Type, failOnMissingTypeArgSerializer: Boolean = true): KSerializer<Any>? =
+    when (type) {
+        is GenericArrayType -> {
+            genericArraySerializer(type, failOnMissingTypeArgSerializer)
+        }
+        is Class<*> -> typeSerializer(type, failOnMissingTypeArgSerializer)
+        is ParameterizedType -> {
+            val rootClass = (type.rawType as Class<*>)
+            val args = (type.actualTypeArguments)
+            val argsSerializers =
+                if (failOnMissingTypeArgSerializer) args.map { serializer(it) } else args.map { serializerOrNull(it) ?: return null }
+            when {
+                Set::class.java.isAssignableFrom(rootClass) -> SetSerializer(argsSerializers[0]) as KSerializer<Any>
+                List::class.java.isAssignableFrom(rootClass) || Collection::class.java.isAssignableFrom(rootClass) -> ListSerializer(
+                    argsSerializers[0]
+                ) as KSerializer<Any>
+                Map::class.java.isAssignableFrom(rootClass) -> MapSerializer(
+                    argsSerializers[0],
+                    argsSerializers[1]
+                ) as KSerializer<Any>
+                Map.Entry::class.java.isAssignableFrom(rootClass) -> MapEntrySerializer(
+                    argsSerializers[0],
+                    argsSerializers[1]
+                ) as KSerializer<Any>
+                Pair::class.java.isAssignableFrom(rootClass) -> PairSerializer(
+                    argsSerializers[0],
+                    argsSerializers[1]
+                ) as KSerializer<Any>
+                Triple::class.java.isAssignableFrom(rootClass) -> TripleSerializer(
+                    argsSerializers[0],
+                    argsSerializers[1],
+                    argsSerializers[2]
+                ) as KSerializer<Any>
+
+                else -> {
+                    // probably we should deprecate this method because it can't differ nullable vs non-nullable types
+                    // since it uses Java TypeToken, not Kotlin one
+                    val varargs = argsSerializers.map { it as KSerializer<Any?> }.toTypedArray()
+                    (rootClass.kotlin.constructSerializerForGivenTypeArgs(*varargs) as? KSerializer<Any>)
+                            ?: reflectiveOrContextual(rootClass.kotlin as KClass<Any>)
+                }
+            }
+        }
+        is WildcardType -> serializerByJavaTypeImpl(type.upperBounds.first())
+        else -> throw IllegalArgumentException("typeToken should be an instance of Class<?>, GenericArray, ParametrizedType or WildcardType, but actual type is $type ${type::class}")
+    }
+
+@OptIn(ExperimentalSerializationApi::class)
+private fun SerializersModule.typeSerializer(type: Class<*>, failOnMissingTypeArgSerializer: Boolean): KSerializer<Any>? {
     return if (!type.isArray) {
         reflectiveOrContextual(type.kotlin as KClass<Any>)
     } else {
         val eType: Class<*> = type.componentType
-        val s = serializer(eType)
+        val s = if (failOnMissingTypeArgSerializer) serializer(eType) else (serializerOrNull(eType) ?: return null)
         val arraySerializer = ArraySerializer(eType.kotlin as KClass<Any>, s)
         arraySerializer as KSerializer<Any>
     }
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-private fun SerializersModule.genericArraySerializer(type: GenericArrayType): KSerializer<Any> {
+private fun SerializersModule.genericArraySerializer(
+    type: GenericArrayType,
+    failOnMissingTypeArgSerializer: Boolean
+): KSerializer<Any>? {
     val eType = type.genericComponentType.let {
         when (it) {
             is WildcardType -> it.upperBounds.first()
             else -> it
         }
     }
-    val serializer = serializer(eType)
+    val serializer = if (failOnMissingTypeArgSerializer) serializer(eType) else (serializerOrNull(eType) ?: return null)
     val kclass = when (eType) {
         is ParameterizedType -> (eType.rawType as Class<*>).kotlin
         is KClass<*> -> eType
@@ -110,6 +155,15 @@ private fun SerializersModule.genericArraySerializer(type: GenericArrayType): KS
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-private fun <T: Any> SerializersModule.reflectiveOrContextual(kClass: KClass<T>): KSerializer<T> {
-    return kClass.serializerOrNull() ?: getContextual(kClass) ?: kClass.serializerNotRegistered()
+private fun <T : Any> SerializersModule.reflectiveOrContextual(kClass: KClass<T>): KSerializer<T>? {
+    return kClass.serializerOrNull() ?: getContextual(kClass)
+}
+
+private fun Type.kclass(): KClass<*> = when (val it = this) {
+    is KClass<*> -> it
+    is Class<*> -> it.kotlin
+    is ParameterizedType -> it.rawType.kclass()
+    is WildcardType -> it.upperBounds.first().kclass()
+    is GenericArrayType -> it.genericComponentType.kclass()
+    else -> throw IllegalArgumentException("typeToken should be an instance of Class<?>, GenericArray, ParametrizedType or WildcardType, but actual type is $it ${it::class}")
 }

--- a/formats/json/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
@@ -212,6 +212,29 @@ class SerializersLookupTest : JsonTestBase() {
         assertEquals("42", json.encodeToString(42))
     }
 
+    class NonSerializable
+
+    class NonSerializableBox<T>(val boxed: T)
+
+    @Test
+    fun testLookupFail() {
+        assertNull(serializerOrNull(typeOf<NonSerializable>()))
+        assertNull(serializerOrNull(typeOf<NonSerializableBox<String>>()))
+        assertNull(serializerOrNull(typeOf<Box<NonSerializable>>()))
+
+        assertFailsWithMessage<SerializationException>("for class 'NonSerializable'") {
+            serializer(typeOf<NonSerializable>())
+        }
+
+        assertFailsWithMessage<SerializationException>("for class 'NonSerializableBox'") {
+            serializer(typeOf<NonSerializableBox<String>>())
+        }
+
+        assertFailsWithMessage<SerializationException>("for class 'NonSerializable'") {
+            serializer(typeOf<Box<NonSerializable>>())
+        }
+    }
+
     // Tests with [constructSerializerForGivenTypeArgs] are unsupported on legacy Kotlin/JS
     private inline fun noLegacyJs(test: () -> Unit) {
         if (!isJsLegacy()) test()

--- a/formats/json/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
@@ -247,6 +247,8 @@ class SerializersLookupTest : JsonTestBase() {
     ) {
         val serial = serializer<T>()
         assertEquals(expected, json.encodeToString(serial, value))
+        val serial2 = requireNotNull(serializerOrNull(typeOf<T>())) { "Expected serializer to be found" }
+        assertEquals(expected, json.encodeToString(serial2, value))
     }
 
     inline fun <T> KSerializer<*>.cast(): KSerializer<T> = this as KSerializer<T>

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -96,9 +96,9 @@ abstract class JsonTestBase {
             assertEquals(data, deserialized)
         }
     }
+}
 
-    inline fun <reified T : Throwable> assertFailsWithMessage(message: String, block: () -> Unit) {
-        val exception = assertFailsWith(T::class, null, block)
-        assertTrue(exception.message!!.contains(message), "Expected message '${exception.message}' to contain substring '$message'")
-    }
+inline fun <reified T : Throwable> assertFailsWithMessage(message: String, block: () -> Unit) {
+    val exception = assertFailsWith(T::class, null, block)
+    assertTrue(exception.message!!.contains(message), "Expected message '${exception.message}' to contain substring '$message'")
 }

--- a/formats/json/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/formats/json/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 import org.junit.Test
 import java.lang.reflect.*
+import kotlin.reflect.*
 import kotlin.test.*
 
 class SerializerByTypeTest {
@@ -51,18 +52,14 @@ class SerializerByTypeTest {
     @Test
     fun testGenericParameter() {
         val b = Box(42)
-        val serial = serializer(IntBoxToken)
-        val s = json.encodeToString(serial, b)
-        assertEquals("""{"a":42}""", s)
+        assertSerializedWithType(IntBoxToken, """{"a":42}""", b)
     }
 
     @Test
     fun testArray() {
         val myArr = arrayOf("a", "b", "c")
         val token = myArr::class.java
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myArr)
-        assertEquals("""["a","b","c"]""", s)
+        assertSerializedWithType(token, """["a","b","c"]""", myArr)
     }
 
     @Test
@@ -73,9 +70,7 @@ class SerializerByTypeTest {
             override fun getOwnerType(): Type? = null
             override fun getActualTypeArguments(): Array<Type> = arrayOf(String::class.java)
         }
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myArr)
-        assertEquals("""["a","b","c"]""", s)
+        assertSerializedWithType(token, """["a","b","c"]""", myArr)
     }
 
     @Test
@@ -86,9 +81,7 @@ class SerializerByTypeTest {
             override fun getOwnerType(): Type? = null
             override fun getActualTypeArguments(): Array<Type> = arrayOf(String::class.java)
         }
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myArr)
-        assertEquals("""["a","b","c"]""", s)
+        assertSerializedWithType(token, """["a","b","c"]""", myArr)
     }
 
 
@@ -96,88 +89,70 @@ class SerializerByTypeTest {
     fun testReifiedArrayResolving() {
         val myArr = arrayOf("a", "b", "c")
         val token = typeTokenOf<Array<String>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myArr)
-        assertEquals("""["a","b","c"]""", s)
+        assertSerializedWithType(token, """["a","b","c"]""", myArr)
     }
 
     @Test
     fun testReifiedListResolving() {
         val myList = listOf("a", "b", "c")
         val token = typeTokenOf<List<String>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myList)
-        assertEquals("""["a","b","c"]""", s)
+        assertSerializedWithType(token, """["a","b","c"]""", myList)
     }
 
     @Test
     fun testReifiedSetResolving() {
         val mySet = setOf("a", "b", "c", "c")
         val token = typeTokenOf<Set<String>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, mySet)
-        assertEquals("""["a","b","c"]""", s)
+        assertSerializedWithType(token, """["a","b","c"]""", mySet)
     }
 
     @Test
     fun testReifiedMapResolving() {
         val myMap = mapOf("a" to Data(listOf("c"), Box(6)))
         val token = typeTokenOf<Map<String, Data>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myMap)
-        assertEquals("""{"a":{"l":["c"],"b":{"a":6}}}""", s)
+        assertSerializedWithType(token, """{"a":{"l":["c"],"b":{"a":6}}}""",myMap)
     }
 
     @Test
     fun testNestedListResolving() {
         val myList = listOf(listOf(listOf(1, 2, 3)), listOf())
         val token = typeTokenOf<List<List<List<Int>>>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myList)
-        assertEquals("[[[1,2,3]],[]]", s)
+        assertSerializedWithType(token, "[[[1,2,3]],[]]", myList)
     }
 
     @Test
     fun testNestedArrayResolving() {
         val myList = arrayOf(arrayOf(arrayOf(1, 2, 3)), arrayOf())
         val token = typeTokenOf<Array<Array<Array<Int>>>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myList)
-        assertEquals("[[[1,2,3]],[]]", s)
+        assertSerializedWithType(token, "[[[1,2,3]],[]]", myList)
     }
 
     @Test
     fun testNestedMixedResolving() {
         val myList = arrayOf(listOf(arrayOf(1, 2, 3)), listOf())
         val token = typeTokenOf<Array<List<Array<Int>>>>()
-        val serial = serializer(token)
-        val s = json.encodeToString(serial, myList)
-        assertEquals("[[[1,2,3]],[]]", s)
+        assertSerializedWithType(token, "[[[1,2,3]],[]]", myList)
     }
 
     @Test
     fun testPair() {
         val myPair = "42" to 42
         val token = typeTokenOf<Pair<String, Int>>()
-        val serial = serializer(token)
-        assertEquals("""{"first":"42","second":42}""", json.encodeToString(serial, myPair))
+        assertSerializedWithType(token, """{"first":"42","second":42}""", myPair)
     }
 
     @Test
     fun testTriple() {
         val myTriple = Triple("1", 2, Box(42))
         val token = typeTokenOf<Triple<String, Int, Box<Int>>>()
-        val serial = serializer(token)
-        assertEquals("""{"first":"1","second":2,"third":{"a":42}}""", json.encodeToString(serial, myTriple))
+        assertSerializedWithType(token, """{"first":"1","second":2,"third":{"a":42}}""", myTriple)
 
     }
 
     @Test
     fun testGenericInHolder() {
         val b = Data(listOf("a", "b", "c"), Box(42))
-        val serial = serializer(Data::class.java)
-        val s = json.encodeToString(serial, b)
-        assertEquals("""{"l":["a","b","c"],"b":{"a":42}}""", s)
+        assertSerializedWithType(Data::class.java,"""{"l":["a","b","c"],"b":{"a":42}}""", b )
     }
 
     @Test
@@ -189,9 +164,7 @@ class SerializerByTypeTest {
     @Test
     fun testNamedCompanion() {
         val namedCompanion = WithNamedCompanion(1)
-        val serial = serializer(WithNamedCompanion::class.java)
-        val s = json.encodeToString(serial, namedCompanion)
-        assertEquals("""{"a":1}""", s)
+        assertSerializedWithType(WithNamedCompanion::class.java, """{"a":1}""", namedCompanion)
     }
 
     @Test
@@ -206,6 +179,18 @@ class SerializerByTypeTest {
         val token = typeTokenOf<SerializableObject>()
         val serial = serializer(token)
         assertEquals(SerializableObject.serializer().descriptor, serial.descriptor)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> assertSerializedWithType(
+        token: Type,
+        expected: String,
+        value: T,
+    ) {
+        val serial = serializer(token) as KSerializer<T>
+        assertEquals(expected, json.encodeToString(serial, value))
+        val serial2 = requireNotNull(serializerOrNull(token)) { "Expected serializer to be found" }
+        assertEquals(expected, json.encodeToString(serial2 as KSerializer<T>, value))
     }
 
     @PublishedApi

--- a/formats/json/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/formats/json/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -256,4 +256,27 @@ class SerializerByTypeTest {
         assertEquals("[[1]]", Json.encodeToString(serializer, listOf(listOf<Int>(1))))
         assertEquals("42", Json.encodeToString(module.serializer(typeTokenOf<Int>()), 42))
     }
+
+    class NonSerializable
+
+    class NonSerializableBox<T>(val boxed: T)
+
+    @Test
+    fun testLookupFail() {
+        assertNull(serializerOrNull(typeTokenOf<NonSerializable>()))
+        assertNull(serializerOrNull(typeTokenOf<NonSerializableBox<String>>()))
+        assertNull(serializerOrNull(typeTokenOf<Box<NonSerializable>>()))
+
+        assertFailsWithMessage<SerializationException>("for class 'NonSerializable'") {
+            serializer(typeTokenOf<NonSerializable>())
+        }
+
+        assertFailsWithMessage<SerializationException>("for class 'NonSerializableBox'") {
+            serializer(typeTokenOf<NonSerializableBox<String>>())
+        }
+
+        assertFailsWithMessage<SerializationException>("for class 'NonSerializable'") {
+            serializer(typeTokenOf<kotlinx.serialization.Box<NonSerializable>>())
+        }
+    }
 }


### PR DESCRIPTION
to avoid building framework logic on catching exceptions.

Fixes #1163

Didn't add orNull method for reified overloads because usually the type is specified there explicitly.