### PR TITLE
Added tests on caching serializer for `serializer()` function

### DIFF
--- a/core/commonTest/src/kotlinx/serialization/CachedSerializersTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/CachedSerializersTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.test.noJsLegacy
+import kotlin.test.*
+
+class CachedSerializersTest {
+    @Serializable
+    object Object
+
+    @Serializable
+    sealed class SealedParent {
+        @Serializable
+        data class Child(val i: Int) : SealedParent()
+    }
+
+    @Serializable
+    abstract class Abstract
+
+    @Test
+    fun testObjectSerializersAreSame() = noJsLegacy {
+        assertSame(Object.serializer(), Object.serializer())
+    }
+
+    @Test
+    fun testSealedSerializersAreSame() = noJsLegacy {
+        assertSame(SealedParent.serializer(), SealedParent.serializer())
+    }
+
+    @Test
+    fun testAbstractSerializersAreSame() = noJsLegacy {
+        assertSame(Abstract.serializer(), Abstract.serializer())
+    }
+}

--- a/core/commonTest/src/kotlinx/serialization/test/TestHelpers.kt
+++ b/core/commonTest/src/kotlinx/serialization/test/TestHelpers.kt
@@ -34,6 +34,10 @@ inline fun noJs(test: () -> Unit) {
     if (!isJs()) test()
 }
 
+inline fun noJsLegacy(test: () -> Unit) {
+    if (!isJsLegacy()) test()
+}
+
 inline fun jvmOnly(test: () -> Unit) {
     if (isJvm()) test()
 }


### PR DESCRIPTION
Serializer cached for the object, abstract, and sealed classes.

Works since 1.5.20