### PR TITLE
Don't encode nulls

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -233,6 +233,12 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
      */
     public var serializersModule: SerializersModule = conf.serializersModule
 
+    /**
+     * Encode values if it's `null`
+     * `true` by default.
+     */
+    public var encodeNulls: Boolean = conf.encodeNulls
+
     @OptIn(ExperimentalSerializationApi::class)
     internal fun build(): JsonConf {
         if (useArrayPolymorphism) require(classDiscriminator == defaultDiscriminator) {
@@ -255,7 +261,8 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
             encodeDefaults, ignoreUnknownKeys, isLenient,
             allowStructuredMapKeys, prettyPrint, prettyPrintIndent,
             coerceInputValues, useArrayPolymorphism,
-            classDiscriminator, allowSpecialFloatingPointValues, serializersModule
+            classDiscriminator, allowSpecialFloatingPointValues, serializersModule,
+            encodeNulls
         )
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonConf.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonConf.kt
@@ -21,5 +21,6 @@ internal data class JsonConf(
     @JvmField public val useArrayPolymorphism: Boolean = false,
     @JvmField public val classDiscriminator: String = "type",
     @JvmField public val allowSpecialFloatingPointValues: Boolean = false,
-    @JvmField public val serializersModule: SerializersModule = EmptySerializersModule
+    @JvmField public val serializersModule: SerializersModule = EmptySerializersModule,
+    @JvmField public val encodeNulls: Boolean = true
 )

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -158,7 +158,9 @@ internal class StreamingJsonEncoder(
     }
 
     override fun encodeNull() {
-        composer.print(NULL)
+        if(configuration.encodeNulls) {
+            composer.print(NULL)
+        }
     }
 
     override fun encodeBoolean(value: Boolean) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -52,7 +52,11 @@ private sealed class AbstractJsonTreeEncoder(
         encodeTaggedNull(tag)
     }
 
-    override fun encodeTaggedNull(tag: String) = putElement(tag, JsonNull)
+    override fun encodeTaggedNull(tag: String){
+        if(configuration.encodeNulls) {
+            putElement(tag, JsonNull)
+        }
+    }
 
     override fun encodeTaggedInt(tag: String, value: Int) = putElement(tag, JsonPrimitive(value))
     override fun encodeTaggedByte(tag: String, value: Byte) = putElement(tag, JsonPrimitive(value))

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -13,6 +13,7 @@ import kotlin.test.*
 abstract class JsonTestBase {
     protected val default = Json { encodeDefaults = true }
     protected val lenient = Json { isLenient = true; ignoreUnknownKeys = true; allowSpecialFloatingPointValues = true }
+    protected val dontEncodeNulls = Json { encodeNulls = false }
 
     internal inline fun <reified T : Any> Json.encodeToString(value: T, useStreaming: Boolean): String {
         val serializer = serializersModule.serializer<T>()

--- a/formats/json/jvmTest/src/kotlinx/serialization/SerializationCasesTest.kt
+++ b/formats/json/jvmTest/src/kotlinx/serialization/SerializationCasesTest.kt
@@ -16,9 +16,10 @@
 
 package kotlinx.serialization
 
-import kotlinx.serialization.json.*
-import org.junit.*
-import org.junit.Assert.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonTestBase
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 class SerializationCasesTest : JsonTestBase() {
 
@@ -48,7 +49,7 @@ class SerializationCasesTest : JsonTestBase() {
         override fun equals(other: Any?) = other is Data2 && other.a == a && other.b == b
     }
 
-    @Serializer(forClass=Data2::class)
+    @Serializer(forClass = Data2::class)
     object ExtDataSerializer2
 
     @Test
@@ -71,9 +72,9 @@ class SerializationCasesTest : JsonTestBase() {
 
     @Serializable
     data class Data3(
-        val a: String,
-        val b: List<Int>,
-        val c: Map<String, TintEnum>
+            val a: String,
+            val b: List<Int>,
+            val c: Map<String, TintEnum>
     )
 
     // Serialize with external serializer for Data class
@@ -89,5 +90,24 @@ class SerializationCasesTest : JsonTestBase() {
         assertEquals(data, Json.decodeFromString<Data3>(expected))
         assertEquals(expected, default.encodeToString(ExtDataSerializer3, data))
         assertEquals(data, Json.decodeFromString(ExtDataSerializer3, expected))
+    }
+
+    @Serializable
+    data class Data4(
+            val a: String,
+            val b: String? = null
+    )
+
+    // Serialize with external serializer for Data class
+    @Serializer(forClass = Data4::class)
+    object ExtDataSerializer4
+
+    @Test
+    fun testExcludeNullableValues() {
+        val data = Data4("Str", null)
+        // Serialize with internal serializer for Data class
+        val expected = """{"a":"Str"}"""
+        assertEquals(expected, dontEncodeNulls.encodeToString(data))
+        assertEquals(expected, dontEncodeNulls.encodeToString(ExtDataSerializer4, data))
     }
 }


### PR DESCRIPTION
Allow to exclude object from encoded string if it's `null`

`encodeNulls` by default `true` to support backward compatibility 

See: #195 