### PR TITLE
CBOR: ignore tags when reading

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -32,6 +32,7 @@ private const val HEADER_STRING: Byte = 0b011_00000
 private const val HEADER_NEGATIVE: Byte = 0b001_00000
 private const val HEADER_ARRAY: Int = 0b100_00000
 private const val HEADER_MAP: Int = 0b101_00000
+private const val HEADER_TAG: Int = 0b110_00000
 
 /** Value to represent an indefinite length CBOR item within a "length stack". */
 private const val LENGTH_STACK_INDEFINITE = -1
@@ -326,11 +327,13 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     fun isNull() = curByte == NULL
 
     fun nextNull(): Nothing? {
+        skipOverTags()
         skipByte(NULL)
         return null
     }
 
     fun nextBoolean(): Boolean {
+        skipOverTags()
         val ans = when (curByte) {
             TRUE -> true
             FALSE -> false
@@ -345,6 +348,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     fun startMap() = startSized(BEGIN_MAP, HEADER_MAP, "map")
 
     private fun startSized(unboundedHeader: Int, boundedHeaderMask: Int, collectionType: String): Int {
+        skipOverTags()
         if (curByte == unboundedHeader) {
             skipByte(unboundedHeader)
             return -1
@@ -361,6 +365,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     fun end() = skipByte(BREAK)
 
     fun nextByteString(): ByteArray {
+        skipOverTags()
         if ((curByte and 0b111_00000) != HEADER_BYTE_STRING.toInt())
             throw CborDecodingException("start of byte string", curByte)
         val arr = readBytes()
@@ -369,6 +374,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     }
 
     fun nextString(): String {
+        skipOverTags()
         if ((curByte and 0b111_00000) != HEADER_STRING.toInt())
             throw CborDecodingException("start of string", curByte)
         val arr = readBytes()
@@ -386,7 +392,16 @@ internal class CborDecoder(private val input: ByteArrayInput) {
             input.readExactNBytes(strLen)
         }
 
+    private fun skipOverTags() {
+        while ((curByte and 0b111_00000) == HEADER_TAG) {
+            val tagNumber = readNumber()
+            print(tagNumber)
+            readByte()
+        }
+    }
+
     fun nextNumber(): Long {
+        skipOverTags()
         val res = readNumber()
         readByte()
         return res
@@ -430,6 +445,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     }
 
     fun nextFloat(): Float {
+        skipOverTags()
         val res = when (curByte) {
             NEXT_FLOAT -> Float.fromBits(readInt())
             NEXT_HALF -> floatFromHalfBits(readShort())
@@ -440,6 +456,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     }
 
     fun nextDouble(): Double {
+        skipOverTags()
         val res = when (curByte) {
             NEXT_DOUBLE -> Double.fromBits(readLong())
             NEXT_FLOAT -> Float.fromBits(readInt()).toDouble()
@@ -489,6 +506,8 @@ internal class CborDecoder(private val input: ByteArrayInput) {
     fun skipElement() {
         val lengthStack = mutableListOf<Int>()
 
+        skipOverTags()
+
         do {
             if (isEof()) throw CborDecodingException("Unexpected EOF while skipping element")
 
@@ -503,6 +522,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
                 val length = elementLength()
                 if (header == HEADER_ARRAY || header == HEADER_MAP) {
                     if (length > 0) lengthStack.add(length)
+                    skipOverTags()
                 } else {
                     input.skip(length)
                     prune(lengthStack)
@@ -558,6 +578,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
      * | 3. string           | bytes                          |
      * | 4. array            | data items (values)            |
      * | 5. map              | sub-items (keys + values)      |
+     * | 6. tag              | bytes                          |
      */
     private fun elementLength(): Int {
         val majorType = curByte and 0b111_00000

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -394,8 +394,7 @@ internal class CborDecoder(private val input: ByteArrayInput) {
 
     private fun skipOverTags() {
         while ((curByte and 0b111_00000) == HEADER_TAG) {
-            val tagNumber = readNumber()
-            print(tagNumber)
+            readNumber() // This is the tag number
             readByte()
         }
     }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborReaderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborReaderTest.kt
@@ -588,6 +588,96 @@ class CborReaderTest {
                 actual = Cbor.decodeFromHexString("bf6178f6ff")
         )
     }
+
+    @Test
+    fun testIgnoresTagsOnStrings() {
+        /*
+         * 84                                # array(4)
+         * 68                             # text(8)
+         *    756E746167676564            # "untagged"
+         * C0                             # tag(0)
+         *    68                          # text(8)
+         *       7461676765642D30         # "tagged-0"
+         * D8 F5                          # tag(245)
+         *    6A                          # text(10)
+         *       7461676765642D323435     # "tagged-244"
+         * D9 3039                        # tag(12345)
+         *    6C                          # text(12)
+         *       7461676765642D3132333435 # "tagged-12345"
+         *
+         */
+        withDecoder("8468756E746167676564C0687461676765642D30D8F56A7461676765642D323435D930396C7461676765642D3132333435") {
+            assertEquals(4, startArray())
+            assertEquals("untagged", nextString())
+            assertEquals("tagged-0", nextString())
+            assertEquals("tagged-245", nextString())
+            assertEquals("tagged-12345", nextString())
+        }
+    }
+
+    @Test
+    fun testIgnoresTagsOnNumbers() {
+        /*
+         * 86                     # array(6)
+         * 18 7B                  # unsigned(123)
+         * C0                     # tag(0)
+         *    1A 0001E240         # unsigned(123456)
+         * D8 F5                  # tag(245)
+         *    1A 000F423F         # unsigned(999999)
+         * D9 3039                # tag(12345)
+         *    38 31               # negative(49)
+         * D8 22                  # tag(34)
+         *    FB 3FE161F9F01B866E # primitive(4603068020252444270)
+         * D9 0237                # tag(567)
+         *    FB 401999999999999A # primitive(4618891777831180698)
+         */
+        withDecoder("86187BC01A0001E240D8F51A000F423FD930393831D822FB3FE161F9F01B866ED90237FB401999999999999A") {
+            assertEquals(6, startArray())
+            assertEquals(123, nextNumber())
+            assertEquals(123456, nextNumber())
+            assertEquals(999999, nextNumber())
+            assertEquals(-50, nextNumber())
+            assertEquals(0.54321, nextDouble(), 0.00001)
+            assertEquals(6.4, nextDouble(), 0.00001)
+        }
+    }
+
+    @Test
+    fun testIgnoresTagsOnArraysAndMaps() {
+        /*
+         * A2                                  # map(2)
+         * 63                                  # text(3)
+         *    6D6170                           # "map"
+         * D8 7B                               # tag(123)
+         *    A1                               # map(1)
+         *       68                            # text(8)
+         *          74686973206D6170           # "this map"
+         *       6D                            # text(13)
+         *          69732074616767656420313233 # "is tagged 123"
+         * 65                                  # text(5)
+         *    6172726179                       # "array"
+         * DA 0012D687                         # tag(1234567)
+         *    83                               # array(3)
+         *       6A                            # text(10)
+         *          74686973206172726179       # "this array"
+         *       69                            # text(9)
+         *          697320746167676564         # "is tagged"
+         *       67                            # text(7)
+         *          31323334353637             # "1234567"
+         */
+        withDecoder("A2636D6170D87BA16874686973206D61706D69732074616767656420313233656172726179DA0012D687836A74686973206172726179696973207461676765646731323334353637") {
+            assertEquals(2, startMap())
+            assertEquals("map", nextString())
+            assertEquals(1, startMap())
+            assertEquals("this map", nextString())
+            assertEquals("is tagged 123", nextString())
+            assertEquals("array", nextString())
+            assertEquals(3, startArray())
+            assertEquals("this array", nextString())
+            assertEquals("is tagged", nextString())
+            assertEquals("1234567", nextString())
+        }
+    }
 }
 
 private fun CborDecoder.expect(expected: String) {


### PR DESCRIPTION
Currently, if the CBOR-encoded input contains any [tags](https://datatracker.ietf.org/doc/html/rfc7049#section-2.4) an exception will be thrown. The default behaviour should be to ignore any tags.