### PR TITLE
Fixed loss of precision in JS test for current kotlin master branch

### DIFF
--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonParserFailureModesTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonParserFailureModesTest.kt
@@ -128,8 +128,8 @@ class JsonParserFailureModesTest : JsonTestBase() {
         default.decodeFromString<PrimitiveHolder>("""{"s": ${Short.MIN_VALUE}}""", it)
         default.decodeFromString<PrimitiveHolder>("""{"i": ${Int.MAX_VALUE}}""", it)
         default.decodeFromString<PrimitiveHolder>("""{"i": ${Int.MIN_VALUE}}""", it)
-        default.decodeFromString<Holder>("""{"id": ${Long.MIN_VALUE}}""", it)
-        default.decodeFromString<Holder>("""{"id": ${Long.MAX_VALUE}}""", it)
+        default.decodeFromString<Holder>("""{"id": ${Long.MIN_VALUE.toString()}}""", it)
+        default.decodeFromString<Holder>("""{"id": ${Long.MAX_VALUE.toString()}}""", it)
     }
 
     @Test


### PR DESCRIPTION
Error in the current master may be corrected later.

"${Long.MIN_VALUE}" gives "-9223372036854776000" but not "-9223372036854775808"