### PR TITLE
Update xml library coordinate

### DIFF
--- a/formats/README.md
+++ b/formats/README.md
@@ -95,13 +95,13 @@ This library allows serialization and deserialization of objects into and from A
 
 ### XML
 * GitHub repo: [pdvrieze/xmlutil](https://github.com/pdvrieze/xmlutil)
-* Artifact ID: `net.devrieze:xmlutil-serialization`
+* Artifact ID: `io.github.pdvrieze.xmlutil:serialization`
 * Platform: JVM, Android, JavaScript
 
 This library allows for reading and writing of XML documents with the serialization library.
 It is multiplatform, but as the xmlutil library (which handles the multiplatform xml bit) 
 delegates to platform specific parsers each platform needs to  be implemented for each platform 
-specifically. The library is designed to handle existing formats that use features that would 
+specifically. The library is designed to handle existing xml formats that use features that would 
 not be available in other formats such as JSON.
 
 ### YAML


### PR DESCRIPTION
Due to the jcenter change, the coordinate of the library has changed (for a while now). Better to fix this in the documentation too. At the same time add some clarification to the documentation.