### PR TITLE
Add test for serialization of data class with default value

### DIFF
--- a/formats/json/commonTest/src/kotlinx/serialization/SerializableClasses.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/SerializableClasses.kt
@@ -8,7 +8,7 @@ package kotlinx.serialization
 data class IntData(val intV: Int)
 
 @Serializable
-data class StringData(val data: String)
+data class StringData(val data: String = "default")
 
 enum class SampleEnum { OptionA, OptionB, OptionC }
 

--- a/formats/json/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
@@ -33,6 +33,12 @@ class SerializersLookupTest : JsonTestBase() {
     }
 
     @Test
+    fun testDataClassWithDefaultValues() {
+        val b = StringData()
+        assertSerializedWithType("""{"data":"default"}""", b)
+    }
+
+    @Test
     fun testListWithT() {
         val source = """[{"intV":42}]"""
         val serial = serializer<List<IntData>>()


### PR DESCRIPTION
Add a test to verify if serialization of data class with default values is working.

The problem is happening on `JakeWharton/retrofit2-kotlinx-serialization-converter`
https://github.com/JakeWharton/retrofit2-kotlinx-serialization-converter/issues/36

This test change verifies that the issue is not on Kotlinx Serialization.