### PR TITLE
Add polymorphic default serializers (as opposed to deserializers)

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -1176,7 +1176,6 @@ public final class kotlinx/serialization/modules/PolymorphicModuleBuilder {
 	public final fun buildTo (Lkotlinx/serialization/modules/SerializersModuleBuilder;)V
 	public final fun default (Lkotlin/jvm/functions/Function1;)V
 	public final fun defaultDeserializer (Lkotlin/jvm/functions/Function1;)V
-	public final fun defaultSerializer (Lkotlin/jvm/functions/Function1;)V
 	public final fun subclass (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 }
 

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -1175,6 +1175,8 @@ public final class kotlinx/serialization/modules/PolymorphicModuleBuilder {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public final fun buildTo (Lkotlinx/serialization/modules/SerializersModuleBuilder;)V
 	public final fun default (Lkotlin/jvm/functions/Function1;)V
+	public final fun defaultDeserializer (Lkotlin/jvm/functions/Function1;)V
+	public final fun defaultSerializer (Lkotlin/jvm/functions/Function1;)V
 	public final fun subclass (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 }
 
@@ -1195,6 +1197,8 @@ public final class kotlinx/serialization/modules/SerializersModuleBuilder : kotl
 	public final fun include (Lkotlinx/serialization/modules/SerializersModule;)V
 	public fun polymorphic (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public fun polymorphicDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun polymorphicDeserializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun polymorphicSerializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleBuildersKt {
@@ -1209,10 +1213,13 @@ public abstract interface class kotlinx/serialization/modules/SerializersModuleC
 	public abstract fun contextual (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public abstract fun polymorphic (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public abstract fun polymorphicDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun polymorphicDeserializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun polymorphicSerializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleCollector$DefaultImpls {
 	public static fun contextual (Lkotlinx/serialization/modules/SerializersModuleCollector;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
+	public static fun polymorphicDefault (Lkotlinx/serialization/modules/SerializersModuleCollector;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleKt {

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -1197,8 +1197,8 @@ public final class kotlinx/serialization/modules/SerializersModuleBuilder : kotl
 	public final fun include (Lkotlinx/serialization/modules/SerializersModule;)V
 	public fun polymorphic (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public fun polymorphicDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
-	public fun polymorphicDeserializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
-	public fun polymorphicSerializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun polymorphicDefaultDeserializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun polymorphicDefaultSerializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleBuildersKt {
@@ -1213,8 +1213,8 @@ public abstract interface class kotlinx/serialization/modules/SerializersModuleC
 	public abstract fun contextual (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public abstract fun polymorphic (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public abstract fun polymorphicDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
-	public abstract fun polymorphicDeserializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
-	public abstract fun polymorphicSerializerDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun polymorphicDefaultDeserializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun polymorphicDefaultSerializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleCollector$DefaultImpls {

--- a/core/commonMain/src/kotlinx/serialization/descriptors/ContextAware.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/ContextAware.kt
@@ -63,7 +63,8 @@ public fun SerializersModule.getContextualDescriptor(descriptor: SerialDescripto
 /**
  * Retrieves a collection of descriptors which serializers are registered for polymorphic serialization in [this]
  * with base class equal to [descriptor]'s [SerialDescriptor.capturedKClass].
- * This method does not retrieve serializers registered with [PolymorphicModuleBuilder.default].
+ * This method does not retrieve serializers registered with [PolymorphicModuleBuilder.defaultDeserializer]
+ * or [PolymorphicModuleBuilder.defaultSerializer].
  *
  * @see SerializersModule.getPolymorphic
  * @see SerializersModuleBuilder.polymorphic

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -55,25 +55,28 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
 
     /**
      * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
-     * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`
+     * [defaultSerializerProvider] is invoked when no polymorphic serializers associated with the `className`
      * were found. `className` could be `null` for formats that support nullable class discriminators
      * (currently only [Json] with [useArrayPolymorphism][JsonBuilder.useArrayPolymorphism] set to `false`)
      *
-     * [defaultDeserializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
+     * [defaultSerializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
+     *
+     * [defaultSerializerProvider] is named as such for backwards compatibility reasons; it provides deserializers.
      *
      * Typically, if the class is not registered in advance, it is not possible to know the structure of the unknown
      * type and have a precise serializer, so the default serializer has limited capabilities.
      * To have a structural access to the unknown data, it is recommended to use [JsonTransformingSerializer]
      * or [JsonContentPolymorphicSerializer] classes.
      *
-     * Default deserializers provider affects only deserialization process.
+     * Default deserializers provider affects only deserialization process. To affect serialization process, use
+     * [SerializersModuleBuilder.polymorphicDefaultSerializer].
      *
      * @see defaultDeserializer
      */
     @OptIn(ExperimentalSerializationApi::class)
     // TODO: deprecate in 1.4
-    public fun default(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
-        defaultDeserializer(defaultDeserializerProvider)
+    public fun default(defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
+        defaultDeserializer(defaultSerializerProvider)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -31,23 +31,6 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
     }
 
     /**
-     * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
-     * [defaultSerializerProvider] is invoked when no polymorphic serializers for `value` were found.
-     *
-     * [defaultSerializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
-     *
-     * Default serializers provider affects only serialization process.
-     */
-    @ExperimentalSerializationApi
-    @Suppress("UNCHECKED_CAST")
-    public fun defaultSerializer(defaultSerializerProvider: (value: @UnsafeVariance Base) -> SerializationStrategy<@UnsafeVariance Base>?) {
-        require(this.defaultSerializerProvider == null) {
-            "Default serializer provider is already registered for class $baseClass: ${this.defaultSerializerProvider}"
-        }
-        this.defaultSerializerProvider = defaultSerializerProvider
-    }
-
-    /**
      * Adds a default serializers provider associated with the given [baseClass] to the resulting module.
      * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`
      * were found. `className` could be `null` for formats that support nullable class discriminators

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -38,12 +38,13 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
      *
      * Default serializers provider affects only serialization process.
      */
+    @ExperimentalSerializationApi
     @Suppress("UNCHECKED_CAST")
-    public fun <T : Base> defaultSerializer(defaultSerializerProvider: (value: T) -> SerializationStrategy<T>?) {
+    public fun defaultSerializer(defaultSerializerProvider: (value: @UnsafeVariance Base) -> SerializationStrategy<@UnsafeVariance Base>?) {
         require(this.defaultSerializerProvider == null) {
             "Default serializer provider is already registered for class $baseClass: ${this.defaultSerializerProvider}"
         }
-        this.defaultSerializerProvider = defaultSerializerProvider as ((Base) -> SerializationStrategy<Base>?)
+        this.defaultSerializerProvider = defaultSerializerProvider
     }
 
     /**
@@ -61,6 +62,7 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
      *
      * Default deserializers provider affects only deserialization process.
      */
+    @ExperimentalSerializationApi
     public fun defaultDeserializer(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
         require(this.defaultDeserializerProvider == null) {
             "Default deserializer provider is already registered for class $baseClass: ${this.defaultDeserializerProvider}"
@@ -85,9 +87,8 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
      *
      * @see defaultDeserializer
      */
-    @Deprecated("Specify whether it's a default serializer/deserializer",
-        ReplaceWith("defaultDeserializer(defaultSerializerProvider)")
-    )
+    @OptIn(ExperimentalSerializationApi::class)
+    // TODO: deprecate in 1.4
     public fun default(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
         defaultDeserializer(defaultDeserializerProvider)
     }

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -20,7 +20,8 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
     private val baseSerializer: KSerializer<Base>? = null
 ) {
     private val subclasses: MutableList<Pair<KClass<out Base>, KSerializer<out Base>>> = mutableListOf()
-    private var defaultSerializerProvider: ((String?) -> DeserializationStrategy<out Base>?)? = null
+    private var defaultSerializerProvider: ((Base) -> SerializationStrategy<Base>?)? = null
+    private var defaultDeserializerProvider: ((String?) -> DeserializationStrategy<out Base>?)? = null
 
     /**
      * Registers a [subclass] [serializer] in the resulting module under the [base class][Base].
@@ -30,25 +31,65 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
     }
 
     /**
+     * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
+     * [defaultSerializerProvider] is invoked when no polymorphic serializers for `value` were found.
+     *
+     * [defaultSerializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
+     *
+     * Default serializers provider affects only serialization process.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public fun <T : Base> defaultSerializer(defaultSerializerProvider: (value: T) -> SerializationStrategy<T>?) {
+        require(this.defaultSerializerProvider == null) {
+            "Default serializer provider is already registered for class $baseClass: ${this.defaultSerializerProvider}"
+        }
+        this.defaultSerializerProvider = defaultSerializerProvider as ((Base) -> SerializationStrategy<Base>?)
+    }
+
+    /**
      * Adds a default serializers provider associated with the given [baseClass] to the resulting module.
-     * [defaultSerializerProvider] is invoked when no polymorphic serializers associated with the `className`
+     * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`
      * were found. `className` could be `null` for formats that support nullable class discriminators
      * (currently only [Json] with [useArrayPolymorphism][JsonBuilder.useArrayPolymorphism] set to `false`)
      *
-     * [defaultSerializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
+     * [defaultDeserializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
      *
      * Typically, if the class is not registered in advance, it is not possible to know the structure of the unknown
      * type and have a precise serializer, so the default serializer has limited capabilities.
      * To have a structural access to the unknown data, it is recommended to use [JsonTransformingSerializer]
      * or [JsonContentPolymorphicSerializer] classes.
      *
-     * Default serializers provider affects only deserialization process.
+     * Default deserializers provider affects only deserialization process.
      */
-    public fun default(defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
-        require(this.defaultSerializerProvider == null) {
-            "Default serializer provider is already registered for class $baseClass: ${this.defaultSerializerProvider}"
+    public fun defaultDeserializer(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
+        require(this.defaultDeserializerProvider == null) {
+            "Default deserializer provider is already registered for class $baseClass: ${this.defaultDeserializerProvider}"
         }
-        this.defaultSerializerProvider = defaultSerializerProvider
+        this.defaultDeserializerProvider = defaultDeserializerProvider
+    }
+
+    /**
+     * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
+     * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`
+     * were found. `className` could be `null` for formats that support nullable class discriminators
+     * (currently only [Json] with [useArrayPolymorphism][JsonBuilder.useArrayPolymorphism] set to `false`)
+     *
+     * [defaultDeserializerProvider] can be stateful and lookup a serializer for the missing type dynamically.
+     *
+     * Typically, if the class is not registered in advance, it is not possible to know the structure of the unknown
+     * type and have a precise serializer, so the default serializer has limited capabilities.
+     * To have a structural access to the unknown data, it is recommended to use [JsonTransformingSerializer]
+     * or [JsonContentPolymorphicSerializer] classes.
+     *
+     * Default deserializers provider affects only deserialization process.
+     *
+     * @see defaultDeserializer
+     */
+    @Deprecated("Specify whether it's a default serializer/deserializer",
+        ReplaceWith("defaultDeserializer(defaultSerializerProvider)")
+    )
+    public fun default(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
+        defaultDeserializer(defaultDeserializerProvider)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -63,9 +104,14 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
             )
         }
 
-        val default = defaultSerializerProvider
-        if (default != null) {
-            builder.registerDefaultPolymorphicSerializer(baseClass, default, false)
+        val defaultSerializer = defaultSerializerProvider
+        if (defaultSerializer != null) {
+            builder.registerDefaultPolymorphicSerializer(baseClass, defaultSerializer, false)
+        }
+
+        val defaultDeserializer = defaultDeserializerProvider
+        if (defaultDeserializer != null) {
+            builder.registerDefaultPolymorphicDeserializer(baseClass, defaultDeserializer, false)
         }
     }
 }

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -71,7 +71,7 @@ public sealed class SerializersModule {
  */
 @SharedImmutable
 @ExperimentalSerializationApi
-public val EmptySerializersModule: SerializersModule = SerialModuleImpl(emptyMap(), emptyMap(), emptyMap(), emptyMap())
+public val EmptySerializersModule: SerializersModule = SerialModuleImpl(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap())
 
 /**
  * Returns a combination of two serial modules
@@ -113,11 +113,18 @@ public infix fun SerializersModule.overwriteWith(other: SerializersModule): Seri
             registerPolymorphicSerializer(baseClass, actualClass, actualSerializer, allowOverwrite = true)
         }
 
-        override fun <Base : Any> polymorphicDefault(
+        override fun <Base : Any> polymorphicSerializerDefault(
             baseClass: KClass<Base>,
-            defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
+            defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
         ) {
             registerDefaultPolymorphicSerializer(baseClass, defaultSerializerProvider, allowOverwrite = true)
+        }
+
+        override fun <Base : Any> polymorphicDeserializerDefault(
+            baseClass: KClass<Base>,
+            defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
+        ) {
+            registerDefaultPolymorphicDeserializer(baseClass, defaultDeserializerProvider, allowOverwrite = true)
         }
     })
 }
@@ -133,13 +140,18 @@ public infix fun SerializersModule.overwriteWith(other: SerializersModule): Seri
 internal class SerialModuleImpl(
     private val class2ContextualFactory: Map<KClass<*>, ContextualProvider>,
     @JvmField val polyBase2Serializers: Map<KClass<*>, Map<KClass<*>, KSerializer<*>>>,
+    private val polyBase2DefaultSerializerProvider: Map<KClass<*>, PolymorphicSerializerProvider<*>>,
     private val polyBase2NamedSerializers: Map<KClass<*>, Map<String, KSerializer<*>>>,
-    private val polyBase2DefaultProvider: Map<KClass<*>, PolymorphicProvider<*>>
+    private val polyBase2DefaultDeserializerProvider: Map<KClass<*>, PolymorphicDeserializerProvider<*>>
 ) : SerializersModule() {
 
     override fun <T : Any> getPolymorphic(baseClass: KClass<in T>, value: T): SerializationStrategy<T>? {
         if (!value.isInstanceOf(baseClass)) return null
-        return polyBase2Serializers[baseClass]?.get(value::class) as? SerializationStrategy<T>
+        // Registered
+        val registered = polyBase2Serializers[baseClass]?.get(value::class) as? SerializationStrategy<T>
+        if (registered != null) return registered
+        // Default
+        return (polyBase2DefaultSerializerProvider[baseClass] as? PolymorphicSerializerProvider<T>)?.invoke(value)
     }
 
     override fun <T : Any> getPolymorphic(baseClass: KClass<in T>, serializedClassName: String?): DeserializationStrategy<out T>? {
@@ -147,7 +159,7 @@ internal class SerialModuleImpl(
         val registered = polyBase2NamedSerializers[baseClass]?.get(serializedClassName) as? KSerializer<out T>
         if (registered != null) return registered
         // Default
-        return (polyBase2DefaultProvider[baseClass] as? PolymorphicProvider<T>)?.invoke(serializedClassName)
+        return (polyBase2DefaultDeserializerProvider[baseClass] as? PolymorphicDeserializerProvider<T>)?.invoke(serializedClassName)
     }
 
     override fun <T : Any> getContextual(kClass: KClass<T>, typeArgumentsSerializers: List<KSerializer<*>>): KSerializer<T>? {
@@ -175,13 +187,18 @@ internal class SerialModuleImpl(
             }
         }
 
-        polyBase2DefaultProvider.forEach { (baseClass, provider) ->
-            collector.polymorphicDefault(baseClass as KClass<Any>, provider as (PolymorphicProvider<out Any>))
+        polyBase2DefaultSerializerProvider.forEach { (baseClass, provider) ->
+            collector.polymorphicSerializerDefault(baseClass as KClass<Any>, provider as (PolymorphicSerializerProvider<Any>))
+        }
+
+        polyBase2DefaultDeserializerProvider.forEach { (baseClass, provider) ->
+            collector.polymorphicDeserializerDefault(baseClass as KClass<Any>, provider as (PolymorphicDeserializerProvider<out Any>))
         }
     }
 }
 
-internal typealias PolymorphicProvider<Base> = (className: String?) -> DeserializationStrategy<out Base>?
+internal typealias PolymorphicDeserializerProvider<Base> = (className: String?) -> DeserializationStrategy<out Base>?
+internal typealias PolymorphicSerializerProvider<Base> = (value: Base) -> SerializationStrategy<Base>?
 
 /** This class is needed to support re-registering the same static (argless) serializers:
  *

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -113,14 +113,14 @@ public infix fun SerializersModule.overwriteWith(other: SerializersModule): Seri
             registerPolymorphicSerializer(baseClass, actualClass, actualSerializer, allowOverwrite = true)
         }
 
-        override fun <Base : Any> polymorphicSerializerDefault(
+        override fun <Base : Any> polymorphicDefaultSerializer(
             baseClass: KClass<Base>,
             defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
         ) {
             registerDefaultPolymorphicSerializer(baseClass, defaultSerializerProvider, allowOverwrite = true)
         }
 
-        override fun <Base : Any> polymorphicDeserializerDefault(
+        override fun <Base : Any> polymorphicDefaultDeserializer(
             baseClass: KClass<Base>,
             defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
         ) {
@@ -188,11 +188,11 @@ internal class SerialModuleImpl(
         }
 
         polyBase2DefaultSerializerProvider.forEach { (baseClass, provider) ->
-            collector.polymorphicSerializerDefault(baseClass as KClass<Any>, provider as (PolymorphicSerializerProvider<Any>))
+            collector.polymorphicDefaultSerializer(baseClass as KClass<Any>, provider as (PolymorphicSerializerProvider<Any>))
         }
 
         polyBase2DefaultDeserializerProvider.forEach { (baseClass, provider) ->
-            collector.polymorphicDeserializerDefault(baseClass as KClass<Any>, provider as (PolymorphicDeserializerProvider<out Any>))
+            collector.polymorphicDefaultDeserializer(baseClass as KClass<Any>, provider as (PolymorphicDeserializerProvider<out Any>))
         }
     }
 }

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -94,9 +94,12 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
      * Adds a default serializers provider associated with the given [baseClass] to the resulting module.
      * [defaultSerializerProvider] is invoked when no polymorphic serializers for `value` were found.
      *
+     * This will not affect deserialization.
+     *
      * @see PolymorphicModuleBuilder.defaultSerializer
      */
-    public override fun <Base : Any> polymorphicSerializerDefault(
+    @ExperimentalSerializationApi
+    public override fun <Base : Any> polymorphicDefaultSerializer(
         baseClass: KClass<Base>,
         defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
     ) {
@@ -107,11 +110,14 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
      * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
      * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`
      * were found. `className` could be `null` for formats that support nullable class discriminators
-     * (currently only `Json` with `useArrayPolymorphism` set to `false`)
+     * (currently only `Json` with `useArrayPolymorphism` set to `false`).
+     *
+     * This will not affect serialization.
      *
      * @see PolymorphicModuleBuilder.defaultDeserializer
      */
-    public override fun <Base : Any> polymorphicDeserializerDefault(
+    @ExperimentalSerializationApi
+    public override fun <Base : Any> polymorphicDefaultDeserializer(
         baseClass: KClass<Base>,
         defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
     ) {

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -95,8 +95,6 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
      * [defaultSerializerProvider] is invoked when no polymorphic serializers for `value` were found.
      *
      * This will not affect deserialization.
-     *
-     * @see PolymorphicModuleBuilder.defaultSerializer
      */
     @ExperimentalSerializationApi
     public override fun <Base : Any> polymorphicDefaultSerializer(

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
@@ -48,10 +48,13 @@ public interface SerializersModuleCollector {
     /**
      * Accept a default serializer provider, associated with the [baseClass] for polymorphic serialization.
      *
-     * @see SerializersModuleBuilder.polymorphicSerializerDefault
+     * This will not affect deserialization.
+     *
+     * @see SerializersModuleBuilder.polymorphicDefaultSerializer
      * @see PolymorphicModuleBuilder.defaultSerializer
      */
-    public fun <Base : Any> polymorphicSerializerDefault(
+    @ExperimentalSerializationApi
+    public fun <Base : Any> polymorphicDefaultSerializer(
         baseClass: KClass<Base>,
         defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
     )
@@ -59,21 +62,30 @@ public interface SerializersModuleCollector {
     /**
      * Accept a default deserializer provider, associated with the [baseClass] for polymorphic deserialization.
      *
-     * @see SerializersModuleBuilder.polymorphicDeserializerDefault
+     * This will not affect serialization.
+     *
+     * @see SerializersModuleBuilder.polymorphicDefaultDeserializer
      * @see PolymorphicModuleBuilder.defaultDeserializer
      */
-    public fun <Base : Any> polymorphicDeserializerDefault(
+    @ExperimentalSerializationApi
+    public fun <Base : Any> polymorphicDefaultDeserializer(
         baseClass: KClass<Base>,
         defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
     )
 
-    @Deprecated("Specify whether using deserializer or serializer",
-        ReplaceWith("polymorphicDeserializerDefault(baseClass, defaultSerializerProvider)")
-    )
+    /**
+     * Accept a default deserializer provider, associated with the [baseClass] for polymorphic deserialization.
+     *
+     * This will not affect serialization.
+     *
+     * @see SerializersModuleBuilder.polymorphicDefaultDeserializer
+     * @see PolymorphicModuleBuilder.defaultDeserializer
+     */
+    // TODO: deprecate in 1.4
     public fun <Base : Any> polymorphicDefault(
         baseClass: KClass<Base>,
         defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
     ) {
-        polymorphicDeserializerDefault(baseClass, defaultDeserializerProvider)
+        polymorphicDefaultDeserializer(baseClass, defaultDeserializerProvider)
     }
 }

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
@@ -48,11 +48,32 @@ public interface SerializersModuleCollector {
     /**
      * Accept a default serializer provider, associated with the [baseClass] for polymorphic serialization.
      *
-     * @see SerializersModuleBuilder.polymorphicDefault
-     * @see PolymorphicModuleBuilder.default
+     * @see SerializersModuleBuilder.polymorphicSerializerDefault
+     * @see PolymorphicModuleBuilder.defaultSerializer
      */
+    public fun <Base : Any> polymorphicSerializerDefault(
+        baseClass: KClass<Base>,
+        defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
+    )
+
+    /**
+     * Accept a default deserializer provider, associated with the [baseClass] for polymorphic deserialization.
+     *
+     * @see SerializersModuleBuilder.polymorphicDeserializerDefault
+     * @see PolymorphicModuleBuilder.defaultDeserializer
+     */
+    public fun <Base : Any> polymorphicDeserializerDefault(
+        baseClass: KClass<Base>,
+        defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
+    )
+
+    @Deprecated("Specify whether using deserializer or serializer",
+        ReplaceWith("polymorphicDeserializerDefault(baseClass, defaultSerializerProvider)")
+    )
     public fun <Base : Any> polymorphicDefault(
         baseClass: KClass<Base>,
-        defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
-    )
+        defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
+    ) {
+        polymorphicDeserializerDefault(baseClass, defaultDeserializerProvider)
+    }
 }

--- a/core/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/modules/ModuleBuildersTest.kt
@@ -279,13 +279,13 @@ class ModuleBuildersTest {
     fun testPolymorphicCollision() {
         val m1 = SerializersModule {
             polymorphic<Any>(Any::class) {
-                default { _ -> Unit.serializer() }
+                defaultDeserializer { _ -> Unit.serializer() }
             }
         }
 
         val m2 = SerializersModule {
             polymorphic<Any>(Any::class) {
-                default { _ -> Unit.serializer() }
+                defaultDeserializer { _ -> Unit.serializer() }
             }
         }
 
@@ -297,7 +297,7 @@ class ModuleBuildersTest {
         val defaultSerializerProvider = { _: String? -> Unit.serializer() }
         val m1 = SerializersModule {
             polymorphic(Any::class) {
-                default(defaultSerializerProvider)
+                defaultDeserializer(defaultSerializerProvider)
             }
         }
 

--- a/docs/polymorphism.md
+++ b/docs/polymorphism.md
@@ -938,21 +938,19 @@ object AnimalProvider {
 }
 ```
 
-We register a default serializer handler using the [`defaultSerializer`][PolymorphicModuleBuilder.defaultSerializer] function in
-the [`polymorphic { ... }`][PolymorphicModuleBuilder] DSL that defines a strategy which takes an instance of the base class and
+We register a default serializer handler using the [`polymorphicDefaultSerializer`][SerializersModuleBuilder.polymorphicDefaultSerializer] function in
+the [`SerializersModule { ... }`][SerializersModuleBuilder] DSL that defines a strategy which takes an instance of the base class and
 provides a [serialization strategy][SerializationStrategy]. In the below example we use a `when` block to check the type of the
 instance, without ever having to refer to the private implementation classes.
 
 ```kotlin
 val module = SerializersModule {
-    polymorphic(Animal::class) {
+    polymorphicDefaultSerializer(Animal::class) { instance ->
         @Suppress("UNCHECKED_CAST")
-        defaultSerializer { instance: Animal ->
-            when (instance) {
-                is Cat -> CatSerializer as SerializationStrategy<Animal>
-                is Dog -> DogSerializer as SerializationStrategy<Animal>
-                else -> null
-            }
+        when (instance) {
+            is Cat -> CatSerializer as SerializationStrategy<Animal>
+            is Dog -> DogSerializer as SerializationStrategy<Animal>
+            else -> null
         }
     }
 }
@@ -1022,7 +1020,8 @@ The next chapter covers [JSON features](json.md).
 [SerializersModuleBuilder.include]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-serializers-module-builder/include.html
 [PolymorphicModuleBuilder.defaultDeserializer]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/default-deserializer.html
 [PolymorphicModuleBuilder]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/index.html
-[PolymorphicModuleBuilder.defaultSerializer]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/default-serializer.html
+[SerializersModuleBuilder.polymorphicDefaultSerializer]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-serializers-module-builder/polymorphic-default-serializer.html
+[SerializersModuleBuilder]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-serializers-module-builder/index.html
 <!--- MODULE /kotlinx-serialization-json -->
 <!--- INDEX kotlinx-serialization-json/kotlinx.serialization.json -->
 [Json.encodeToString]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-json/kotlinx-serialization-json/kotlinx.serialization.json/-json/encode-to-string.html

--- a/docs/polymorphism.md
+++ b/docs/polymorphism.md
@@ -904,7 +904,7 @@ on [Maintaining custom JSON attributes](json.md#maintaining-custom-json-attribut
 ### Default polymorphic type handler for serialization
 
 Sometimes you need to dynamically choose which serializer to use for a polymorphic type based on the instance, for example if you
-don't have access to the full type hierarchy, or if it changes a lot. For this situation, you can use serializer defaults.
+don't have access to the full type hierarchy, or if it changes a lot. For this situation, you can register a default serializer.
 
 <!--- INCLUDE
 import kotlinx.serialization.descriptors.*

--- a/docs/polymorphism.md
+++ b/docs/polymorphism.md
@@ -26,6 +26,7 @@ In this chapter we'll see how Kotlin Serialization deals with polymorphic class 
   * [Polymorphism and generic classes](#polymorphism-and-generic-classes)
   * [Merging library serializers modules](#merging-library-serializers-modules)
   * [Default polymorphic type handler for deserialization](#default-polymorphic-type-handler-for-deserialization)
+  * [Default polymorphic type handler for serialization](#default-polymorphic-type-handler-for-serialization)
 
 <!--- END -->
 
@@ -854,7 +855,7 @@ data class BasicProject(override val name: String, val type: String): Project()
 data class OwnedProject(override val name: String, val owner: String) : Project()
 ```
 
-We register a default handler using the [`default`][PolymorphicModuleBuilder.default] function in
+We register a default deserializer handler using the [`defaultDeserializer`][PolymorphicModuleBuilder.defaultDeserializer] function in
 the [`polymorphic { ... }`][PolymorphicModuleBuilder] DSL that defines a strategy which maps the `type` string from the input
 to the [deserialization strategy][DeserializationStrategy]. In the below example we don't use the type,
 but always return the [Plugin-generated serializer](serializers.md#plugin-generated-serializer)
@@ -864,7 +865,7 @@ of the `BasicProject` class.
 val module = SerializersModule {
     polymorphic(Project::class) {
         subclass(OwnedProject::class)
-        default { BasicProject.serializer() }
+        defaultDeserializer { BasicProject.serializer() }
     }
 }
 ```
@@ -895,10 +896,110 @@ Notice, how `BasicProject` had also captured the specified type key in its `type
 
 <!--- TEST -->
 
-We used a plugin-generated serializer as a default serializer, implying that 
+We used a plugin-generated serializer as a default serializer, implying that
 the structure of the "unknown" data is known in advance. In a real-world API it's rarely the case.
 For that purpose a custom, less-structured serializer is needed. You will see the example of such serializer in the future section
 on [Maintaining custom JSON attributes](json.md#maintaining-custom-json-attributes).
+
+### Default polymorphic type handler for serialization
+
+Sometimes you need to dynamically choose which serializer to use for a polymorphic type based on the instance, for example if you
+don't have access to the full type hierarchy, or if it changes a lot. For this situation, you can use serializer defaults.
+
+<!--- INCLUDE
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+-->
+
+```kotlin
+interface Animal {
+}
+
+interface Cat : Animal {
+    val catType: String
+}
+
+interface Dog : Animal {
+    val dogType: String
+}
+
+private class CatImpl : Cat {
+    override val catType: String = "Tabby"
+}
+
+private class DogImpl : Dog {
+    override val dogType: String = "Husky"
+}
+
+object AnimalProvider {
+    fun createCat(): Cat = CatImpl()
+    fun createDog(): Dog = DogImpl()
+}
+```
+
+We register a default serializer handler using the [`defaultSerializer`][PolymorphicModuleBuilder.defaultSerializer] function in
+the [`polymorphic { ... }`][PolymorphicModuleBuilder] DSL that defines a strategy which takes an instance of the base class and
+provides a [serialization strategy][SerializationStrategy]. In the below example we use a `when` block to check the type of the
+instance, without ever having to refer to the private implementation classes.
+
+```kotlin
+val module = SerializersModule {
+    polymorphic(Animal::class) {
+        @Suppress("UNCHECKED_CAST")
+        defaultSerializer { instance: Animal ->
+            when (instance) {
+                is Cat -> CatSerializer as SerializationStrategy<Animal>
+                is Dog -> DogSerializer as SerializationStrategy<Animal>
+                else -> null
+            }
+        }
+    }
+}
+
+object CatSerializer : SerializationStrategy<Cat> {
+    override val descriptor = buildClassSerialDescriptor("Cat") {
+        element<String>("catType")
+    }
+  
+    override fun serialize(encoder: Encoder, value: Cat) {
+        encoder.encodeStructure(descriptor) {
+          encodeStringElement(descriptor, 0, value.catType)
+        }
+    }
+}
+
+object DogSerializer : SerializationStrategy<Dog> {
+  override val descriptor = buildClassSerialDescriptor("Dog") {
+    element<String>("dogType")
+  }
+
+  override fun serialize(encoder: Encoder, value: Dog) {
+    encoder.encodeStructure(descriptor) {
+      encodeStringElement(descriptor, 0, value.dogType)
+    }
+  }
+}
+```
+
+Using this module we can now serialize instances of `Cat` and `Dog`.
+
+```kotlin
+val format = Json { serializersModule = module }
+
+fun main() {
+    println(format.encodeToString<Animal>(AnimalProvider.createCat()))
+}
+```
+
+> You can get the full code [here](../guide/example/example-poly-20.kt)
+
+```text
+{"type":"Cat","catType":"Tabby"}
+```
+
+
+<!--- TEST -->
 
 ---
 
@@ -911,6 +1012,7 @@ The next chapter covers [JSON features](json.md).
 [Serializable]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization/-serializable/index.html
 [Polymorphic]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization/-polymorphic/index.html
 [DeserializationStrategy]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization/-deserialization-strategy/index.html
+[SerializationStrategy]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization/-serialization-strategy/index.html
 <!--- INDEX kotlinx-serialization-core/kotlinx.serialization.modules -->
 [SerializersModule]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-serializers-module/index.html
 [SerializersModule()]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-serializers-module.html
@@ -918,8 +1020,9 @@ The next chapter covers [JSON features](json.md).
 [subclass]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/subclass.html
 [plus]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/plus.html
 [SerializersModuleBuilder.include]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-serializers-module-builder/include.html
-[PolymorphicModuleBuilder.default]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/default.html
+[PolymorphicModuleBuilder.defaultDeserializer]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/default-deserializer.html
 [PolymorphicModuleBuilder]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/index.html
+[PolymorphicModuleBuilder.defaultSerializer]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/default-serializer.html
 <!--- MODULE /kotlinx-serialization-json -->
 <!--- INDEX kotlinx-serialization-json/kotlinx.serialization.json -->
 [Json.encodeToString]: https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-json/kotlinx-serialization-json/kotlinx.serialization.json/-json/encode-to-string.html

--- a/docs/serialization-guide.md
+++ b/docs/serialization-guide.md
@@ -99,6 +99,7 @@ Once the project is set up, we can start serializing some classes.
   * <a name='polymorphism-and-generic-classes'></a>[Polymorphism and generic classes](polymorphism.md#polymorphism-and-generic-classes)
   * <a name='merging-library-serializers-modules'></a>[Merging library serializers modules](polymorphism.md#merging-library-serializers-modules)
   * <a name='default-polymorphic-type-handler-for-deserialization'></a>[Default polymorphic type handler for deserialization](polymorphism.md#default-polymorphic-type-handler-for-deserialization)
+  * <a name='default-polymorphic-type-handler-for-serialization'></a>[Default polymorphic type handler for serialization](polymorphism.md#default-polymorphic-type-handler-for-serialization)
 <!--- END -->
 
 **Chapter 5.** [JSON Features](json.md)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphismValidator.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphismValidator.kt
@@ -74,14 +74,14 @@ internal class PolymorphismValidator(
         }
     }
 
-    override fun <Base : Any> polymorphicSerializerDefault(
+    override fun <Base : Any> polymorphicDefaultSerializer(
         baseClass: KClass<Base>,
         defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
     ) {
         // Nothing here
     }
 
-    override fun <Base : Any> polymorphicDeserializerDefault(
+    override fun <Base : Any> polymorphicDefaultDeserializer(
         baseClass: KClass<Base>,
         defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
     ) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphismValidator.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphismValidator.kt
@@ -74,9 +74,16 @@ internal class PolymorphismValidator(
         }
     }
 
-    override fun <Base : Any> polymorphicDefault(
+    override fun <Base : Any> polymorphicSerializerDefault(
         baseClass: KClass<Base>,
-        defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
+        defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
+    ) {
+        // Nothing here
+    }
+
+    override fun <Base : Any> polymorphicDeserializerDefault(
+        baseClass: KClass<Base>,
+        defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
     ) {
         // Nothing here
     }

--- a/formats/json/commonTest/src/kotlinx/serialization/PolymorphismTestData.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/PolymorphismTestData.kt
@@ -32,6 +32,8 @@ open class PolyBase(val id: Int) {
 @Serializable
 data class PolyDefault(val json: JsonElement) : PolyBase(-1)
 
+class PolyDefaultWithId(id: Int) : PolyBase(id)
+
 @Serializable
 data class PolyDerived(val s: String) : PolyBase(1)
 

--- a/formats/json/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
@@ -83,7 +83,7 @@ class PolymorphismTest : JsonTestBase() {
     @Test
     fun testDefaultDeserializer() = parametrizedTest { jsonTestingMode ->
         val withDefault = module + SerializersModule {
-            polymorphicDeserializerDefault(PolyBase::class) { name ->
+            polymorphicDefaultDeserializer(PolyBase::class) { name ->
                 if (name == "foo") {
                     PolyDefaultDeserializer
                 } else {
@@ -107,7 +107,7 @@ class PolymorphismTest : JsonTestBase() {
     fun testDefaultDeserializerForMissingDiscriminator() = parametrizedTest { jsonTestingMode ->
         val json = Json {
             serializersModule = module + SerializersModule {
-                polymorphicDeserializerDefault(PolyBase::class) { name ->
+                polymorphicDefaultDeserializer(PolyBase::class) { name ->
                     if (name == null) {
                         PolyDefaultDeserializer
                     } else {
@@ -127,7 +127,7 @@ class PolymorphismTest : JsonTestBase() {
     fun testDefaultSerializer() = parametrizedTest { jsonTestingMode ->
         val json = Json {
             serializersModule = module + SerializersModule {
-                polymorphicSerializerDefault(PolyBase::class) { value ->
+                polymorphicDefaultSerializer(PolyBase::class) { value ->
                     if (value.id % 2 == 0) {
                         EvenDefaultSerializer
                     } else {

--- a/formats/json/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/features/PolymorphismTest.kt
@@ -5,6 +5,8 @@
 package kotlinx.serialization.features
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 import kotlinx.serialization.test.*
@@ -47,19 +49,43 @@ class PolymorphismTest : JsonTestBase() {
         assertEquals("""["kotlinx.serialization.PolyDerived",{"id":1,"s":"b"}]""", s)
     }
 
-    object PolyDefaultSerializer : JsonTransformingSerializer<PolyDefault>(PolyDefault.serializer()) {
+    object PolyDefaultDeserializer : JsonTransformingSerializer<PolyDefault>(PolyDefault.serializer()) {
         override fun transformDeserialize(element: JsonElement): JsonElement = buildJsonObject {
             put("json", JsonObject(element.jsonObject.filterKeys { it != "type" }))
             put("id", 42)
         }
     }
 
+    object EvenDefaultSerializer : SerializationStrategy<PolyBase> {
+        override val descriptor = buildClassSerialDescriptor("even") {
+            element<String>("parity")
+        }
+
+        override fun serialize(encoder: Encoder, value: PolyBase) {
+            encoder.encodeStructure(descriptor) {
+                encodeStringElement(descriptor, 0, "even")
+            }
+        }
+    }
+
+    object OddDefaultSerializer : SerializationStrategy<PolyBase> {
+        override val descriptor = buildClassSerialDescriptor("odd") {
+            element<String>("parity")
+        }
+
+        override fun serialize(encoder: Encoder, value: PolyBase) {
+            encoder.encodeStructure(descriptor) {
+                encodeStringElement(descriptor, 0, "odd")
+            }
+        }
+    }
+
     @Test
-    fun testDefaultSerializer() = parametrizedTest { jsonTestingMode ->
+    fun testDefaultDeserializer() = parametrizedTest { jsonTestingMode ->
         val withDefault = module + SerializersModule {
-            polymorphicDefault(PolyBase::class) { name ->
+            polymorphicDeserializerDefault(PolyBase::class) { name ->
                 if (name == "foo") {
-                    PolyDefaultSerializer
+                    PolyDefaultDeserializer
                 } else {
                     null
                 }
@@ -78,12 +104,12 @@ class PolymorphismTest : JsonTestBase() {
     }
 
     @Test
-    fun testDefaultSerializerForMissingDiscriminator() = parametrizedTest { jsonTestingMode ->
+    fun testDefaultDeserializerForMissingDiscriminator() = parametrizedTest { jsonTestingMode ->
         val json = Json {
             serializersModule = module + SerializersModule {
-                polymorphicDefault(PolyBase::class) { name ->
+                polymorphicDeserializerDefault(PolyBase::class) { name ->
                     if (name == null) {
-                        PolyDefaultSerializer
+                        PolyDefaultDeserializer
                     } else {
                         null
                     }
@@ -95,5 +121,26 @@ class PolymorphismTest : JsonTestBase() {
             "polyBase2":{"key":42}}""".trimIndent()
         val result = json.decodeFromString(Wrapper.serializer(), string, jsonTestingMode)
         assertEquals(Wrapper(PolyBase(239), PolyDefault(JsonObject(mapOf("key" to JsonPrimitive(42))))), result)
+    }
+
+    @Test
+    fun testDefaultSerializer() = parametrizedTest { jsonTestingMode ->
+        val json = Json {
+            serializersModule = module + SerializersModule {
+                polymorphicSerializerDefault(PolyBase::class) { value ->
+                    if (value.id % 2 == 0) {
+                        EvenDefaultSerializer
+                    } else {
+                        OddDefaultSerializer
+                    }
+                }
+            }
+        }
+        val obj = Wrapper(
+            PolyDefaultWithId(0),
+            PolyDefaultWithId(1)
+        )
+        val s = json.encodeToString(Wrapper.serializer(), obj, jsonTestingMode)
+        assertEquals("""{"polyBase1":{"type":"even","parity":"even"},"polyBase2":{"type":"odd","parity":"odd"}}""", s)
     }
 }

--- a/guide/example/example-poly-19.kt
+++ b/guide/example/example-poly-19.kt
@@ -21,7 +21,7 @@ data class OwnedProject(override val name: String, val owner: String) : Project(
 val module = SerializersModule {
     polymorphic(Project::class) {
         subclass(OwnedProject::class)
-        default { BasicProject.serializer() }
+        defaultDeserializer { BasicProject.serializer() }
     }
 }
 

--- a/guide/example/example-poly-20.kt
+++ b/guide/example/example-poly-20.kt
@@ -33,14 +33,12 @@ object AnimalProvider {
 }
 
 val module = SerializersModule {
-    polymorphic(Animal::class) {
+    polymorphicDefaultSerializer(Animal::class) { instance ->
         @Suppress("UNCHECKED_CAST")
-        defaultSerializer { instance: Animal ->
-            when (instance) {
-                is Cat -> CatSerializer as SerializationStrategy<Animal>
-                is Dog -> DogSerializer as SerializationStrategy<Animal>
-                else -> null
-            }
+        when (instance) {
+            is Cat -> CatSerializer as SerializationStrategy<Animal>
+            is Dog -> DogSerializer as SerializationStrategy<Animal>
+            else -> null
         }
     }
 }

--- a/guide/example/example-poly-20.kt
+++ b/guide/example/example-poly-20.kt
@@ -1,0 +1,76 @@
+// This file was automatically generated from polymorphism.md by Knit tool. Do not edit.
+package example.examplePoly20
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+
+interface Animal {
+}
+
+interface Cat : Animal {
+    val catType: String
+}
+
+interface Dog : Animal {
+    val dogType: String
+}
+
+private class CatImpl : Cat {
+    override val catType: String = "Tabby"
+}
+
+private class DogImpl : Dog {
+    override val dogType: String = "Husky"
+}
+
+object AnimalProvider {
+    fun createCat(): Cat = CatImpl()
+    fun createDog(): Dog = DogImpl()
+}
+
+val module = SerializersModule {
+    polymorphic(Animal::class) {
+        @Suppress("UNCHECKED_CAST")
+        defaultSerializer { instance: Animal ->
+            when (instance) {
+                is Cat -> CatSerializer as SerializationStrategy<Animal>
+                is Dog -> DogSerializer as SerializationStrategy<Animal>
+                else -> null
+            }
+        }
+    }
+}
+
+object CatSerializer : SerializationStrategy<Cat> {
+    override val descriptor = buildClassSerialDescriptor("Cat") {
+        element<String>("catType")
+    }
+  
+    override fun serialize(encoder: Encoder, value: Cat) {
+        encoder.encodeStructure(descriptor) {
+          encodeStringElement(descriptor, 0, value.catType)
+        }
+    }
+}
+
+object DogSerializer : SerializationStrategy<Dog> {
+  override val descriptor = buildClassSerialDescriptor("Dog") {
+    element<String>("dogType")
+  }
+
+  override fun serialize(encoder: Encoder, value: Dog) {
+    encoder.encodeStructure(descriptor) {
+      encodeStringElement(descriptor, 0, value.dogType)
+    }
+  }
+}
+
+val format = Json { serializersModule = module }
+
+fun main() {
+    println(format.encodeToString<Animal>(AnimalProvider.createCat()))
+}

--- a/guide/test/PolymorphismTest.kt
+++ b/guide/test/PolymorphismTest.kt
@@ -142,4 +142,11 @@ class PolymorphismTest {
             "[BasicProject(name=example, type=unknown), OwnedProject(name=kotlinx.serialization, owner=kotlin)]"
         )
     }
+
+    @Test
+    fun testExamplePoly20() {
+        captureOutput("ExamplePoly20") { example.examplePoly20.main() }.verifyOutputLines(
+            "{\"type\":\"Cat\",\"catType\":\"Tabby\"}"
+        )
+    }
 }


### PR DESCRIPTION
Closes #1317. Possible usecases for this are described in that issue.

- Adds the concept of polymorphic default serializers, and renames the existing concept of default serializers to default deserializers to avoid confusion.
- Deprecates functions that refer to polymorphic default deserializers as simply "default", in favour of new functions with more explicit names.

I am by no means a kotlin expert so please let me know if there's something that needs changing.