### PR TITLE
Add explicit module-info's for JPMS compatability

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30-RC")
+}
+
 kotlinDslPluginOptions {
     experimentalWarning.set(false)
 }

--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -97,7 +97,7 @@ object Java9Modularity {
                 val actualOutput = outputCaptureStream.toString(Charsets.UTF_8).trim()
 
                 if (actualOutput != expectedOutput) {
-                    throw IllegalStateException("Module-info does not match!\n$actualOutput")
+                    throw IllegalStateException("Module-info requirements section does not match!\n$actualOutput")
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -1,0 +1,108 @@
+import org.gradle.api.*
+import org.gradle.api.file.*
+import org.gradle.api.tasks.bundling.*
+import org.gradle.api.tasks.compile.*
+import org.gradle.kotlin.dsl.*
+import org.gradle.util.GUtil.*
+import org.jetbrains.kotlin.gradle.dsl.*
+import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.pm20.*
+import org.jetbrains.kotlin.gradle.targets.jvm.*
+import java.io.*
+import java.lang.module.*
+import java.util.spi.*
+
+object Java9Modularity {
+
+    @JvmStatic
+    @JvmOverloads
+    fun Project.configureJava9ModuleInfo(multiRelease: Boolean = true) {
+        val kotlin = extensions.findByType<KotlinProjectExtension>() ?: return
+        val jvmTargets = kotlin.targets.filter { it is KotlinJvmTarget || it is KotlinWithJavaTarget<*> }
+        if (jvmTargets.isEmpty()) {
+            logger.warn("No Kotlin JVM targets found, can't configure compilation of module-info!")
+        }
+        jvmTargets.forEach { target ->
+            target.compilations.forEach { compilation ->
+                val defaultSourceSet = compilation.defaultSourceSet.kotlin
+                val moduleInfoSourceFile = defaultSourceSet.find { it.name == "module-info.java" }
+
+                if (moduleInfoSourceFile == null) {
+                    logger.info("No module-info.java file found in ${defaultSourceSet.srcDirs}, can't configure compilation of module-info!")
+                } else {
+                    val targetName = toCamelCase(target.targetName)
+                    val compilationName = if (compilation.name != KotlinCompilation.MAIN_COMPILATION_NAME) toCamelCase(compilation.name) else ""
+                    val compileModuleInfoTaskName = "compile${compilationName}ModuleInfo$targetName"
+                    val checkModuleInfoTaskName = "check${compilationName}ModuleInfo$targetName"
+
+                    val compileKotlinTask = compilation.compileKotlinTask as AbstractCompile
+                    val modulePath = compileKotlinTask.classpath
+                    val moduleInfoClassFile = compileKotlinTask.destinationDirectory.file("module-info.class").get().asFile
+
+                    val compileModuleInfoTask = registerCompileModuleInfoTask(compileModuleInfoTaskName, modulePath, compileKotlinTask.destinationDirectory, moduleInfoSourceFile)
+                    tasks.getByName(compilation.compileAllTaskName).dependsOn(compileModuleInfoTask)
+
+                    val checkModuleInfoTask = registerCheckModuleInfoTask(checkModuleInfoTaskName, modulePath, moduleInfoClassFile)
+                    checkModuleInfoTask.configure { dependsOn(compilation.compileAllTaskName) }
+                    tasks.getByName("check").dependsOn(checkModuleInfoTask)
+                }
+            }
+
+            if (multiRelease) {
+                tasks.getByName<Jar>(target.artifactsTaskName) {
+                    rename("module-info.class", "META-INF/versions/9/module-info.class")
+                    manifest {
+                        attributes("Multi-Release" to true)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun Project.registerCompileModuleInfoTask(taskName: String, modulePath: FileCollection, destinationDir: DirectoryProperty, moduleInfoSourceFile: File) =
+        tasks.register(taskName, JavaCompile::class) {
+            dependsOn(modulePath)
+            source(moduleInfoSourceFile)
+            classpath = files()
+            destinationDirectory.set(destinationDir)
+            sourceCompatibility = JavaVersion.VERSION_1_9.toString()
+            targetCompatibility = JavaVersion.VERSION_1_9.toString()
+            doFirst {
+                options.compilerArgs = listOf(
+                    "--release", "9",
+                    "--module-path", modulePath.asPath,
+                    "-Xlint:-requires-transitive-automatic"
+                )
+            }
+        }
+
+    private fun Project.registerCheckModuleInfoTask(taskName: String, modulePath: FileCollection, moduleInfoClassFile: File) =
+        tasks.register(taskName) {
+            dependsOn(modulePath)
+            doLast {
+                val jdeps = ToolProvider.findFirst("jdeps").orElseThrow { IllegalStateException("Tool 'jdeps' is not available") }
+                val moduleDescriptor = moduleInfoClassFile.inputStream().use { ModuleDescriptor.read(it) }
+                val moduleName = moduleDescriptor.name()
+                val expectedOutput = moduleDescriptor.toJdepsOutput(moduleInfoClassFile)
+
+                val outputCaptureStream = ByteArrayOutputStream()
+                val printStream = PrintStream(outputCaptureStream, true, Charsets.UTF_8)
+                jdeps.run(
+                    printStream, printStream,
+                    "--multi-release", "9",
+                    "--module-path", (modulePath + files(moduleInfoClassFile.parentFile)).asPath,
+                    "--check", moduleName
+                )
+                val actualOutput = outputCaptureStream.toString(Charsets.UTF_8).trim()
+
+                if (actualOutput != expectedOutput) {
+                    throw IllegalStateException("Module-info does not match!\n$actualOutput")
+                }
+            }
+        }
+
+    private fun ModuleDescriptor.toJdepsOutput(file: File, separator: String = System.lineSeparator()) =
+        "${name()} (${file.parentFile.toURI().toString().replace("file:", "file://")})$separator  [Module descriptor]$separator" +
+                requires().sortedBy { it.name() }.joinToString(separator) { requirement -> "    requires $requirement;" }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,3 +42,5 @@ tasks.withType(Jar).named(kotlin.jvm().artifactsTaskName) {
         )
     }
 }
+
+Java9Modularity.configureJava9ModuleInfo(project)

--- a/core/jvmMain/src/module-info.java
+++ b/core/jvmMain/src/module-info.java
@@ -1,0 +1,10 @@
+module kotlinx.serialization.core {
+    requires transitive kotlin.stdlib;
+
+    exports kotlinx.serialization;
+    exports kotlinx.serialization.builtins;
+    exports kotlinx.serialization.descriptors;
+    exports kotlinx.serialization.encoding;
+    exports kotlinx.serialization.internal;
+    exports kotlinx.serialization.modules;
+}

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,5 +1,10 @@
 # Building Kotlin Serialization from the source
 
+## JDK version
+
+To build Kotlin Serialization JDK version 9 or higher is required.
+This is needed to compile the `module-info` file included for JPMS support.
+
 ## Runtime library
 
 Kotlin Serialization runtime library itself is a [multiplatform](http://kotlinlang.org/docs/reference/multiplatform.html) project.

--- a/formats/cbor/build.gradle
+++ b/formats/cbor/build.gradle
@@ -29,3 +29,5 @@ kotlin {
         }
     }
 }
+
+Java9Modularity.configureJava9ModuleInfo(project)

--- a/formats/cbor/jvmMain/src/module-info.java
+++ b/formats/cbor/jvmMain/src/module-info.java
@@ -1,0 +1,6 @@
+module kotlinx.serialization.cbor {
+    requires transitive kotlin.stdlib;
+    requires transitive kotlinx.serialization.core;
+
+    exports kotlinx.serialization.cbor;
+}

--- a/formats/hocon/build.gradle
+++ b/formats/hocon/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compile project(':kotlinx-serialization-core')
     api 'org.jetbrains.kotlin:kotlin-stdlib'
 
-    api 'com.typesafe:config:1.3.2'
+    api 'com.typesafe:config:1.4.1'
 
     testCompile "org.jetbrains.kotlin:kotlin-test"
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/formats/hocon/build.gradle
+++ b/formats/hocon/build.gradle
@@ -18,3 +18,5 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-test"
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
+
+Java9Modularity.configureJava9ModuleInfo(project)

--- a/formats/hocon/src/main/kotlin/module-info.java
+++ b/formats/hocon/src/main/kotlin/module-info.java
@@ -1,6 +1,7 @@
 module kotlinx.serialization.hocon {
     requires transitive kotlin.stdlib;
     requires transitive kotlinx.serialization.core;
+    requires transitive typesafe.config;
 
     exports kotlinx.serialization.hocon;
 }

--- a/formats/hocon/src/main/kotlin/module-info.java
+++ b/formats/hocon/src/main/kotlin/module-info.java
@@ -1,0 +1,6 @@
+module kotlinx.serialization.hocon {
+    requires transitive kotlin.stdlib;
+    requires transitive kotlinx.serialization.core;
+
+    exports kotlinx.serialization.hocon;
+}

--- a/formats/json/build.gradle
+++ b/formats/json/build.gradle
@@ -28,3 +28,5 @@ kotlin {
 compileTestKotlinJsLegacy {
     exclude '**/PropertyInitializerTest.kt'
 }
+
+Java9Modularity.configureJava9ModuleInfo(project)

--- a/formats/json/jvmMain/src/module-info.java
+++ b/formats/json/jvmMain/src/module-info.java
@@ -1,0 +1,6 @@
+module kotlinx.serialization.json {
+    requires transitive kotlin.stdlib;
+    requires transitive kotlinx.serialization.core;
+
+    exports kotlinx.serialization.json;
+}

--- a/formats/properties/build.gradle
+++ b/formats/properties/build.gradle
@@ -29,3 +29,5 @@ kotlin {
         }
     }
 }
+
+Java9Modularity.configureJava9ModuleInfo(project)

--- a/formats/properties/jvmMain/src/module-info.java
+++ b/formats/properties/jvmMain/src/module-info.java
@@ -1,0 +1,6 @@
+module kotlinx.serialization.properties {
+    requires transitive kotlin.stdlib;
+    requires transitive kotlinx.serialization.core;
+
+    exports kotlinx.serialization.properties;
+}

--- a/formats/protobuf/build.gradle
+++ b/formats/protobuf/build.gradle
@@ -46,3 +46,5 @@ sourceSets.test.proto {
 compileTestKotlinJvm {
     dependsOn 'generateTestProto'
 }
+
+Java9Modularity.configureJava9ModuleInfo(project)

--- a/formats/protobuf/jvmMain/src/module-info.java
+++ b/formats/protobuf/jvmMain/src/module-info.java
@@ -1,0 +1,7 @@
+module kotlinx.serialization.protobuf {
+    requires transitive kotlin.stdlib;
+    requires transitive kotlinx.serialization.core;
+
+    exports kotlinx.serialization.protobuf;
+    exports kotlinx.serialization.protobuf.schema;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ junit_version=4.12
 jackson_version=2.10.0.pr1
 dokka_version=1.4.20-multimodule-dev-7
 native.deploy=
-validator_version=0.5.0
+validator_version=0.7.1
 knit_version=0.2.2
 coroutines_version=1.3.9
 


### PR DESCRIPTION
In this pull request I added a few `module-info.java` files so the `kotlinx.serialization` library can be used in Java JPMS (Jigsaw) projects. I also extended the root `build.gradle` script so that the appropriate subprojects do a separate compilation of the `module-info.java` file. 

To maintain backwards compatibility with Java 8, I marked the resulting JAR as a multi-release JAR with the `module-info.class` moved to `META-INF/versions/9/module-info.class` which is similar as how it's done in the Kotlin stdlib.  See https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jdk8/build.gradle#L80, https://github.com/JetBrains/kotlin/blob/master/buildSrc/src/main/kotlin/LibrariesCommon.kt#L22 and https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jdk8/java9/module-info.java for more details.

Note that moving the `module-info.class` was / is not really necessary for JPMS to work, but I believe it's a bit cleaner than just adding the compiled `module-info.class` to the root of the JAR.

This change allows bundling projects using `jlink`, such as requested in https://github.com/Kotlin/kotlinx.serialization/issues/940. `jlink` requires that all dependencies are explicit JPMS (Jigsaw) modules. That means all JAR's must contain a `module-info.class`, automatic modules don't work with `jlink`. 
In 1 of my own projects I am trying to bundle an OpenJFX / TornadoFX application, which currently works using a SNAPSHOT version of this branch.

Note that at least JDK 9 is needed to build this branch (for compiling the `module-info.java` file). Existing code can of course be compiled using a Java 8 target. 