### PR TITLE
Fix wrong annotation reference

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/SerialFormat.kt
+++ b/core/commonMain/src/kotlinx/serialization/SerialFormat.kt
@@ -55,7 +55,7 @@ public interface BinaryFormat : SerialFormat {
     public fun <T> encodeToByteArray(serializer: SerializationStrategy<T>, value: T): ByteArray
 
     /**
-     * Decodes and deserializes the given [byte array][bytes] to to the value of type [T] using the given [deserializer]
+     * Decodes and deserializes the given [byte array][bytes] to the value of type [T] using the given [deserializer]
      */
     public fun <T> decodeFromByteArray(deserializer: DeserializationStrategy<T>, bytes: ByteArray): T
 }
@@ -79,7 +79,7 @@ public interface StringFormat : SerialFormat {
     public fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String
 
     /**
-     * Decodes and deserializes the given [string] to to the value of type [T] using the given [deserializer]
+     * Decodes and deserializes the given [string] to the value of type [T] using the given [deserializer]
      */
     public fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, string: String): T
 }
@@ -92,7 +92,7 @@ public inline fun <reified T> StringFormat.encodeToString(value: T): String =
     encodeToString(serializersModule.serializer(), value)
 
 /**
- * Decodes and deserializes the given [string] to to the value of type [T] using deserializer
+ * Decodes and deserializes the given [string] to the value of type [T] using deserializer
  * retrieved from the reified type parameter.
  */
 @OptIn(ExperimentalSerializationApi::class)
@@ -153,7 +153,7 @@ public inline fun <reified T> BinaryFormat.encodeToByteArray(value: T): ByteArra
     encodeToByteArray(serializersModule.serializer(), value)
 
 /**
- * Decodes and deserializes the given [byte array][bytes] to to the value of type [T] using deserializer
+ * Decodes and deserializes the given [byte array][bytes] to the value of type [T] using deserializer
  * retrieved from the reified type parameter.
  */
 @OptIn(ExperimentalSerializationApi::class)

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -979,7 +979,7 @@ This gets all the `Project` properties serialized:
 
 ### External serialization uses properties 
 
-As we saw earlier, the regular `@Serializer` annotation creates a serializer so that 
+As we saw earlier, the regular `@Serializable` annotation creates a serializer so that 
 [Backing fields are serialized](basic-serialization.md#backing-fields-are-serialized). _External_ serialization using 
 `Serializer(forClass = ...)` has no access to backing fields and works differently. 
 It serializes only _accessible_ properties that have setters or are part of the primary constructor. 

--- a/formats/README.md
+++ b/formats/README.md
@@ -15,6 +15,7 @@ For convenience, they have same `groupId`, versioning and release cycle as core 
 
 * Artifact id: `kotlinx-serialization-hocon`
 * Platform: JVM only
+* Status: experimental
 
 Allows deserialization of `Config` object from popular [lightbend/config](https://github.com/lightbend/config) library 
 into Kotlin objects.

--- a/formats/README.md
+++ b/formats/README.md
@@ -58,6 +58,14 @@ This library allows serialization and deserialization of objects to and from [Av
 
 Allows serialization and deserialization of objects to and from [BSON](https://docs.mongodb.com/manual/reference/bson-types/).
 
+### Ktoml 
+* GitHub repo: [akuleshov7/ktoml](https://github.com/akuleshov7/ktoml)
+* Artifact ID: `com.akuleshov7:ktoml-core`
+* Platforms: multiplatform, all Kotlin supported platforms
+
+Fully Native and Multiplatform Kotlin serialization library for serialization/deserialization of TOML format.
+This library contains no Java code and no Java dependencies and it implements multiplatform parser, decoder and encoder of TOML.
+
 ### Minecraft NBT (Multiplatform)
 
 * GitHub repo: [BenWoodworth/knbt](https://github.com/BenWoodworth/knbt)

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JsonStringBuilder.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JsonStringBuilder.kt
@@ -8,7 +8,7 @@ package kotlinx.serialization.json.internal
  * In order to encode a single string, it should be processed symbol-per-symbol,
  * in order to detect and escape unicode symbols.
  *
- * Doing naively, it drastically slows down strings processing due to to factors:
+ * Doing naively, it drastically slows down strings processing due to factors:
  * * Byte-by-byte copying that does not leverage optimized array copying
  * * A lot of range and flags checks due to Java's compact strings
  *


### PR DESCRIPTION
The text mentioned `@Serializer`, whereas from the context is was clear it must have been `@Serializable`.