### PR TITLE
Add build parameter to build serialization with JVM IR compiler

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -10,6 +10,12 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 jmh.jmhVersion = 1.21
 
+if (rootProject.ext.jvm_ir_enabled) {
+    kotlin.target.compilations.all {
+        kotlinOptions.useIR = true
+    }
+}
+
 jmhJar {
     baseName 'benchmarks'
     classifier = null

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ buildscript {
             maven { url "https://bintray.com/jetbrains/kotlin-native-dependencies" }
         }
     }
+    // This flag is enabled in train builds for JVM IR compiler testing
+    ext.jvm_ir_enabled = rootProject.properties['enable_jvm_ir'] != null
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,9 @@ buildscript {
             maven { url "https://bintray.com/jetbrains/kotlin-native-dependencies" }
         }
     }
-    // This flag is enabled in train builds for JVM IR compiler testing
+    // These two flags are enabled in train builds for JVM IR compiler testing
     ext.jvm_ir_enabled = rootProject.properties['enable_jvm_ir'] != null
+    ext.jvm_ir_api_check_enabled = rootProject.properties['enable_jvm_ir_api_check'] != null
 
     repositories {
         mavenLocal()
@@ -173,3 +174,14 @@ subprojects {
 
 apply from: rootProject.file('gradle/compiler-version.gradle')
 apply from: rootProject.file("gradle/dokka.gradle")
+
+// Disable binary compatibility check for JVM IR compiler output by default
+if (jvm_ir_enabled) {
+    subprojects { project ->
+        afterEvaluate {
+            configure(tasks.matching { it.name == "apiCheck" }) {
+                enabled = enabled && jvm_ir_api_check_enabled
+            }
+        }
+    }
+}

--- a/formats/hocon/build.gradle
+++ b/formats/hocon/build.gradle
@@ -17,6 +17,12 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlinx-serialization'
 
+if (rootProject.ext.jvm_ir_enabled) {
+    kotlin.target.compilations.all {
+        kotlinOptions.useIR = true
+    }
+}
+
 dependencies {
     compile project(':kotlinx-serialization-core')
     api 'org.jetbrains.kotlin:kotlin-stdlib'

--- a/formats/json/build.gradle
+++ b/formats/json/build.gradle
@@ -24,3 +24,15 @@ kotlin {
         }
     }
 }
+
+// TODO: these tests are failing on JVM IR
+if (rootProject.ext.jvm_ir_enabled) {
+    jvmTest {
+        filter {
+            excludeTest('kotlinx.serialization.json.JsonGenericTest', 'testRecursiveArrays')
+            excludeTest('kotlinx.serialization.features.InheritanceTest', 'canBeSerializedAsDerived')
+            excludeTest('kotlinx.serialization.features.InternalInheritanceTest', 'testEncodeToString')
+            excludeTest('kotlinx.serialization.SerializerForNullableJavaTypeTest', 'testMixedList')
+        }
+    }
+}

--- a/gradle/configure-source-sets.gradle
+++ b/gradle/configure-source-sets.gradle
@@ -3,13 +3,12 @@
  */
 
 kotlin {
-    targets {
-        fromPreset(presets.jvm, 'jvm') {
-            withJava()
-            configure([compilations.main, compilations.test]) {
-                kotlinOptions {
-                    jvmTarget = '1.6'
-                }
+    jvm {
+        withJava()
+        configure([compilations.main, compilations.test]) {
+            kotlinOptions {
+                jvmTarget = '1.6'
+                kotlinOptions.useIR = rootProject.ext.jvm_ir_enabled
             }
         }
     }

--- a/guide/build.gradle
+++ b/guide/build.gradle
@@ -1,6 +1,12 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlinx-serialization'
 
+if (rootProject.ext.jvm_ir_enabled) {
+    kotlin.target.compilations.all {
+        kotlinOptions.useIR = true
+    }
+}
+
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "org.jetbrains.kotlinx:kotlinx-knit-test:$knit_version"


### PR DESCRIPTION
To be used in specific kotlinx-train CI configuration. It's needed for faster adoption of JVM IR compiler.