### PR TITLE
Easier to configure ProGuard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ you will need to write custom rules with narrower [class specifications](https:/
 
 <details>
 <summary>Example of custom rules</summary>
-```
+ 
+```proguard
 -keepattributes RuntimeVisibleAnnotations,AnnotationDefault
 
 # kotlinx-serialization-json specific. Add this if you have java.lang.NoClassDefFoundError kotlinx.serialization.json.JsonObjectSerializer


### PR DESCRIPTION
While enabling ProGuard on my Android project, I ran into the (seemingly recently changed) ProGuard example configuration of `kotlinx.serialization`. Given [the way serializer lookup works at runtime](https://github.com/Kotlin/kotlinx.serialization/blob/master/core/jvmMain/src/kotlinx/serialization/internal/Platform.kt#L32), the ProGuard configuration seems unnecessarily complex to me in terms of the number of changes end users need to make. I noticed this by running into [some alternatives provided by @ArcticLampyrid](https://github.com/Kotlin/kotlinx.serialization/issues/1121#issuecomment-812813321), which provided the base inspiration for this PR.

As part of Hacktoberfest, I wanted to both challenge myself learning about ProGuard and contribute to my favorite Kotlin library!

Noticeable changes, more or less in order they appear in the rules:
- `-keepattributes *Annotation*` does not seem needed. I don't know of any annotations that are retrieved at runtime in `kotlinx.serialization`, but maybe I missed something. If this is needed, [it can probably be narrowed down to `RuntimeVisibleAnnotations` or similar](https://stackoverflow.com/a/69523469/590790).
- I could not figure out what `-dontnote kotlinx.serialization.AnnotationsKt` is meant to do. This may be an omission on my part.
- `-keepattributes InnerClasses` is only needed in case there are serializable classes with named companion objects.
- If I'm not mistaken the `kotlinx.serialization-json` specific rules were to handle `@Serializable` of `JsonElement` and the like. These are no longer needed as they are handled by the new all-encompassing `**` rules. 
- The new rules for serializable classes with unnamed companion objects don't require changes by the end user by relying on wildcard matches.
- The new rule for serializable classes with named companion objects is easier to modify. Only a list of these classes needs to be changed, rather than copy/pasting the rule multiple times. This works again by relying on wildcard matches.
- Custom serializers seem to work out-of-the-box. Don't see why these would need to be kept manually.

These changes were tested in an Android project which contained, and used, the following serializable classes. Maybe it is a good idea to set up a test for this?

```
@Serializable
class HasSimpleCompanion( val output: String )

@Serializable
object ObjectSerializable { val output: String = "This is an object." }

@Serializable
class HasNamedCompanion( val output: String )
{
    companion object Named
}

@Serializable
class HasNamedCompanion2( val output: String )
{
    companion object Named
}

@Serializable
class HasJsonElement( val output: JsonElement )

@Serializable( CustomSerializer::class )
class HasCustomSerializer( val output: String )

object CustomSerializer : KSerializer<HasCustomSerializer>
{
    override val descriptor: SerialDescriptor =
        PrimitiveSerialDescriptor( "Custom", PrimitiveKind.STRING )

    override fun serialize( encoder: Encoder, value: HasCustomSerializer ) =
        encoder.encodeString( "CUSTOM!" )

    override fun deserialize( decoder: Decoder ): HasCustomSerializer {
        val hardcoded = decoder.decodeString()
        return HasCustomSerializer(hardcoded)
    }
}
```

In case you approve of these changes, you can [slap a "hacktoberfest-accepted" label on this PR](https://hacktoberfest.digitalocean.com/resources/maintainers) to thank me. :)