### PR TITLE
Allow custom serializers to serialize CBOR byte strings

### DIFF
--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborReaderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborReaderTest.kt
@@ -564,6 +564,36 @@ class CborReaderTest {
             )
         )
     }
+    
+    @Test
+    fun testReadCustomByteString() {
+        val value = TypeWithCustomByteString(CustomByteString(0x11, 0x22, 0x33))
+
+        assertEquals(
+                expected = value,
+                actual = Cbor.decodeFromHexString("bf617843112233ff")
+        )
+    }
+
+    @Test
+    fun testReadNullableCustomByteString() {
+        val value = TypeWithNullableCustomByteString(CustomByteString(0x11, 0x22, 0x33))
+
+        assertEquals(
+                expected = value,
+                actual = Cbor.decodeFromHexString("bf617843112233ff")
+        )
+    }
+
+    @Test
+    fun testReadNullCustomByteString() {
+        val value = TypeWithNullableCustomByteString(null)
+
+        assertEquals(
+                expected = value,
+                actual = Cbor.decodeFromHexString("bf6178f6ff")
+        )
+    }
 }
 
 private fun CborDecoder.expect(expected: String) {

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborWriterTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborWriterTest.kt
@@ -98,4 +98,28 @@ class CbrWriterTest {
             )
         )
     }
+    
+    @Test
+    fun testWriteCustomByteString() {
+        assertEquals(
+                expected = "bf617843112233ff",
+                actual = Cbor.encodeToHexString(TypeWithCustomByteString(CustomByteString(0x11, 0x22, 0x33)))
+        )
+    }
+
+    @Test
+    fun testWriteNullableCustomByteString() {
+        assertEquals(
+                expected = "bf617843112233ff",
+                actual = Cbor.encodeToHexString(TypeWithNullableCustomByteString(CustomByteString(0x11, 0x22, 0x33)))
+        )
+    }
+
+    @Test
+    fun testWriteNullCustomByteString() {
+        assertEquals(
+                expected = "bf6178f6ff",
+                actual = Cbor.encodeToHexString(TypeWithNullableCustomByteString(null))
+        )
+    }
 }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/SampleClasses.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/SampleClasses.kt
@@ -5,6 +5,10 @@
 package kotlinx.serialization.cbor
 
 import kotlinx.serialization.*
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class Simple(val a: String)
@@ -86,3 +90,26 @@ data class NullableByteString(
         return byteString?.contentHashCode() ?: 0
     }
 }
+
+@Serializable(with = CustomByteStringSerializer::class)
+data class CustomByteString(val a: Byte, val b: Byte, val c: Byte)
+
+class CustomByteStringSerializer : KSerializer<CustomByteString> {
+    override val descriptor: SerialDescriptor = ByteArraySerializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: CustomByteString) {
+        ByteArraySerializer().serialize(encoder, byteArrayOf(value.a, value.b, value.c))
+    }
+
+    override fun deserialize(decoder: Decoder): CustomByteString {
+        val array = ByteArraySerializer().deserialize(decoder)
+        
+        return CustomByteString(array[0], array[1], array[2])
+    }
+}
+
+@Serializable
+data class TypeWithCustomByteString(@ByteString val x: CustomByteString)
+
+@Serializable
+data class TypeWithNullableCustomByteString(@ByteString val x: CustomByteString?)


### PR DESCRIPTION
Currently attempting to use a custom serializer with `@ByteString` will throw an exception because `encodeSerializableValue` tries to cast the object to a `ByteArray`. This PR fixes that and allows custom serializers to be used with `@ByteString`.

I added `value is ByteArray` to the original check for `@ByteString` in `encodeSerializableValue` to make sure that the value is a `ByteArray`. If the object isn't a `ByteArray` but it's using the byte array descriptor then `beginCollection` will return a custom encoder that will build a byte array and then write the byte string in `endStructure`.

I changed the decoder similarly. If the field has `@ByteString` and it's using the byte array serializer then the byte array is decoded directly. If the field has `@ByteString` but is using a different serializer then `beginStructure` will return a custom decoder that will provide the elements in the byte array.