### PR TITLE
Test case to demonstrate Protobuf enum deserialization bug

### DIFF
--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufEnumTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufEnumTest.kt
@@ -9,7 +9,12 @@ import kotlin.test.*
 
 class ProtobufEnumTest {
 
-    enum class SomeEnum { ALPHA, BETA, GAMMA }
+    @Serializable
+    enum class SomeEnum {
+        @ProtoNumber(1) ALPHA,
+        @ProtoNumber(2) BETA,
+        @ProtoNumber(4) GAMMA
+    }
 
     @Serializable
     data class EnumWithUnion(@ProtoNumber(5) val s: String,


### PR DESCRIPTION
During protobuf deserialization, if an unknown enum value is encountered, and the enum is using @ProtoNumber, the deserializer throws an `ArrayIndexOutOfBoundsException` on the JVM instead of a `SerializationException`.

I'm on a limited bandwidth connection, so can't pull all the latest dependencies & am submitting this PR for remote-run before verifying this reproduces the issue.