### PR TITLE
Alllow shared prefix names

### DIFF
--- a/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
@@ -91,7 +91,9 @@ public sealed class Properties(
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
             while (currentIndex < size) {
                 val name = descriptor.getTag(currentIndex++)
-                if (map.keys.any { it.startsWith(name) }) return currentIndex - 1
+                if (map.keys.any {
+                        it.startsWith(name) && (it.length == name.length || it[name.length] == '.')
+                    }) return currentIndex - 1
                 if (isCollection) {
                     // if map does not contain key we look for, then indices in collection have ended
                     break

--- a/formats/properties/commonTest/src/kotlinx/serialization/properties/PropertiesTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/properties/PropertiesTest.kt
@@ -49,6 +49,12 @@ class PropertiesTest {
     @Serializable
     data class NullableEnumData(val data0: TestEnum?, val data1: TestEnum?)
 
+    @Serializable
+    data class SharedPrefixNames(
+        val first: String = "100",
+        val firstSecond: String = "100"
+    )
+
     enum class TestEnum { ZERO, ONE }
 
     private inline fun <reified T : Any> assertMappedAndRestored(
@@ -198,5 +204,12 @@ class PropertiesTest {
     @Test
     fun testCanReadSizeProperty() {
         assertMappedAndRestored(mapOf("p" to "a", "size" to "b"), TestWithSize("a", "b"), TestWithSize.serializer())
+    }
+
+    @Test
+    fun testSharedPrefixNames() {
+        val map: Map<String, Any> = mapOf("firstSecond" to "42")
+        val restored = Properties.decodeFromMap(SharedPrefixNames.serializer(), map)
+        assertEquals(SharedPrefixNames("100", "42"), restored)
     }
 }


### PR DESCRIPTION
Allow names with a prefix that equals another name in the same class.

Fixing https://github.com/Kotlin/kotlinx.serialization/issues/1171