### PR TITLE
Update jmh-gradle-plugin to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
 
         // Various benchmarking stuff
         classpath "com.github.jengelman.gradle.plugins:shadow:4.0.2"
-        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.8"
+        classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.3"
         classpath "net.ltgt.gradle:gradle-apt-plugin:0.21"
     }
 }


### PR DESCRIPTION
Motivation: I tried to run :benchmark:jmh task and recieve error. Version update fix this error.
Env: 
```
OS Name:                   Microsoft Windows 10 Home
OS Version:                10.0.19042 N/A Build 19042
jdk: Amazon corretto 11.0.9
```
```
Error: Could not find or load main class org.openjdk.jmh.runner.ForkedMain
```
![jmh_error](https://user-images.githubusercontent.com/10094292/119202919-7f653080-ba9a-11eb-8f43-7cb4401d1a6c.png)

Related topic
https://github.com/gradle/gradle/issues/9618
