### PR TITLE
Fix SerialFormat doc: Change `BinaryFormat` to `SerialFormat`

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/SerialFormat.kt
+++ b/core/commonMain/src/kotlinx/serialization/SerialFormat.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.modules.*
  * `SerialFormat` interface is not stable for inheritance in 3rd party libraries, as new methods
  * might be added to this interface or contracts of the existing methods can be changed.
  *
- * It is safe to operate with instances of `BinaryFormat` and call its methods.
+ * It is safe to operate with instances of `SerialFormat` and call its methods.
  */
 @ExperimentalSerializationApi
 public interface SerialFormat {


### PR DESCRIPTION
Fixed this line in the SerialFormat interface's documentation:
```
It is safe to operate with instances of `BinaryFormat` and call its methods.
                                         ^^^^^^^^^^^^
```
and changed it to SerialFormat.