### PR TITLE
JSON omit null

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/ImplicitNullsBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/ImplicitNullsBenchmark.kt
@@ -1,0 +1,118 @@
+package kotlinx.benchmarks.json
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(2)
+open class ImplicitNullsBenchmark {
+
+    @Serializable
+    data class Values(
+        val field0: Int?,
+        val field1: Int?,
+        val field2: Int?,
+        val field3: Int?,
+        val field4: Int?,
+        val field5: Int?,
+        val field6: Int?,
+        val field7: Int?,
+        val field8: Int?,
+        val field9: Int?,
+
+        val field10: Int?,
+        val field11: Int?,
+        val field12: Int?,
+        val field13: Int?,
+        val field14: Int?,
+        val field15: Int?,
+        val field16: Int?,
+        val field17: Int?,
+        val field18: Int?,
+        val field19: Int?,
+
+        val field20: Int?,
+        val field21: Int?,
+        val field22: Int?,
+        val field23: Int?,
+        val field24: Int?,
+        val field25: Int?,
+        val field26: Int?,
+        val field27: Int?,
+        val field28: Int?,
+        val field29: Int?,
+
+        val field30: Int?,
+        val field31: Int?
+    )
+
+
+    private val jsonImplicitNulls = Json { explicitNulls = false }
+
+    private val valueWithNulls = Values(
+        null, null, 2, null, null, null, null, null, null, null,
+        null, null, null, null, 14, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null,
+        null, null
+    )
+
+
+    private val jsonWithNulls = """{"field0":null,"field1":null,"field2":2,"field3":null,"field4":null,"field5":null,
+        |"field6":null,"field7":null,"field8":null,"field9":null,"field10":null,"field11":null,"field12":null,
+        |"field13":null,"field14":14,"field15":null,"field16":null,"field17":null,"field18":null,"field19":null,
+        |"field20":null,"field21":null,"field22":null,"field23":null,"field24":null,"field25":null,"field26":null,
+        |"field27":null,"field28":null,"field29":null,"field30":null,"field31":null}""".trimMargin()
+
+    private val jsonNoNulls = """{"field0":0,"field1":1,"field2":2,"field3":3,"field4":4,"field5":5,
+        |"field6":6,"field7":7,"field8":8,"field9":9,"field10":10,"field11":11,"field12":12,
+        |"field13":13,"field14":14,"field15":15,"field16":16,"field17":17,"field18":18,"field19":19,
+        |"field20":20,"field21":21,"field22":22,"field23":23,"field24":24,"field25":25,"field26":26,
+        |"field27":27,"field28":28,"field29":29,"field30":30,"field31":31}""".trimMargin()
+
+    private val jsonWithAbsence = """{"field2":2, "field14":14}"""
+
+    private val serializer = Values.serializer()
+
+    @Benchmark
+    fun decodeNoNulls() {
+        Json.decodeFromString(serializer, jsonNoNulls)
+    }
+
+    @Benchmark
+    fun decodeNoNullsImplicit() {
+        jsonImplicitNulls.decodeFromString(serializer, jsonNoNulls)
+    }
+
+    @Benchmark
+    fun decodeNulls() {
+        Json.decodeFromString(serializer, jsonWithNulls)
+    }
+
+    @Benchmark
+    fun decodeNullsImplicit() {
+        jsonImplicitNulls.decodeFromString(serializer, jsonWithNulls)
+    }
+
+    @Benchmark
+    fun decodeAbsenceImplicit() {
+        jsonImplicitNulls.decodeFromString(serializer, jsonWithAbsence)
+    }
+
+    @Benchmark
+    fun encodeNulls() {
+        Json.encodeToString(serializer, valueWithNulls)
+    }
+
+    @Benchmark
+    fun encodeNullsImplicit() {
+        jsonImplicitNulls.encodeToString(serializer, valueWithNulls)
+    }
+}

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TwitterBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TwitterBenchmark.kt
@@ -1,10 +1,7 @@
 package kotlinx.benchmarks.json
 
 import kotlinx.benchmarks.model.*
-import kotlinx.serialization.*
 import kotlinx.serialization.json.*
-import kotlinx.serialization.json.Json.Default.decodeFromString
-import kotlinx.serialization.json.Json.Default.encodeToString
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.*
 
