### PR TITLE
Allow for Contextual serializers as  map keys in Json

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/WriteMode.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/WriteMode.kt
@@ -8,6 +8,7 @@ package kotlinx.serialization.json.internal
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
 import kotlin.jvm.JvmField
 
 internal enum class WriteMode(@JvmField val begin: Char, @JvmField val end: Char) {
@@ -32,18 +33,8 @@ internal inline fun <T, R1 : T, R2 : T> Json.selectMapMode(
     ifMap: () -> R1,
     ifList: () -> R2
 ): T {
-    var keyDescriptor = mapDescriptor.getElementDescriptor(0).carrierDescriptor
-    var keyKind = keyDescriptor.kind
-
-    if (keyKind == SerialKind.CONTEXTUAL) {
-        keyDescriptor = serializersModule.getContextualDescriptor(keyDescriptor)
-            ?: throw InvalidKeyKindException(keyDescriptor)
-        keyKind = if (keyDescriptor.isInline) {
-            keyDescriptor.getElementDescriptor(0).kind
-        } else {
-            keyDescriptor.kind
-        }
-    }
+    val keyDescriptor = mapDescriptor.getElementDescriptor(0).carrierDescriptor(serializersModule)
+    val keyKind = keyDescriptor.kind
 
     return if (keyKind is PrimitiveKind || keyKind == SerialKind.ENUM) {
         ifMap()
@@ -54,5 +45,8 @@ internal inline fun <T, R1 : T, R2 : T> Json.selectMapMode(
     }
 }
 
-internal val SerialDescriptor.carrierDescriptor: SerialDescriptor
-    get() = if (isInline) getElementDescriptor(0) else this
+internal fun SerialDescriptor.carrierDescriptor(module: SerializersModule): SerialDescriptor = when {
+    kind == SerialKind.CONTEXTUAL -> module.getContextualDescriptor(this)?.carrierDescriptor(module) ?: this
+    isInline -> getElementDescriptor(0)
+    else     -> this
+}

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
@@ -139,7 +139,7 @@ class JsonMapKeysTest : JsonTestBase() {
     }
 
     @Test
-    fun testContextualPrimitivesAreAllowedAsValueMapKeys() =  noLegacyJs {
+    fun testContextualPrimitivesAreAllowedAsValueMapKeys() {
         assertJsonFormAndRestored(
             WithContextualKey.serializer(),
             WithContextualKey(mapOf(ContextualValue("fooKey") to 1)),

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
@@ -40,8 +40,6 @@ data class ContextualValue(val c: String) {
     }
 }
 
-
-
 class JsonMapKeysTest : JsonTestBase() {
     @Serializable
     private data class WithMap(val map: Map<Long, Long>)

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonMapKeysTest.kt
@@ -5,7 +5,14 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.internal.*
+import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.test.*
 import kotlin.jvm.*
 import kotlin.test.*
@@ -17,6 +24,23 @@ value class ComplexCarrier(val c: IntData)
 @JvmInline
 @Serializable
 value class PrimitiveCarrier(val c: String)
+
+data class ContextualValue(val c: String) {
+    @Serializer(forClass = ContextualValue::class)
+    companion object: KSerializer<ContextualValue> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ContextualValue", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ContextualValue) {
+            encoder.encodeString(value.c)
+        }
+
+        override fun deserialize(decoder: Decoder): ContextualValue {
+            return ContextualValue(decoder.decodeString())
+        }
+    }
+}
+
+
 
 class JsonMapKeysTest : JsonTestBase() {
     @Serializable
@@ -33,6 +57,12 @@ class JsonMapKeysTest : JsonTestBase() {
 
     @Serializable
     private data class WithComplexValueKey(val map: Map<ComplexCarrier, String>)
+
+    @Serializable
+    private data class WithContextualValueKey(val map: Map<@Contextual PrimitiveCarrier, Long>)
+
+    @Serializable
+    private data class WithContextualKey(val map: Map<@Contextual ContextualValue, Long>)
 
     @Test
     fun testMapKeysShouldBeStrings() = parametrizedTest(default) {
@@ -92,6 +122,31 @@ class JsonMapKeysTest : JsonTestBase() {
             WithValueKeyMap(mapOf(PrimitiveCarrier("fooKey") to 1)),
             """{"map":{"fooKey":1}}""",
             Json
+        )
+    }
+
+    @Test
+    fun testContextualValuePrimitivesAreAllowedAsValueMapKeys() =  noLegacyJs {
+        assertJsonFormAndRestored(
+            WithContextualValueKey.serializer(),
+            WithContextualValueKey(mapOf(PrimitiveCarrier("fooKey") to 1)),
+            """{"map":{"fooKey":1}}""",
+            Json {
+                serializersModule =
+                    SerializersModule { contextual(PrimitiveCarrier::class, PrimitiveCarrier.serializer()) }
+            }
+        )
+    }
+
+    @Test
+    fun testContextualPrimitivesAreAllowedAsValueMapKeys() =  noLegacyJs {
+        assertJsonFormAndRestored(
+            WithContextualKey.serializer(),
+            WithContextualKey(mapOf(ContextualValue("fooKey") to 1)),
+            """{"map":{"fooKey":1}}""",
+            Json {
+                serializersModule = SerializersModule { contextual(ContextualValue::class, ContextualValue.Companion) }
+            }
         )
     }
 }


### PR DESCRIPTION
This addresses #1551 and allows contextual serializers to be used as map keys (it supports both value and non-value variants). It adds tests for both.