### PR TITLE
Fix inability to encode/decode inline class with string to JsonElement

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -246,9 +246,9 @@ internal open class StreamingJsonDecoder(
         }
     }
 
-    override fun decodeInline(inlineDescriptor: SerialDescriptor): Decoder {
-        return if (inlineDescriptor.isUnsignedNumber) JsonDecoderForUnsignedTypes(lexer, json) else this
-    }
+    override fun decodeInline(inlineDescriptor: SerialDescriptor): Decoder =
+        if (inlineDescriptor.isUnsignedNumber) JsonDecoderForUnsignedTypes(lexer, json)
+        else super.decodeInline(inlineDescriptor)
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
         return enumDescriptor.getElementIndexOrThrow(decodeString())

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -147,15 +147,14 @@ internal class StreamingJsonEncoder(
         return true
     }
 
-    override fun encodeInline(inlineDescriptor: SerialDescriptor): Encoder {
-        return if (inlineDescriptor.isUnsignedNumber) StreamingJsonEncoder(
+    override fun encodeInline(inlineDescriptor: SerialDescriptor): Encoder =
+        if (inlineDescriptor.isUnsignedNumber) StreamingJsonEncoder(
             ComposerForUnsignedNumbers(
                 composer.sb,
                 json
             ), json, mode, null
         )
-        else this
-    }
+        else super.encodeInline(inlineDescriptor)
 
     override fun encodeNull() {
         composer.print(NULL)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -157,9 +157,9 @@ private sealed class AbstractJsonTreeDecoder(
     }
 
     @OptIn(ExperimentalUnsignedTypes::class)
-    override fun decodeTaggedInline(tag: String, inlineDescriptor: SerialDescriptor): Decoder {
-        return JsonDecoderForUnsignedTypes(JsonLexer(getValue(tag).content), json)
-    }
+    override fun decodeTaggedInline(tag: String, inlineDescriptor: SerialDescriptor): Decoder =
+        if (inlineDescriptor.isUnsignedNumber) JsonDecoderForUnsignedTypes(JsonLexer(getValue(tag).content), json)
+        else super.decodeTaggedInline(tag, inlineDescriptor)
 }
 
 private class JsonPrimitiveDecoder(json: Json, override val value: JsonPrimitive) : AbstractJsonTreeDecoder(json, value) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -99,17 +99,17 @@ private sealed class AbstractJsonTreeEncoder(
     }
 
     @OptIn(ExperimentalUnsignedTypes::class)
-    override fun encodeTaggedInline(tag: String, inlineDescriptor: SerialDescriptor): Encoder {
-        return object : AbstractEncoder() {
+    override fun encodeTaggedInline(tag: String, inlineDescriptor: SerialDescriptor): Encoder =
+        if (inlineDescriptor.isUnsignedNumber) object : AbstractEncoder() {
             override val serializersModule: SerializersModule = json.serializersModule
-            
+
             fun putUnquotedString(s: String) = putElement(tag, JsonLiteral(s, isString = false))
             override fun encodeInt(value: Int) = putUnquotedString(value.toUInt().toString())
             override fun encodeLong(value: Long) = putUnquotedString(value.toULong().toString())
             override fun encodeByte(value: Byte) = putUnquotedString(value.toUByte().toString())
             override fun encodeShort(value: Short) = putUnquotedString(value.toUShort().toString())
         }
-    }
+        else super.encodeTaggedInline(tag, inlineDescriptor)
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
         val consumer =

--- a/formats/json/commonTest/src/kotlinx/serialization/features/inline/InlineClassesTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/features/inline/InlineClassesTest.kt
@@ -92,7 +92,7 @@ class InlineClassesTest : JsonTestBase() {
     }
 
     @Test
-    fun testInlineClassesWithStrings() {
+    fun testInlineClassesWithStrings() = noLegacyJs {
         assertJsonFormAndRestored(
             ResourceIdentifier.serializer(),
             ResourceIdentifier(ResourceId("resId"), ResourceType("resType")),

--- a/formats/json/commonTest/src/kotlinx/serialization/features/inline/InlineClassesTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/features/inline/InlineClassesTest.kt
@@ -10,6 +10,7 @@ package kotlinx.serialization.features.inline
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 
@@ -55,39 +56,55 @@ data class MixedPositions(
     val boxedNullableUInt: List<UInt?>
 )
 
-class InlineClassesTest {
+@Serializable
+inline class ResourceId(val id: String)
+@Serializable
+inline class ResourceType(val type: String)
+@Serializable
+data class ResourceIdentifier(val id: ResourceId, val type: ResourceType)
+
+class InlineClassesTest : JsonTestBase() {
     private val precedent: UInt = Int.MAX_VALUE.toUInt() + 10.toUInt()
 
     @Test
     fun testSimpleContainer() = noLegacyJs {
-        assertStringFormAndRestored(
-            """{"i":2147483657}""",
+        assertJsonFormAndRestored(
+            SimpleContainerForUInt.serializer(),
             SimpleContainerForUInt(precedent),
-            SimpleContainerForUInt.serializer()
+            """{"i":2147483657}""",
         )
     }
 
     @Test
-    fun testSimpleContainerForMyTypeWithCustomSerializer() = assertStringFormAndRestored(
-        """{"i":2147483657}""",
-        SimpleContainerForMyType(MyUInt(precedent.toInt())),
+    fun testSimpleContainerForMyTypeWithCustomSerializer() = assertJsonFormAndRestored(
         SimpleContainerForMyType.serializer(),
+        SimpleContainerForMyType(MyUInt(precedent.toInt())),
+        """{"i":2147483657}""",
     )
 
     @Test
     fun testSimpleContainerForList() = noLegacyJs {
-        assertStringFormAndRestored(
-            """{"i":[2147483657]}""",
-            ContainerForList(MyList(listOf(precedent))),
+        assertJsonFormAndRestored(
             ContainerForList.serializer(UInt.serializer()),
+            ContainerForList(MyList(listOf(precedent))),
+            """{"i":[2147483657]}""",
         )
     }
 
     @Test
-    fun testUnsignedInBoxedPosition() = assertStringFormAndRestored(
-        """{"i":[2147483657]}""",
-        UnsignedInBoxedPosition(listOf(precedent)),
+    fun testInlineClassesWithStrings() {
+        assertJsonFormAndRestored(
+            ResourceIdentifier.serializer(),
+            ResourceIdentifier(ResourceId("resId"), ResourceType("resType")),
+            """{"id":"resId","type":"resType"}"""
+        )
+    }
+
+    @Test
+    fun testUnsignedInBoxedPosition() = assertJsonFormAndRestored(
         UnsignedInBoxedPosition.serializer(),
+        UnsignedInBoxedPosition(listOf(precedent)),
+        """{"i":[2147483657]}""",
     )
 
     @Test
@@ -102,10 +119,10 @@ class InlineClassesTest {
             boxedNullableInt = listOf(null, precedent.toInt(), null),
             boxedNullableUInt = listOf(null, precedent, null)
         )
-        assertStringFormAndRestored(
-            """{"int":-2147483639,"intNullable":-2147483639,"uint":2147483657,"uintNullable":2147483657,"boxedInt":[-2147483639],"boxedUInt":[2147483657],"boxedNullableInt":[null,-2147483639,null],"boxedNullableUInt":[null,2147483657,null]}""",
-            o,
+        assertJsonFormAndRestored(
             MixedPositions.serializer(),
+            o,
+            """{"int":-2147483639,"intNullable":-2147483639,"uint":2147483657,"uintNullable":2147483657,"boxedInt":[-2147483639],"boxedUInt":[2147483657],"boxedNullableInt":[null,-2147483639,null],"boxedNullableUInt":[null,2147483657,null]}""",
         )
     }
 }

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -91,9 +91,9 @@ abstract class JsonTestBase {
     ) {
         parametrizedTest { useStreaming ->
             val serialized = json.encodeToString(serializer, data, useStreaming)
-            assertEquals(expected, serialized)
+            assertEquals(expected, serialized, "Failed with streaming = $useStreaming")
             val deserialized: T = json.decodeFromString(serializer, serialized, useStreaming)
-            assertEquals(data, deserialized)
+            assertEquals(data, deserialized, "Failed with streaming = $useStreaming")
         }
     }
 }


### PR DESCRIPTION
because of missing check that descriptor is unsigned number descriptor

Fixes #1342