@@ -25,6 +22,8 @@ open class TwitterBenchmark {
     private val input = TwitterBenchmark::class.java.getResource("/twitter.json").readBytes().decodeToString()
     private val twitter = Json.decodeFromString(Twitter.serializer(), input)
 
+    private val jsonImplicitNulls = Json { explicitNulls = false }
+
     @Setup
     fun init() {
         require(twitter == Json.decodeFromString(Twitter.serializer(), Json.encodeToString(Twitter.serializer(), twitter)))
@@ -33,6 +32,9 @@ open class TwitterBenchmark {
     // Order of magnitude: 4-7 op/ms
     @Benchmark
     fun decodeTwitter() = Json.decodeFromString(Twitter.serializer(), input)
+
+    @Benchmark
+    fun decodeTwitterImplicitNulls() = jsonImplicitNulls.decodeFromString(Twitter.serializer(), input)
 
     @Benchmark
     fun encodeTwitter() = Json.encodeToString(Twitter.serializer(), twitter)

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -369,9 +369,9 @@ public abstract class kotlinx/serialization/encoding/AbstractEncoder : kotlinx/s
 	public final fun encodeLongElement (Lkotlinx/serialization/descriptors/SerialDescriptor;IJ)V
 	public fun encodeNotNullMark ()V
 	public fun encodeNull ()V
-	public final fun encodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
+	public fun encodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public fun encodeNullableSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
-	public final fun encodeSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
+	public fun encodeSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public fun encodeSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public fun encodeShort (S)V
 	public final fun encodeShortElement (Lkotlinx/serialization/descriptors/SerialDescriptor;IS)V
@@ -627,6 +627,12 @@ public final class kotlinx/serialization/internal/DoubleSerializer : kotlinx/ser
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;D)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class kotlinx/serialization/internal/ElementMarker {
+	public fun <init> (Lkotlinx/serialization/descriptors/SerialDescriptor;Lkotlin/jvm/functions/Function2;)V
+	public final fun mark (I)V
+	public final fun nextUnmarkedIndex ()I
 }
 
 public final class kotlinx/serialization/internal/EnumDescriptor : kotlinx/serialization/internal/PluginGeneratedSerialDescriptor {
@@ -1062,9 +1068,9 @@ public abstract class kotlinx/serialization/internal/TaggedEncoder : kotlinx/ser
 	public final fun encodeLongElement (Lkotlinx/serialization/descriptors/SerialDescriptor;IJ)V
 	public final fun encodeNotNullMark ()V
 	public fun encodeNull ()V
-	public final fun encodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
+	public fun encodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public fun encodeNullableSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
-	public final fun encodeSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
+	public fun encodeSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public fun encodeSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public final fun encodeShort (S)V
 	public final fun encodeShortElement (Lkotlinx/serialization/descriptors/SerialDescriptor;IS)V

--- a/core/commonMain/src/kotlinx/serialization/encoding/AbstractEncoder.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/AbstractEncoder.kt
@@ -70,7 +70,7 @@ public abstract class AbstractEncoder : Encoder, CompositeEncoder {
     ): Encoder =
         if (encodeElement(descriptor, index)) encodeInline(descriptor.getElementDescriptor(index)) else NoOpEncoder
 
-    final override fun <T : Any?> encodeSerializableElement(
+    override fun <T : Any?> encodeSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         serializer: SerializationStrategy<T>,
@@ -80,7 +80,7 @@ public abstract class AbstractEncoder : Encoder, CompositeEncoder {
             encodeSerializableValue(serializer, value)
     }
 
-    final override fun <T : Any> encodeNullableSerializableElement(
+    override fun <T : Any> encodeNullableSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         serializer: SerializationStrategy<T>,

--- a/core/commonMain/src/kotlinx/serialization/internal/ElementMarker.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/ElementMarker.kt
@@ -7,17 +7,18 @@ package kotlinx.serialization.internal
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.CompositeDecoder
-import kotlin.jvm.JvmStatic
 
 @OptIn(ExperimentalSerializationApi::class)
 @PublishedApi
 internal class ElementMarker(
     private val descriptor: SerialDescriptor,
+    // Instead of inheritance and virtual function in order to keep cross-module internal modifier via suppresses
+    // Can be reworked via public + internal api if necessary
     private val readIfAbsent: (SerialDescriptor, Int) -> Boolean
 ) {
     /*
      * Element decoding marks from given bytes.
-     * The element number is the same as the bit position.
+     * The element index is the same as the set bit position.
      * Marks for the lowest 64 elements are always stored in a single Long value, higher elements stores in long array.
      */
     private var lowerMarks: Long

--- a/core/commonMain/src/kotlinx/serialization/internal/ElementMarker.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/ElementMarker.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.internal
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlin.jvm.JvmStatic
+
+@OptIn(ExperimentalSerializationApi::class)
+@PublishedApi
+internal class ElementMarker(
+    private val descriptor: SerialDescriptor,
+    private val readIfAbsent: (SerialDescriptor, Int) -> Boolean
+) {
+    /*
+     * Element decoding marks from given bytes.
+     * The element number is the same as the bit position.
+     * Marks for the lowest 64 elements are always stored in a single Long value, higher elements stores in long array.
+     */
+    private var lowerMarks: Long
+    private val highMarksArray: LongArray
+
+    private companion object {
+        private val EMPTY_HIGH_MARKS = LongArray(0)
+    }
+
+    init {
+        val elementsCount = descriptor.elementsCount
+        if (elementsCount <= Long.SIZE_BITS) {
+            lowerMarks = if (elementsCount == Long.SIZE_BITS) {
+                // number of bits in the mark is equal to the number of fields
+                0L
+            } else {
+                // (1 - elementsCount) bits are always 1 since there are no fields for them
+                -1L shl elementsCount
+            }
+            highMarksArray = EMPTY_HIGH_MARKS
+        } else {
+            lowerMarks = 0L
+            highMarksArray = prepareHighMarksArray(elementsCount)
+        }
+    }
+
+    fun mark(index: Int) {
+        if (index < Long.SIZE_BITS) {
+            lowerMarks = lowerMarks or (1L shl index)
+        } else {
+            markHigh(index)
+        }
+    }
+
+    fun nextUnmarkedIndex(): Int {
+        val elementsCount = descriptor.elementsCount
+        while (lowerMarks != -1L) {
+            val index = lowerMarks.inv().countTrailingZeroBits()
+            lowerMarks = lowerMarks or (1L shl index)
+
+            if (readIfAbsent(descriptor, index)) {
+                return index
+            }
+        }
+
+        if (elementsCount > Long.SIZE_BITS) {
+            return nextUnmarkedHighIndex()
+        }
+        return CompositeDecoder.DECODE_DONE
+    }
+
+    private fun prepareHighMarksArray(elementsCount: Int): LongArray {
+        // (elementsCount - 1) / Long.SIZE_BITS
+        // (elementsCount - 1) because only one Long value is needed to store 64 fields etc
+        val slotsCount = (elementsCount - 1) ushr 6
+        // elementsCount % Long.SIZE_BITS
+        val elementsInLastSlot = elementsCount and (Long.SIZE_BITS - 1)
+        val highMarks = LongArray(slotsCount)
+        // if (elementsCount % Long.SIZE_BITS) == 0 means that the fields occupy all bits in mark
+        if (elementsInLastSlot != 0) {
+            // all marks except the higher are always 0
+            highMarks[highMarks.lastIndex] = -1L shl elementsCount
+        }
+        return highMarks
+    }
+
+    private fun markHigh(index: Int) {
+        // (index / Long.SIZE_BITS) - 1
+        val slot = (index ushr 6) - 1
+        // index % Long.SIZE_BITS
+        val offsetInSlot = index and (Long.SIZE_BITS - 1)
+        highMarksArray[slot] = highMarksArray[slot] or (1L shl offsetInSlot)
+    }
+
+    private fun nextUnmarkedHighIndex(): Int {
+        for (slot in highMarksArray.indices) {
+            // (slot + 1) because first element in high marks has index 64
+            val slotOffset = (slot + 1) * Long.SIZE_BITS
+            // store in a variable so as not to frequently use the array
+            var slotMarks = highMarksArray[slot]
+
+            while (slotMarks != -1L) {
+                val indexInSlot = slotMarks.inv().countTrailingZeroBits()
+                slotMarks = slotMarks or (1L shl indexInSlot)
+
+                val index = slotOffset + indexInSlot
+                if (readIfAbsent(descriptor, index)) {
+                    highMarksArray[slot] = slotMarks
+                    return index
+                }
+            }
+            highMarksArray[slot] = slotMarks
+        }
+        return CompositeDecoder.DECODE_DONE
+    }
+}

--- a/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -126,7 +126,7 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
         return encodeTaggedInline(descriptor.getTag(index), descriptor.getElementDescriptor(index))
     }
 
-    final override fun <T : Any?> encodeSerializableElement(
+    override fun <T : Any?> encodeSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         serializer: SerializationStrategy<T>,
@@ -137,7 +137,7 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    final override fun <T : Any> encodeNullableSerializableElement(
+    override fun <T : Any> encodeNullableSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         serializer: SerializationStrategy<T>,

--- a/core/commonTest/src/kotlinx/serialization/ElementMarkerTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/ElementMarkerTest.kt
@@ -1,0 +1,97 @@
+package kotlinx.serialization
+
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.internal.ElementMarker
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ElementMarkerTest {
+    @Test
+    fun testNothingWasRead() {
+        val size = 5
+        val descriptor = createClassDescriptor(size)
+        val reader = ElementMarker(descriptor) { _, _ -> true }
+
+        for (i in 0 until size) {
+            assertEquals(i, reader.nextUnmarkedIndex())
+        }
+        assertEquals(CompositeDecoder.DECODE_DONE, reader.nextUnmarkedIndex())
+    }
+
+    @Test
+    fun testAllWasRead() {
+        val size = 5
+        val descriptor = createClassDescriptor(size)
+        val reader = ElementMarker(descriptor) { _, _ -> true }
+        for (i in 0 until size) {
+            reader.mark(i)
+        }
+
+        assertEquals(CompositeDecoder.DECODE_DONE, reader.nextUnmarkedIndex())
+    }
+
+    @Test
+    fun testFilteredRead() {
+        val size = 10
+        val readIndex = 4
+
+        val predicate: (Any?, Int) -> Boolean = { _, i -> i % 2 == 0 }
+        val descriptor = createClassDescriptor(size)
+        val reader = ElementMarker(descriptor, predicate)
+        reader.mark(readIndex)
+
+        for (i in 0 until size) {
+            if (predicate(descriptor, i) && i != readIndex) {
+                //`readIndex` already read and only filtered elements must be read
+                assertEquals(i, reader.nextUnmarkedIndex())
+            }
+        }
+        assertEquals(CompositeDecoder.DECODE_DONE, reader.nextUnmarkedIndex())
+    }
+
+    @Test
+    fun testSmallPartiallyRead() {
+        testPartiallyRead(Long.SIZE_BITS / 3)
+    }
+
+    @Test
+    fun test64PartiallyRead() {
+        testPartiallyRead(Long.SIZE_BITS)
+    }
+
+    @Test
+    fun test128PartiallyRead() {
+        testPartiallyRead(Long.SIZE_BITS * 2)
+    }
+
+    @Test
+    fun testLargePartiallyRead() {
+        testPartiallyRead(Long.SIZE_BITS * 2 + Long.SIZE_BITS / 3)
+    }
+
+    private fun testPartiallyRead(size: Int) {
+        val descriptor = createClassDescriptor(size)
+        val reader = ElementMarker(descriptor) { _, _ -> true }
+        for (i in 0 until size) {
+            if (i % 2 == 0) {
+                reader.mark(i)
+            }
+        }
+
+        for (i in 0 until size) {
+            if (i % 2 != 0) {
+                assertEquals(i, reader.nextUnmarkedIndex())
+            }
+        }
+        assertEquals(CompositeDecoder.DECODE_DONE, reader.nextUnmarkedIndex())
+    }
+
+    private fun createClassDescriptor(size: Int): SerialDescriptor {
+        return buildClassSerialDescriptor("descriptor") {
+            for (i in 0 until size) {
+                element("element$i", buildSerialDescriptor("int", PrimitiveKind.INT))
+            }
+        }
+    }
+}

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -80,6 +80,7 @@ public final class kotlinx/serialization/json/JsonBuilder {
 	public final fun getClassDiscriminator ()Ljava/lang/String;
 	public final fun getCoerceInputValues ()Z
 	public final fun getEncodeDefaults ()Z
+	public final fun getExplicitNulls ()Z
 	public final fun getIgnoreUnknownKeys ()Z
 	public final fun getPrettyPrint ()Z
 	public final fun getPrettyPrintIndent ()Ljava/lang/String;
@@ -92,6 +93,7 @@ public final class kotlinx/serialization/json/JsonBuilder {
 	public final fun setClassDiscriminator (Ljava/lang/String;)V
 	public final fun setCoerceInputValues (Z)V
 	public final fun setEncodeDefaults (Z)V
+	public final fun setExplicitNulls (Z)V
 	public final fun setIgnoreUnknownKeys (Z)V
 	public final fun setLenient (Z)V
 	public final fun setPrettyPrint (Z)V
@@ -108,6 +110,7 @@ public final class kotlinx/serialization/json/JsonConfiguration {
 	public final fun getClassDiscriminator ()Ljava/lang/String;
 	public final fun getCoerceInputValues ()Z
 	public final fun getEncodeDefaults ()Z
+	public final fun getExplicitNulls ()Z
 	public final fun getIgnoreUnknownKeys ()Z
 	public final fun getPrettyPrint ()Z
 	public final fun getPrettyPrintIndent ()Ljava/lang/String;

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -96,7 +96,7 @@ public sealed class Json(
      */
     public final override fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, string: String): T {
         val lexer = JsonLexer(string)
-        val input = StreamingJsonDecoder(this, WriteMode.OBJ, lexer)
+        val input = StreamingJsonDecoder(this, WriteMode.OBJ, lexer, deserializer.descriptor)
         val result = input.decodeSerializableValue(deserializer)
         lexer.expectEof()
         return result
@@ -169,6 +169,17 @@ public class JsonBuilder internal constructor(json: Json) {
      * `false` by default.
      */
     public var encodeDefaults: Boolean = json.configuration.encodeDefaults
+
+    /**
+     * Specifies whether `null` values should be encoded for nullable properties and must be present in JSON object
+     * during decoding.
+     *
+     * When this flag is disabled properties with `null` values without default are not encoded;
+     * during decoding, the absence of a field value is treated as `null` for nullable properties without a default value.
+     *
+     * `true` by default.
+     */
+    public var explicitNulls: Boolean = json.configuration.explicitNulls
 
     /**
      * Specifies whether encounters of unknown properties in the input JSON
@@ -275,7 +286,7 @@ public class JsonBuilder internal constructor(json: Json) {
 
         return JsonConfiguration(
             encodeDefaults, ignoreUnknownKeys, isLenient,
-            allowStructuredMapKeys, prettyPrint, prettyPrintIndent,
+            allowStructuredMapKeys, prettyPrint, explicitNulls, prettyPrintIndent,
             coerceInputValues, useArrayPolymorphism,
             classDiscriminator, allowSpecialFloatingPointValues, useAlternativeNames
         )

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -1,7 +1,6 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
-import kotlinx.serialization.modules.*
 
 /**
  * Configuration of the current [Json] instance available through [Json.configuration]
@@ -23,6 +22,8 @@ public class JsonConfiguration internal constructor(
     public val allowStructuredMapKeys: Boolean = false,
     public val prettyPrint: Boolean = false,
     @ExperimentalSerializationApi
+    public val explicitNulls: Boolean = true,
+    @ExperimentalSerializationApi
     public val prettyPrintIndent: String = "    ",
     public val coerceInputValues: Boolean = false,
     public val useArrayPolymorphism: Boolean = false,
@@ -33,6 +34,6 @@ public class JsonConfiguration internal constructor(
 
     /** @suppress Dokka **/
     override fun toString(): String {
-        return "JsonConfiguration(encodeDefaults=$encodeDefaults, ignoreUnknownKeys=$ignoreUnknownKeys, isLenient=$isLenient, allowStructuredMapKeys=$allowStructuredMapKeys, prettyPrint=$prettyPrint, prettyPrintIndent='$prettyPrintIndent', coerceInputValues=$coerceInputValues, useArrayPolymorphism=$useArrayPolymorphism, classDiscriminator='$classDiscriminator', allowSpecialFloatingPointValues=$allowSpecialFloatingPointValues)"
+        return "JsonConfiguration(encodeDefaults=$encodeDefaults, ignoreUnknownKeys=$ignoreUnknownKeys, isLenient=$isLenient, allowStructuredMapKeys=$allowStructuredMapKeys, prettyPrint=$prettyPrint, explicitNulls=$explicitNulls, prettyPrintIndent='$prettyPrintIndent', coerceInputValues=$coerceInputValues, useArrayPolymorphism=$useArrayPolymorphism, classDiscriminator='$classDiscriminator', allowSpecialFloatingPointValues=$allowSpecialFloatingPointValues)"
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonElementMarker.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonElementMarker.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package kotlinx.serialization.json.internal
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.internal.ElementMarker
+
+@OptIn(ExperimentalSerializationApi::class)
+internal class JsonElementMarker(descriptor: SerialDescriptor) {
+    private val origin: ElementMarker = ElementMarker(descriptor, ::readIfAbsent)
+
+    internal var isUnmarkedNull: Boolean = false
+        private set
+
+    internal fun mark(index: Int) {
+        origin.mark(index)
+    }
+
+    internal fun nextUnmarkedIndex(): Int {
+        return origin.nextUnmarkedIndex()
+    }
+
+    private fun readIfAbsent(descriptor: SerialDescriptor, index: Int): Boolean {
+        isUnmarkedNull = !descriptor.isElementOptional(index) && descriptor.getElementDescriptor(index).isNullable
+        return isUnmarkedNull
+    }
+}

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -147,6 +147,17 @@ internal class StreamingJsonEncoder(
         return true
     }
 
+    override fun <T : Any> encodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T?
+    ) {
+        if (value != null || configuration.explicitNulls) {
+            super.encodeNullableSerializableElement(descriptor, index, serializer, value)
+        }
+    }
+
     override fun encodeInline(inlineDescriptor: SerialDescriptor): Encoder =
         if (inlineDescriptor.isUnsignedNumber) StreamingJsonEncoder(
             ComposerForUnsignedNumbers(

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -171,6 +171,17 @@ private open class JsonTreeEncoder(
         content[key] = element
     }
 
+    override fun <T : Any> encodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T?
+    ) {
+        if (value != null || configuration.explicitNulls) {
+            super.encodeNullableSerializableElement(descriptor, index, serializer, value)
+        }
+    }
+
     override fun getCurrent(): JsonElement = JsonObject(content)
 }
 

--- a/formats/json/commonTest/src/kotlinx/serialization/json/AbstractJsonImplicitNullsTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/AbstractJsonImplicitNullsTest.kt
@@ -1,0 +1,151 @@
+package kotlinx.serialization.json
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+/*
+ * Actual testing should be performed in subclasses.
+ * Subclasses implement serialization and deserialization for different types: serial Kotlin classes, JsonElement, dynamic etc
+ */
+@Ignore
+abstract class AbstractJsonImplicitNullsTest {
+    @Serializable
+    data class Nullable(
+        val f0: Int?,
+        val f1: Int?,
+        val f2: Int?,
+        val f3: Int?,
+    )
+
+    @Serializable
+    data class WithNotNull(
+        val f0: Int?,
+        val f1: Int?,
+        val f2: Int,
+    )
+
+    @Serializable
+    data class WithOptional(
+        val f0: Int?,
+        val f1: Int? = 1,
+        val f2: Int = 2,
+    )
+
+    @Serializable
+    data class Outer(val i: Inner)
+
+    @Serializable
+    data class Inner(val s1: String?, val s2: String?)
+
+    @Serializable
+    data class ListWithNullable(val l: List<Int?>)
+
+    @Serializable
+    data class MapWithNullable(val m: Map<Int?, Int?>)
+
+    @Serializable
+    data class NullableList(val l: List<Int>?)
+
+    @Serializable
+    data class NullableMap(val m: Map<Int, Int>?)
+
+
+    private val format = Json { explicitNulls = false }
+
+    protected abstract fun <T> Json.encode(value: T, serializer: KSerializer<T>): String
+
+    protected abstract fun <T> Json.decode(json: String, serializer: KSerializer<T>): T
+
+    @Test
+    fun testExplicit() {
+        val plain = Nullable(null, 10, null, null)
+        val json = """{"f0":null,"f1":10,"f2":null,"f3":null}"""
+
+        assertEquals(json, Json.encode(plain, Nullable.serializer()))
+        assertEquals(plain, Json.decode(json, Nullable.serializer()))
+    }
+
+    @Test
+    fun testNullable() {
+        val plain = Nullable(null, 10, null, null)
+        val json = """{"f1":10}"""
+
+        assertEquals(json, format.encode(plain, Nullable.serializer()))
+        assertEquals(plain, format.decode(json, Nullable.serializer()))
+    }
+
+    @Test
+    fun testMissingNotNull() {
+        val json = """{"f1":10}"""
+
+        assertFailsWith(SerializationException::class) {
+            format.decode(json, WithNotNull.serializer())
+        }
+    }
+
+    @Test
+    fun testDecodeOptional() {
+        val json = """{}"""
+
+        val decoded = format.decode(json, WithOptional.serializer())
+        assertEquals(WithOptional(null), decoded)
+    }
+
+
+    @Test
+    fun testNestedJsonObject() {
+        val json = """{"i": {}}"""
+
+        val decoded = format.decode(json, Outer.serializer())
+        assertEquals(Outer(Inner(null, null)), decoded)
+    }
+
+    @Test
+    fun testListWithNullable() {
+        val jsonWithNull = """{"l":[null]}"""
+        val jsonWithEmptyList = """{"l":[]}"""
+
+        val encoded = format.encode(ListWithNullable(listOf(null)), ListWithNullable.serializer())
+        assertEquals(jsonWithNull, encoded)
+
+        val decoded = format.decode(jsonWithEmptyList, ListWithNullable.serializer())
+        assertEquals(ListWithNullable(emptyList()), decoded)
+    }
+
+    @Test
+    fun testMapWithNullable() {
+        val jsonWithNull = """{"m":{null:null}}"""
+        val jsonWithQuotedNull = """{"m":{"null":null}}"""
+        val jsonWithEmptyList = """{"m":{}}"""
+
+        val encoded = format.encode(MapWithNullable(mapOf(null to null)), MapWithNullable.serializer())
+        //Json encode map null key as `null:` but other external utilities may encode it as a String `"null":`
+        assertTrue { listOf(jsonWithNull, jsonWithQuotedNull).contains(encoded) }
+
+        val decoded = format.decode(jsonWithEmptyList, MapWithNullable.serializer())
+        assertEquals(MapWithNullable(emptyMap()), decoded)
+    }
+
+    @Test
+    fun testNullableList() {
+        val json = """{}"""
+
+        val encoded = format.encode(NullableList(null), NullableList.serializer())
+        assertEquals(json, encoded)
+
+        val decoded = format.decode(json, NullableList.serializer())
+        assertEquals(NullableList(null), decoded)
+    }
+
+    @Test
+    fun testNullableMap() {
+        val json = """{}"""
+
+        val encoded = format.encode(NullableMap(null), NullableMap.serializer())
+        assertEquals(json, encoded)
+
+        val decoded = format.decode(json, NullableMap.serializer())
+        assertEquals(NullableMap(null), decoded)
+    }
+
+}

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonImplicitNullsTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonImplicitNullsTest.kt
@@ -1,0 +1,13 @@
+package kotlinx.serialization.json
+
+import kotlinx.serialization.*
+
+class JsonImplicitNullsTest: AbstractJsonImplicitNullsTest() {
+    override fun <T> Json.encode(value: T, serializer: KSerializer<T>): String {
+        return encodeToString(serializer, value)
+    }
+
+    override fun <T> Json.decode(json: String, serializer: KSerializer<T>): T {
+        return decodeFromString(serializer, json)
+    }
+}

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -38,7 +38,7 @@ abstract class JsonTestBase {
             decodeFromString(deserializer, source)
         } else {
             val lexer = JsonLexer(source)
-            val input = StreamingJsonDecoder(this, WriteMode.OBJ, lexer)
+            val input = StreamingJsonDecoder(this, WriteMode.OBJ, lexer, deserializer.descriptor)
             val tree = input.decodeJsonElement()
             lexer.expectEof()
             readJson(tree, deserializer)

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonTreeImplicitNullsTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonTreeImplicitNullsTest.kt
@@ -1,0 +1,14 @@
+package kotlinx.serialization.json
+
+import kotlinx.serialization.KSerializer
+
+class JsonTreeImplicitNullsTest: AbstractJsonImplicitNullsTest() {
+    override fun <T> Json.encode(value: T, serializer: KSerializer<T>): String {
+        return encodeToJsonElement(serializer, value).toString()
+    }
+
+    override fun <T> Json.decode(json: String, serializer: KSerializer<T>): T {
+        val jsonElement = parseToJsonElement(json)
+        return decodeFromJsonElement(serializer, jsonElement)
+    }
+}

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
@@ -151,6 +151,17 @@ private class DynamicObjectEncoder(
         encodeValue(value)
     }
 
+    override fun <T : Any> encodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T?
+    ) {
+        if (value != null || json.configuration.explicitNulls) {
+            super.encodeNullableSerializableElement(descriptor, index, serializer, value)
+        }
+    }
+
     override fun encodeJsonElement(element: JsonElement) {
         encodeSerializableValue(JsonElementSerializer, element)
     }

--- a/formats/json/jsTest/src/kotlinx/serialization/json/EncodeToDynamicTest.kt
+++ b/formats/json/jsTest/src/kotlinx/serialization/json/EncodeToDynamicTest.kt
@@ -136,27 +136,6 @@ class EncodeToDynamicTest {
         }
     }
 
-    // todo: this is a test for internal class. Rewrite it after implementing 'omitNulls' JSON flag.
-    @Test
-    @Ignore
-    fun nullsTest() {
-//        val data = DataWrapper("a string", null)
-//
-//        val serialized = DynamicObjectSerializer(
-//            Json,
-//            encodeNullAsUndefined = true
-//        ).serialize(DataWrapper.serializer(), data)
-//        assertNull(serialized.d)
-//        assertFalse(js("""Object.keys(serialized).includes("d")"""), "should omit null properties")
-//
-//        val serializedWithNull = DynamicObjectSerializer(
-//            Json,
-//            encodeNullAsUndefined = false
-//        ).serialize(DataWrapper.serializer(), data)
-//        assertNull(serializedWithNull.d)
-//        assertTrue(js("""Object.keys(serializedWithNull).includes("d")"""), "should contain null properties")
-    }
-
     @Test
     fun listTest() {
         assertDynamicForm(listOf(1, 2, 3, 44), serializer = ListSerializer(Int.serializer())) { data, serialized ->

--- a/formats/json/jsTest/src/kotlinx/serialization/json/JsonDynamicImplicitNullsTest.kt
+++ b/formats/json/jsTest/src/kotlinx/serialization/json/JsonDynamicImplicitNullsTest.kt
@@ -1,0 +1,14 @@
+package kotlinx.serialization.json
+
+import kotlinx.serialization.KSerializer
+
+class JsonDynamicImplicitNullsTest : AbstractJsonImplicitNullsTest() {
+    override fun <T> Json.encode(value: T, serializer: KSerializer<T>): String {
+        return JSON.stringify(encodeToDynamic(serializer, value))
+    }
+
+    override fun <T> Json.decode(json: String, serializer: KSerializer<T>): T {
+        val x: dynamic = JSON.parse(json)
+        return decodeFromDynamic(serializer, x)
+    }
+}


### PR DESCRIPTION
### benchmarks
```
+1.75%	k.b.json.CitmBenchmark.decodeCitm
+0.49%	k.b.json.CitmBenchmark.encodeCitm
-0.82%	k.b.json.CoerceInputValuesBenchmark.testNonNullableCoercing
-0.65%	k.b.json.CoerceInputValuesBenchmark.testNonNullableRegular
-1.89%	k.b.json.CoerceInputValuesBenchmark.testNullableCoercing
+1.22%	k.b.json.CoerceInputValuesBenchmark.testNullableRegular
+1.67%	k.b.json.JacksonComparisonBenchmark.jacksonFromString
+1.76%	k.b.json.JacksonComparisonBenchmark.jacksonSmallToString
-0.71%	k.b.json.JacksonComparisonBenchmark.jacksonToString
+4.49%	k.b.json.JacksonComparisonBenchmark.jacksonToStringWithEscapes
+3.07%	k.b.json.JacksonComparisonBenchmark.kotlinFromString
+0.53%	k.b.json.JacksonComparisonBenchmark.kotlinSmallToString
+4.46%	k.b.json.JacksonComparisonBenchmark.kotlinToString
+2.43%	k.b.json.JacksonComparisonBenchmark.kotlinToStringWithEscapes
+4.89%	k.b.json.PrimitiveValuesBenchmark.decodeBoolean
+0.74%	k.b.json.PrimitiveValuesBenchmark.decodeInt
+6.29%	k.b.json.PrimitiveValuesBenchmark.decodeLong
+1.36%	k.b.json.TwitterBenchmark.decodeTwitter
-0.55%	k.b.json.TwitterBenchmark.encodeTwitter
+3.65%	k.b.json.TwitterFeedBenchmark.decodeMicroTwitter
-1.54%	k.b.json.TwitterFeedBenchmark.decodeMicroTwitterNoAltNames
-0.52%	k.b.json.TwitterFeedBenchmark.decodeTwitter
-1.24%	k.b.json.TwitterFeedBenchmark.decodeTwitterNoAltNames
+1.30%	k.b.json.TwitterFeedBenchmark.encodeTwitter
+15.57%	k.b.protobuf.ProtoBaseline.fromBytes
-4.58%	k.b.protobuf.ProtoBaseline.fromBytesExplicit
+3.49%	k.b.protobuf.ProtoBaseline.toBytes
+3.03%	k.b.protobuf.ProtoBaseline.toBytesExplicit
-0.50%	k.b.protobuf.ProtoHuge.fromBytes130
-1.64%	k.b.protobuf.ProtoHuge.toBytes130
+1.51%	k.b.protobuf.ProtoListBenchmark.fromBytes
-3.79%	k.b.protobuf.ProtoListBenchmark.toBytes
-0.39%	k.b.protobuf.ProtoListLikeBenchmark.fromBytes
+1.45%	k.b.protobuf.ProtoListLikeBenchmark.toBytes
``` 

Using `omitNull = true` flag for JSON's with all fields filled can sometimes slow down performance and increase volatility:  
 * TwitterBenchmark.decodeTwitterOmitNull vs TwitterBenchmark.decodeTwitter: -5% .. +1.5%
 * OmitNullBenchmark.decodeNoNullsWithOmit vs OmitNullBenchmark.decodeNoNulls: -4.5% .. -3%
 * OmitNullBenchmark.decodeNullsWithOmit vs OmitNullBenchmark.decodeNulls: -4.7% .. -1%
