### PR TITLE
Fix serializer lookup by KType for third party generics

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -115,9 +115,16 @@ private fun SerializersModule.builtinSerializer(
                 return ArraySerializer<Any, Any?>(typeArguments[0].classifier as KClass<Any>, serializers[0]).cast()
             }
             rootClass.constructSerializerForGivenTypeArgs(*serializers.toTypedArray())
+                ?: reflectiveOrContextual(rootClass)
         }
     }
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun <T : Any> SerializersModule.reflectiveOrContextual(kClass: KClass<T>): KSerializer<T>? {
+    return kClass.serializerOrNull() ?: getContextual(kClass)
+}
+
 
 /**
  * Retrieves a [KSerializer] for the given [KClass].

--- a/core/commonTest/src/kotlinx/serialization/features/ThirdPartyGenericsTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/features/ThirdPartyGenericsTest.kt
@@ -1,0 +1,45 @@
+package kotlinx.serialization.features
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+import kotlin.test.*
+
+open class ThirdPartyGenericsTest {
+    // This is a 3rd party class that we can't annotate as @Serializable
+    data class ThirdPartyBox<T>(val contents: T)
+
+    // This is the item that we put in the ThirdPartyBox, we control it, so can annotate it
+    @Serializable
+    data class Item(val name: String)
+
+    // The serializer for the ThirdPartyBox<T>
+    class BoxSerializer<T>(dataSerializer: KSerializer<T>) : KSerializer<ThirdPartyBox<T>> {
+        @Serializable
+        data class BoxSurrogate<T>(val contents: T)
+
+        private val strategy = BoxSurrogate.serializer(dataSerializer)
+        override val descriptor: SerialDescriptor = strategy.descriptor
+
+        override fun deserialize(decoder: Decoder): ThirdPartyBox<T> {
+            return ThirdPartyBox(decoder.decodeSerializableValue(strategy).contents)
+        }
+
+        override fun serialize(encoder: Encoder, value: ThirdPartyBox<T>) {
+            encoder.encodeSerializableValue(strategy, BoxSurrogate(value.contents))
+        }
+    }
+
+    // Register contextual serializer for ThirdPartyBox<Item>
+    protected val boxWithItemSerializer = BoxSerializer(Item.serializer())
+    protected val serializersModule = SerializersModule {
+        contextual(boxWithItemSerializer)
+    }
+
+    @Test
+    fun testSurrogateSerializerFoundForGenericWithKotlinType() {
+        val serializer = serializersModule.serializer<ThirdPartyBox<Item>>()
+        assertEquals(boxWithItemSerializer.descriptor, serializer.descriptor)
+    }
+}

--- a/core/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
+++ b/core/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
@@ -154,11 +154,6 @@ private fun SerializersModule.genericArraySerializer(
     return ArraySerializer(kclass, serializer) as KSerializer<Any>
 }
 
-@OptIn(ExperimentalSerializationApi::class)
-private fun <T : Any> SerializersModule.reflectiveOrContextual(kClass: KClass<T>): KSerializer<T>? {
-    return kClass.serializerOrNull() ?: getContextual(kClass)
-}
-
 private fun Type.kclass(): KClass<*> = when (val it = this) {
     is KClass<*> -> it
     is Class<*> -> it.kotlin

--- a/core/jvmTest/src/kotlinx/serialization/features/JvmThirdPartyGenericsTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/features/JvmThirdPartyGenericsTest.kt
@@ -1,0 +1,13 @@
+package kotlinx.serialization.features
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+class JvmThirdPartyGenericsTest : ThirdPartyGenericsTest() {
+    @Test
+    fun testSurrogateSerializerFoundForGenericWithJavaType() {
+        val filledBox = ThirdPartyBox(contents = Item("Foo"))
+        val serializer = serializersModule.serializer(filledBox::class.java)
+        assertEquals(boxWithItemSerializer.descriptor, serializer.descriptor)
+    }
+}


### PR DESCRIPTION
Fix serializer lookup by KType for third party generics

This lookup used to fail, because `SerializersModule.serializerByKTypeImpl()`
never tried `getContextual()` after constructSerializerForGivenTypeArgs() fails
to find a serializer (and that *will* fail, because `ThirdPartyBox` is not
annotated as @Serializable, since it is a third party class).

This does work when doing the look up by Java type with
`serializerByJavaTypeImpl.serializerByJavaTypeImpe()`.

The difference is that the former does this:

```kotlin
rootClass.constructSerializerForGivenTypeArgs(*serializers.toTypedArray())
```

And the latter does this:

```kotlin
rootClass.constructSerializerForGivenTypeArgs(*serializers.toTypedArray())
    ?: reflectiveOrContextual(rootClass)
```

This commit adds the call to `reflectiveOrContextual()` to
`SerializersModule.serializerByKTypeImpl()`, which fixes it for all platforms.

The accompanying test illustrates the scenario where this used to fail and is now succesful. Both for JVM and other platforms.