### PR TITLE
Fix numeric overflow in JsonLexer

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonLexer.kt
@@ -521,7 +521,11 @@ internal class JsonLexer(private val source: String) {
             ++current
         }
         currentPosition = current
-        return if (isNegative) accumulator else -accumulator
+        return when {
+            isNegative -> accumulator
+            accumulator != Long.MIN_VALUE -> -accumulator
+            else -> fail("Numeric value overflow")
+        }
     }
 
 

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonParserFailureModesTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonParserFailureModesTest.kt
@@ -62,6 +62,14 @@ class JsonParserFailureModesTest : JsonTestBase() {
                     it
                 )
             }
+            // -9223372036854775808 is Long.MIN_VALUE
+            assertFailsWith<JsonDecodingException> {
+                default.decodeFromString(
+                    Holder.serializer(),
+                    """{"id":9223372036854775808}""",
+                    it
+                )
+            }
             assertFailsWith<JsonDecodingException> { default.decodeFromString(Holder.serializer(), """{"id"}""", it) }
             assertFailsWith<JsonDecodingException> { default.decodeFromString(Holder.serializer(), """{"id}""", it) }
             assertFailsWith<JsonDecodingException> { default.decodeFromString(Holder.serializer(), """{"i}""", it) }


### PR DESCRIPTION
Before this fix `9223372036854775808` is read as `-9223372036854775808`.