### PR TITLE
Contextual serialization for derived classes

### DIFF
--- a/formats/json/commonTest/src/kotlinx/serialization/features/DerivedContextualSerializerTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/features/DerivedContextualSerializerTest.kt
@@ -1,0 +1,49 @@
+package kotlinx.serialization.features
+
+import kotlin.test.*
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+
+class DerivedContextualSerializerTest {
+
+    @Serializable
+    abstract class Message
+
+    @Serializable
+    class SimpleMessage(val body: String) : Message()
+
+    @Serializable
+    class Holder(@Contextual val message: Message)
+
+    object MessageAsStringSerializer : KSerializer<Message> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("kotlinx.serialization.MessageAsStringSerializer", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: Message) {
+            // dummy serializer that assumes Message is always SimpleMessage
+            check(value is SimpleMessage)
+            encoder.encodeString(value.body)
+        }
+
+        override fun deserialize(decoder: Decoder): Message {
+            return SimpleMessage(decoder.decodeString())
+        }
+    }
+
+    @Test
+    fun testDerivedContextualSerializer() {
+        val module = SerializersModule {
+            contextual(MessageAsStringSerializer)
+        }
+        val format = Json { serializersModule = module }
+        val data = Holder(SimpleMessage("hello"))
+        val serialized = format.encodeToString(data)
+        assertEquals("""{"message":"hello"}""", serialized)
+        val deserialized = format.decodeFromString<Holder>(serialized)
+        assertTrue(deserialized.message is SimpleMessage)
+        assertEquals("hello", deserialized.message.body)
+    }
+}


### PR DESCRIPTION
Fixes: #1276 

The issue #1276 is happening because, in the implementation of `ContextualSerializer`, the serializer is looked up using the concrete class instead of the serializable class: https://github.com/Kotlin/kotlinx.serialization/blob/master/core/commonMain/src/kotlinx/serialization/ContextualSerializer.kt#L56.

The reason for that is not clear to me. In this PR, I'm updating the implementation to do the lookup using the serializable class instead (which is actually simpler). This solves the issue, and all tests still pass.

 I also added the example from the issue as a test case.