### PR TITLE
#1384 | Select deserializer with fieldname argument

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonDecoder.kt
@@ -88,4 +88,9 @@ public interface JsonDecoder : Decoder, CompositeDecoder {
      * ```
      */
     public fun decodeJsonElement(): JsonElement
+
+    /**
+     * Returns the [String] name of the current element [JsonElement].
+     */
+    public fun currentElementName(): String
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -47,6 +47,8 @@ private sealed class AbstractJsonTreeDecoder(
 
     override fun decodeJsonElement(): JsonElement = currentObject()
 
+    override fun currentElementName(): String = currentTagOrNull?: ""
+
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
         return decodeSerializableValuePolymorphic(deserializer)
     }

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
@@ -64,6 +64,8 @@ private open class DynamicInput(
         }
     }
 
+    override fun currentElementName(): String = currentTagOrNull?: ""
+
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
         return decodeSerializableValuePolymorphic(deserializer)
     }


### PR DESCRIPTION
The feature `@JsonNames("name1";"name2")` introduced with 1.2.0 provides the new possibility to have different names for the same property.
To now also allow to distinguish the serialization strategy based on the element name, it must be passed on to custom `JsonContentPolymorphicSerializer`.

This resolved issue #1384 