### PR TITLE
CBOR Integer Encoding Length Fix

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -166,30 +166,29 @@ internal class CborEncoder(private val output: ByteArrayOutput) {
     }
 
     private fun composeNumber(value: Long): ByteArray =
-        if (value >= 0) composePositive(value) else composeNegative(value)
+        if (value >= 0) composePositive(value.toULong()) else composeNegative(value)
 
-    private fun composePositive(value: Long): ByteArray = when (value) {
-        in 0..23 -> byteArrayOf(value.toByte())
-        in 24..Byte.MAX_VALUE -> byteArrayOf(24, value.toByte())
-        in Byte.MAX_VALUE + 1..Short.MAX_VALUE -> encodeToByteArray(value, 2, 25)
-        in Short.MAX_VALUE + 1..Int.MAX_VALUE -> encodeToByteArray(value, 4, 26)
-        in (Int.MAX_VALUE.toLong() + 1..Long.MAX_VALUE) -> encodeToByteArray(value, 8, 27)
-        else -> throw AssertionError("$value should be positive")
+    private fun composePositive(value: ULong): ByteArray = when (value) {
+        in 0u..23u -> byteArrayOf(value.toByte())
+        in 24u..UByte.MAX_VALUE.toUInt() -> byteArrayOf(24, value.toByte())
+        in (UByte.MAX_VALUE.toUInt() + 1u)..UShort.MAX_VALUE.toUInt() -> encodeToByteArray(value, 2, 25)
+        in (UShort.MAX_VALUE.toUInt() + 1u)..UInt.MAX_VALUE -> encodeToByteArray(value, 4, 26)
+        else -> encodeToByteArray(value, 8, 27)
     }
 
-    private fun encodeToByteArray(value: Long, bytes: Int, tag: Byte): ByteArray {
+    private fun encodeToByteArray(value: ULong, bytes: Int, tag: Byte): ByteArray {
         val result = ByteArray(bytes + 1)
         val limit = bytes * 8 - 8
         result[0] = tag
         for (i in 0 until bytes) {
-            result[i + 1] = ((value shr (limit - 8 * i)) and 0xFF).toByte()
+            result[i + 1] = ((value shr (limit - 8 * i)) and 0xFFu).toByte()
         }
         return result
     }
 
     private fun composeNegative(value: Long): ByteArray {
         val aVal = if (value == Long.MIN_VALUE) Long.MAX_VALUE else -1 - value
-        val data = composePositive(aVal)
+        val data = composePositive(aVal.toULong())
         data[0] = data[0] or HEADER_NEGATIVE
         return data
     }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
@@ -1,0 +1,215 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CborNumberEncodingTest {
+
+    // 0-23 packs into a single byte
+    @Test
+    fun testEncodingLengthOfTinyNumbers() {
+        val tinyNumbers = listOf(0, 1, 23)
+        for (number in tinyNumbers) {
+            assertEquals(
+                expected = 1,
+                actual = Cbor.encodeToByteArray(number).size,
+                "when encoding value '$number'"
+            )
+        }
+    }
+
+    // 24..(2^8-1) packs into 2 bytes
+    @Test
+    fun testEncodingLengthOf8BitNumbers() {
+        val tinyNumbers = listOf(24, 127, 128, 255)
+        for (number in tinyNumbers) {
+            assertEquals(
+                expected = 2,
+                actual = Cbor.encodeToByteArray(number).size,
+                "when encoding value '$number'"
+            )
+        }
+    }
+
+    // 2^8..(2^16-1) packs into 3 bytes
+    @Test
+    fun testEncodingLengthOf16BitNumbers() {
+        val tinyNumbers = listOf(256, 32767, 32768, 65535)
+        for (number in tinyNumbers) {
+            assertEquals(
+                expected = 3,
+                actual = Cbor.encodeToByteArray(number).size,
+                "when encoding value '$number'"
+            )
+        }
+    }
+
+    // 2^16..(2^32-1) packs into 5 bytes
+    @Test
+    fun testEncodingLengthOf32BitNumbers() {
+        val tinyNumbers = listOf(65536, 2147483647, 2147483648, 4294967295)
+        for (number in tinyNumbers) {
+            assertEquals(
+                expected = 5,
+                actual = Cbor.encodeToByteArray(number).size,
+                "when encoding value '$number'"
+            )
+        }
+    }
+
+    // 2^32+ packs into 9 bytes
+    @Test
+    fun testEncodingLengthOfLargeNumbers() {
+        val tinyNumbers = listOf(4294967296, 8589934592)
+        for (number in tinyNumbers) {
+            assertEquals(
+                expected = 9,
+                actual = Cbor.encodeToByteArray(number).size,
+                "when encoding value '$number'"
+            )
+        }
+    }
+
+    @Test
+    fun testEncodingLargestPositiveTinyNumber() {
+        assertEquals(
+            expected = byteArrayOf(23).toList(),
+            actual = Cbor.encodeToByteArray(23).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestPositiveTinyNumber() {
+        assertEquals(
+            expected = 23,
+            actual = Cbor.decodeFromByteArray(byteArrayOf(23)),
+        )
+    }
+
+
+    @Test
+    fun testEncodingLargestNegativeTinyNumber() {
+        assertEquals(
+            expected = byteArrayOf(55).toList(),
+            actual = Cbor.encodeToByteArray(-24).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestNegativeTinyNumber() {
+        assertEquals(
+            expected = -24,
+            actual = Cbor.decodeFromByteArray(byteArrayOf(55)),
+        )
+    }
+
+    @Test
+    fun testEncodingLargestPositive8BitNumber() {
+        val bytes = listOf(24, 255).map { it.toByte() }
+        assertEquals(
+            expected = bytes,
+            actual = Cbor.encodeToByteArray(255).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestPositive8BitNumber() {
+        val bytes = listOf(24, 255).map { it.toByte() }.toByteArray()
+        assertEquals(
+            expected = 255,
+            actual = Cbor.decodeFromByteArray(bytes),
+        )
+    }
+
+    @Test
+    fun testEncodingLargestNegative8BitNumber() {
+        val bytes = listOf(56, 255).map { it.toByte() }
+        assertEquals(
+            expected = bytes,
+            actual = Cbor.encodeToByteArray(-256).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestNegative8BitNumber() {
+        val bytes = listOf(56, 255).map { it.toByte() }.toByteArray()
+        assertEquals(
+            expected = -256,
+            actual = Cbor.decodeFromByteArray(bytes),
+        )
+    }
+
+    @Test
+    fun testEncodingLargestPositive16BitNumber() {
+        val bytes = listOf(25, 255, 255).map { it.toByte() }
+        assertEquals(
+            expected = bytes,
+            actual = Cbor.encodeToByteArray(65535).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestPositive16BitNumber() {
+        val bytes = listOf(25, 255, 255).map { it.toByte() }.toByteArray()
+        assertEquals(
+            expected = 65535,
+            actual = Cbor.decodeFromByteArray(bytes),
+        )
+    }
+
+    @Test
+    fun testEncodingLargestNegative16BitNumber() {
+        val bytes = listOf(57, 255, 255).map { it.toByte() }
+        assertEquals(
+            expected = bytes,
+            actual = Cbor.encodeToByteArray(-65536).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestNegative16BitNumber() {
+        val bytes = listOf(57, 255, 255).map { it.toByte() }.toByteArray()
+        assertEquals(
+            expected = -65536,
+            actual = Cbor.decodeFromByteArray(bytes),
+        )
+    }
+
+    @Test
+    fun testEncodingLargestPositive32BitNumber() {
+        val bytes = listOf(26, 255, 255, 255, 255).map { it.toByte() }
+        assertEquals(
+            expected = bytes,
+            actual = Cbor.encodeToByteArray(4294967295).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestPositive32BitNumber() {
+        val bytes = listOf(26, 255, 255, 255, 255).map { it.toByte() }.toByteArray()
+        assertEquals(
+            expected = 4294967295,
+            actual = Cbor.decodeFromByteArray(bytes),
+        )
+    }
+
+    @Test
+    fun testEncodingLargestNegative32BitNumber() {
+        val bytes = listOf(58, 255, 255, 255, 255).map { it.toByte() }
+        assertEquals(
+            expected = bytes,
+            actual = Cbor.encodeToByteArray(-4294967296).toList(),
+        )
+    }
+
+    @Test
+    fun testDecodingLargestNegative32BitNumber() {
+        val bytes = listOf(58, 255, 255, 255, 255).map { it.toByte() }.toByteArray()
+        assertEquals(
+            expected = -4294967296,
+            actual = Cbor.decodeFromByteArray(bytes),
+        )
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where the packed length is sub-optimal for all positive integers that have the MSB bit set.

CBOR integers are packed with a set number of bytes, bucketed by length (8bit, 16bit, 32bit etc) determined by the bit length of the source. Negative integers are denoted with a different Major Type (1 for -ve, 0 for +ve) but are otherwise treated as an unsigned value when packing/unpacking.

The original code bucketing check uses the *signed* `MAX_VALUE` constants which means any values with the MSB set will fall into the next highest bucket, and thus pack into double the expected number of bytes.

e.g. 65535 (uint16, all bits high) is encoded with two extra zero bytes as `0x19 0x00 0x00 0xFF 0xFF` whereas it should encode to `0x19 0xFF 0xFF`.

The RFC does not explicitly state that integers must always pack to the fewest bytes possible, and the format certainly allows it so it is still valid CBOR. e.g. you could pack the value 1 into the space large enough for a 64bit integer and it can still be decoded successfully. However this is certainly at odds with the "C" in "CBOR". 
