### PR TITLE
Improved enum and onject serializer lookup tests

### DIFF
--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
@@ -31,15 +31,15 @@ class SerializersLookupEnumTest {
     @Serializable(with = EnumExternalClassSerializer::class)
     enum class EnumExternalClass
 
-    @Serializer(forClass = EnumExternalObject::class)
+    @Serializer(forClass = EnumExternalClass::class)
     class EnumExternalClassSerializer {
         override val descriptor: SerialDescriptor = buildSerialDescriptor("tmp", SerialKind.ENUM)
 
-        override fun serialize(encoder: Encoder, value: EnumExternalObject) {
+        override fun serialize(encoder: Encoder, value: EnumExternalClass) {
             TODO()
         }
 
-        override fun deserialize(decoder: Decoder): EnumExternalObject {
+        override fun deserialize(decoder: Decoder): EnumExternalClass {
             TODO()
         }
     }
@@ -56,24 +56,33 @@ class SerializersLookupEnumTest {
     }
 
     @Test
-    @Ignore
     fun testEnumExternalObject() {
-        assertFailsWith<SerializationException> { (serializer<EnumExternalObject>()) }
+        assertSame(EnumExternalObjectSerializer, EnumExternalObject.serializer())
+        assertSame(EnumExternalObjectSerializer, serializer<EnumExternalObject>())
     }
 
     @Test
-    @Ignore
     fun testEnumExternalClass() {
-        assertFailsWith<SerializationException> { serializer<EnumExternalClass>() }
+        assertIs<EnumExternalClassSerializer>(EnumExternalClass.serializer())
+
+        if (isJvm()) {
+            assertIs<EnumExternalClassSerializer>(serializer<EnumExternalClass>())
+        } else if (isJsIr() || isNative()) {
+            // FIXME serializer<EnumWithClassSerializer> is broken for K/JS and K/Native. Remove `assertFails` after fix
+            assertFails { serializer<EnumExternalClass>() }
+        }
     }
 
     @Test
     fun testEnumPolymorphic() {
-        jvmOnly {
+        if (isJvm()) {
             assertEquals(
                 PolymorphicSerializer(EnumPolymorphic::class).descriptor,
                 serializer<EnumPolymorphic>().descriptor
             )
+        } else {
+            // FIXME serializer<PolymorphicEnum> is broken for K/JS and K/Native. Remove `assertFails` after fix
+            assertFails { serializer<EnumPolymorphic>() }
         }
     }
 }

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupObjectTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupObjectTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.test.*
+import kotlin.test.*
+
+@Suppress("RemoveExplicitTypeArguments") // This is exactly what's being tested
+class SerializersLookupObjectTest {
+    @Serializable(with = ObjectExternalObjectSerializer::class)
+    object ObjectExternalObject
+
+    @Serializer(forClass = ObjectExternalObject::class)
+    object ObjectExternalObjectSerializer {
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("tmp", StructureKind.OBJECT)
+
+        override fun serialize(encoder: Encoder, value: ObjectExternalObject) {
+            TODO()
+        }
+
+        override fun deserialize(decoder: Decoder): ObjectExternalObject {
+            TODO()
+        }
+    }
+
+    @Serializable(with = ObjectExternalClassSerializer::class)
+    object ObjectExternalClass
+
+    @Serializer(forClass = ObjectExternalClass::class)
+    class ObjectExternalClassSerializer {
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("tmp", StructureKind.OBJECT)
+
+        override fun serialize(encoder: Encoder, value: ObjectExternalClass) {
+            TODO()
+        }
+
+        override fun deserialize(decoder: Decoder): ObjectExternalClass {
+            TODO()
+        }
+    }
+
+    @Polymorphic
+    object ObjectPolymorphic
+
+    @Serializable
+    object PlainObject
+
+    @Test
+    fun testPlainObject() {
+        if (!isJsLegacy()) {
+            assertSame(PlainObject.serializer(), serializer<PlainObject>())
+        }
+    }
+
+
+    @Test
+    fun testObjectExternalObject() {
+        assertSame(ObjectExternalObjectSerializer, ObjectExternalObject.serializer())
+        if (!isJsLegacy()) {
+            assertSame(ObjectExternalObjectSerializer, serializer<ObjectExternalObject>())
+        }
+    }
+
+    @Test
+    fun testObjectExternalClass() {
+        assertIs<ObjectExternalClassSerializer>(ObjectExternalClass.serializer())
+
+        if (!isJsLegacy()) {
+            assertIs<ObjectExternalClassSerializer>(serializer<ObjectExternalClass>())
+        }
+    }
+
+    @Test
+    fun testEnumPolymorphic() {
+        if (isJvm()) {
+            assertEquals(
+                PolymorphicSerializer(ObjectPolymorphic::class).descriptor,
+                serializer<ObjectPolymorphic>().descriptor
+            )
+        } else {
+            // FIXME serializer<PolymorphicObject> is broken for K/JS and K/Native. Remove `assertFails` after fix
+            assertFails { serializer<ObjectPolymorphic>() }
+        }
+
+    }
+}

--- a/core/commonTest/src/kotlinx/serialization/test/CurrentPlatform.common.kt
+++ b/core/commonTest/src/kotlinx/serialization/test/CurrentPlatform.common.kt
@@ -12,5 +12,6 @@ public expect val currentPlatform: Platform
 
 public fun isJs(): Boolean = currentPlatform == Platform.JS_LEGACY || currentPlatform == Platform.JS_IR
 public fun isJsLegacy(): Boolean = currentPlatform == Platform.JS_LEGACY
+public fun isJsIr(): Boolean = currentPlatform == Platform.JS_IR
 public fun isJvm(): Boolean = currentPlatform == Platform.JVM
 public fun isNative(): Boolean = currentPlatform == Platform.NATIVE


### PR DESCRIPTION
* added `.serializer()` invoke for enums with generated and external serializers
* added tests on object's serializer lookup and `.serializer()` invoke
* added `assertFails()` invoke for platforms on which the lookup is broken and needs to be fixed in the future