### PR TITLE
Optimize the loop for writing varints in ProtoBuf

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compileOnly 'com.google.auto.value:auto-value:1.4.1'
     compileOnly 'com.ryanharter.auto.value:auto-value-gson:0.4.6'
 
-    compile "org.openjdk.jmh:jmh-core:1.21"
+    compile "org.openjdk.jmh:jmh-core:1.22"
     implementation 'com.google.guava:guava:24.1.1-jre'
 
     compile 'com.squareup.okio:okio:1.13.0'


### PR DESCRIPTION
It has no performance impact on small (~1-2 bytes) varints, but increases throughput of large (7-9 bytes) varints by up to 25%