### PR TITLE
Rename JsonConf to JsonConfiguration

### DIFF
--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -1,6 +1,6 @@
 public abstract class kotlinx/serialization/json/Json : kotlinx/serialization/StringFormat {
 	public static final field Default Lkotlinx/serialization/json/Json$Default;
-	public synthetic fun <init> (Lkotlinx/serialization/json/internal/JsonConf;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/internal/JsonConfiguration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun decodeFromJsonElement (Lkotlinx/serialization/DeserializationStrategy;Lkotlinx/serialization/json/JsonElement;)Ljava/lang/Object;
 	public final fun decodeFromString (Lkotlinx/serialization/DeserializationStrategy;Ljava/lang/String;)Ljava/lang/Object;
 	public final fun encodeToJsonElement (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)Lkotlinx/serialization/json/JsonElement;

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -47,7 +47,7 @@ import kotlinx.serialization.modules.*
  * ```
  */
 @OptIn(ExperimentalSerializationApi::class)
-public sealed class Json(internal val configuration: JsonConf) : StringFormat {
+public sealed class Json(internal val configuration: JsonConfiguration) : StringFormat {
 
     override val serializersModule: SerializersModule
         get() = configuration.serializersModule
@@ -55,7 +55,7 @@ public sealed class Json(internal val configuration: JsonConf) : StringFormat {
     /**
      * The default instance of [Json] with default configuration.
      */
-    public companion object Default : Json(JsonConf())
+    public companion object Default : Json(JsonConfiguration())
 
     /**
      * Serializes the [value] into an equivalent JSON using the given [serializer].
@@ -150,19 +150,19 @@ public inline fun <reified T> Json.decodeFromJsonElement(json: JsonElement): T =
  * Builder of the [Json] instance provided by `Json { ... }` factory function.
  */
 @Suppress("unused", "DeprecatedCallableAddReplaceWith")
-public class JsonBuilder internal constructor(conf: JsonConf) {
+public class JsonBuilder internal constructor(configuration: JsonConfiguration) {
     /**
      * Specifies whether default values of Kotlin properties should be encoded.
      * `false` by default.
      */
-    public var encodeDefaults: Boolean = conf.encodeDefaults
+    public var encodeDefaults: Boolean = configuration.encodeDefaults
 
     /**
      * Specifies whether encounters of unknown properties in the input JSON
      * should be ignored instead of throwing [SerializationException].
      * `false` by default.
      */
-    public var ignoreUnknownKeys: Boolean = conf.ignoreUnknownKeys
+    public var ignoreUnknownKeys: Boolean = configuration.ignoreUnknownKeys
 
     /**
      * Removes JSON specification restriction (RFC-4627) and makes parser
@@ -174,20 +174,20 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
      *
      * `false` by default.
      */
-    public var isLenient: Boolean = conf.isLenient
+    public var isLenient: Boolean = configuration.isLenient
 
     /**
      * Enables structured objects to be serialized as map keys by
      * changing serialized form of the map from JSON object (key-value pairs) to flat array like `[k1, v1, k2, v2]`.
      * `false` by default.
      */
-    public var allowStructuredMapKeys: Boolean = conf.allowStructuredMapKeys
+    public var allowStructuredMapKeys: Boolean = configuration.allowStructuredMapKeys
 
     /**
      * Specifies whether resulting JSON should be pretty-printed.
      *  `false` by default.
      */
-    public var prettyPrint: Boolean = conf.prettyPrint
+    public var prettyPrint: Boolean = configuration.prettyPrint
 
     /**
      * Specifies indent string to use with [prettyPrint] mode
@@ -196,7 +196,7 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
      * it is not clear whether this option has compelling use-cases.
      */
     @ExperimentalSerializationApi
-    public var prettyPrintIndent: String = conf.prettyPrintIndent
+    public var prettyPrintIndent: String = configuration.prettyPrintIndent
 
     /**
      * Enables coercing incorrect JSON values to the default property value in the following cases:
@@ -205,20 +205,20 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
      *
      * `false` by default.
      */
-    public var coerceInputValues: Boolean = conf.coerceInputValues
+    public var coerceInputValues: Boolean = configuration.coerceInputValues
 
     /**
      * Switches polymorphic serialization to the default array format.
      * This is an option for legacy JSON format and should not be generally used.
      * `false` by default.
      */
-    public var useArrayPolymorphism: Boolean = conf.useArrayPolymorphism
+    public var useArrayPolymorphism: Boolean = configuration.useArrayPolymorphism
 
     /**
      * Name of the class descriptor property for polymorphic serialization.
      * "type" by default.
      */
-    public var classDiscriminator: String = conf.classDiscriminator
+    public var classDiscriminator: String = configuration.classDiscriminator
 
     /**
      * Removes JSON specification restriction on
@@ -226,15 +226,15 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
      * When enabling it, please ensure that the receiving party will be able to encode and decode these special values.
      * `false` by default.
      */
-    public var allowSpecialFloatingPointValues: Boolean = conf.allowSpecialFloatingPointValues
+    public var allowSpecialFloatingPointValues: Boolean = configuration.allowSpecialFloatingPointValues
 
     /**
      * Module with contextual and polymorphic serializers to be used in the resulting [Json] instance.
      */
-    public var serializersModule: SerializersModule = conf.serializersModule
+    public var serializersModule: SerializersModule = configuration.serializersModule
 
     @OptIn(ExperimentalSerializationApi::class)
-    internal fun build(): JsonConf {
+    internal fun build(): JsonConfiguration {
         if (useArrayPolymorphism) require(classDiscriminator == defaultDiscriminator) {
             "Class discriminator should not be specified when array polymorphism is specified"
         }
@@ -251,7 +251,7 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
             }
         }
 
-        return JsonConf(
+        return JsonConfiguration(
             encodeDefaults, ignoreUnknownKeys, isLenient,
             allowStructuredMapKeys, prettyPrint, prettyPrintIndent,
             coerceInputValues, useArrayPolymorphism,
@@ -261,7 +261,7 @@ public class JsonBuilder internal constructor(conf: JsonConf) {
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-private class JsonImpl(configuration: JsonConf) : Json(configuration) {
+private class JsonImpl(configuration: JsonConfiguration) : Json(configuration) {
 
     init {
         validateConfiguration()

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonConfiguration.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonConfiguration.kt
@@ -10,7 +10,7 @@ import kotlin.jvm.*
 
 // Mirror of the deprecated JsonConfiguration. Not for external use.
 @OptIn(ExperimentalSerializationApi::class)
-internal data class JsonConf(
+internal data class JsonConfiguration(
     @JvmField public val encodeDefaults: Boolean = false,
     @JvmField public val ignoreUnknownKeys: Boolean = false,
     @JvmField public val isLenient: Boolean = false,

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonTreeReader.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonTreeReader.kt
@@ -7,7 +7,7 @@ package kotlinx.serialization.json.internal
 import kotlinx.serialization.json.*
 
 internal class JsonTreeReader(
-    configuration: JsonConf,
+    configuration: JsonConfiguration,
     private val lexer: JsonLexer
 ) {
     private val isLenient = configuration.isLenient


### PR DESCRIPTION
    * Previously it was named that way to prevent clash with deprecated separate JsonConfiguration
    * Also we may want to make it public in the future