### PR TITLE
Hocon encoder

### DIFF
--- a/formats/hocon/api/kotlinx-serialization-hocon.api
+++ b/formats/hocon/api/kotlinx-serialization-hocon.api
@@ -1,7 +1,8 @@
 public abstract class kotlinx/serialization/hocon/Hocon : kotlinx/serialization/SerialFormat {
 	public static final field Default Lkotlinx/serialization/hocon/Hocon$Default;
-	public synthetic fun <init> (ZZLjava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZLjava/lang/String;Lkotlinx/serialization/modules/SerializersModule;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun decodeFromConfig (Lkotlinx/serialization/DeserializationStrategy;Lcom/typesafe/config/Config;)Ljava/lang/Object;
+	public final fun encodeToConfig (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)Lcom/typesafe/config/Config;
 	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 }
 
@@ -10,10 +11,12 @@ public final class kotlinx/serialization/hocon/Hocon$Default : kotlinx/serializa
 
 public final class kotlinx/serialization/hocon/HoconBuilder {
 	public final fun getClassDiscriminator ()Ljava/lang/String;
+	public final fun getEncodeDefaults ()Z
 	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public final fun getUseArrayPolymorphism ()Z
 	public final fun getUseConfigNamingConvention ()Z
 	public final fun setClassDiscriminator (Ljava/lang/String;)V
+	public final fun setEncodeDefaults (Z)V
 	public final fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
 	public final fun setUseArrayPolymorphism (Z)V
 	public final fun setUseConfigNamingConvention (Z)V

--- a/formats/hocon/build.gradle
+++ b/formats/hocon/build.gradle
@@ -12,17 +12,9 @@ compileKotlin {
     }
 }
 
-configurations {
-    apiElements {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
-        }
-    }
-    runtimeElements {
-        attributes {
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
-        }
-    }
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -35,6 +35,13 @@ public sealed class Hocon(
     public fun <T> decodeFromConfig(deserializer: DeserializationStrategy<T>, config: Config): T =
         ConfigReader(config).decodeSerializableValue(deserializer)
 
+    @ExperimentalSerializationApi
+    public fun <T> encodeToConfig(serializer: SerializationStrategy<T>, value: T): Config {
+        val encoder = HoconConfigEncoder(this)
+        encoder.encodeSerializableValue(serializer, value)
+        return encoder.conf
+    }
+
     /**
      * The default instance of Hocon parser.
      */
@@ -251,6 +258,10 @@ public sealed class Hocon(
 @ExperimentalSerializationApi
 public inline fun <reified T> Hocon.decodeFromConfig(config: Config): T =
     decodeFromConfig(serializersModule.serializer(), config)
+
+@ExperimentalSerializationApi
+public inline fun <reified T> Hocon.encodeToConfig(value: T): Config =
+    encodeToConfig(serializersModule.serializer(), value)
 
 /**
  * Creates an instance of [Hocon] configured from the optionally given [Hocon instance][from]

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -37,9 +37,12 @@ public sealed class Hocon(
 
     @ExperimentalSerializationApi
     public fun <T> encodeToConfig(serializer: SerializationStrategy<T>, value: T): Config {
-        val encoder = HoconConfigEncoder(this)
+        lateinit var configValue: ConfigValue
+        val encoder = HoconConfigEncoder(this) { configValue = it }
         encoder.encodeSerializableValue(serializer, value)
-        return encoder.conf
+
+        check(configValue is ConfigObject) { TODO("Write reasonable error here") }
+        return (configValue as ConfigObject).toConfig()
     }
 
     /**

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -41,6 +41,7 @@ public sealed class Hocon(
 
     /**
      * Encodes the given [value] into a [Config] using the given [serializer].
+     * @throws SerializationException If list or primitive type passed as a [value].
      */
     @ExperimentalSerializationApi
     public fun <T> encodeToConfig(serializer: SerializationStrategy<T>, value: T): Config {
@@ -48,9 +49,11 @@ public sealed class Hocon(
         val encoder = HoconConfigEncoder(this) { configValue = it }
         encoder.encodeSerializableValue(serializer, value)
 
-        check(configValue is ConfigObject) {
-            "Value of type '${configValue.valueType()}' can't be used at the root of HOCON Config." +
-                    "It should be either object or map."
+        if (configValue !is ConfigObject) {
+            throw SerializationException(
+                "Value of type '${configValue.valueType()}' can't be used at the root of HOCON Config." +
+                        "It should be either object or map."
+            )
         }
         return (configValue as ConfigObject).toConfig()
     }

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -241,14 +241,14 @@ public sealed class Hocon(
     }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 internal fun SerialDescriptor.getConventionElementName(index: Int, useConfigNamingConvention: Boolean): String {
     val originalName = getElementName(index)
     return if (!useConfigNamingConvention) originalName
     else originalName.replace(Hocon.NAMING_CONVENTION_REGEX) { "-${it.value.lowercase()}" }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 internal fun SerialDescriptor.hoconKind(useArrayPolymorphism: Boolean): SerialKind = when (kind) {
     is PolymorphicKind -> {
         if (useArrayPolymorphism) StructureKind.LIST else StructureKind.MAP
@@ -256,11 +256,11 @@ internal fun SerialDescriptor.hoconKind(useArrayPolymorphism: Boolean): SerialKi
     else -> kind
 }
 
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 internal val SerialKind.listLike
     get() = this == StructureKind.LIST || this is PolymorphicKind
 
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 internal val SerialKind.objLike
     get() = this == StructureKind.CLASS || this == StructureKind.OBJECT
 

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -249,10 +249,15 @@ public sealed class Hocon(
             throw SerializationException("$serialName does not contain element with name '$name'")
         return index
     }
-
-    private val SerialKind.listLike get() = this == StructureKind.LIST || this is PolymorphicKind
-    private val SerialKind.objLike get() = this == StructureKind.CLASS || this == StructureKind.OBJECT
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+internal val SerialKind.listLike
+    get() = this == StructureKind.LIST || this is PolymorphicKind
+
+@OptIn(ExperimentalSerializationApi::class)
+internal val SerialKind.objLike
+    get() = this == StructureKind.CLASS || this == StructureKind.OBJECT
 
 /**
  * Decodes the given [config] into a value of type [T] using a deserialize retrieved

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -59,9 +59,7 @@ public sealed class Hocon(
      * The default instance of Hocon parser.
      */
     @ExperimentalSerializationApi
-    public companion object Default : Hocon(false, false, false, "type", EmptySerializersModule) {
-        internal val NAMING_CONVENTION_REGEX by lazy { "[A-Z]".toRegex() }
-    }
+    public companion object Default : Hocon(false, false, false, "type", EmptySerializersModule)
 
     private abstract inner class ConfigConverter<T> : TaggedDecoder<T>() {
         override val serializersModule: SerializersModule
@@ -243,29 +241,6 @@ public sealed class Hocon(
         return index
     }
 }
-
-@ExperimentalSerializationApi
-internal fun SerialDescriptor.getConventionElementName(index: Int, useConfigNamingConvention: Boolean): String {
-    val originalName = getElementName(index)
-    return if (!useConfigNamingConvention) originalName
-    else originalName.replace(Hocon.NAMING_CONVENTION_REGEX) { "-${it.value.lowercase()}" }
-}
-
-@ExperimentalSerializationApi
-internal fun SerialDescriptor.hoconKind(useArrayPolymorphism: Boolean): SerialKind = when (kind) {
-    is PolymorphicKind -> {
-        if (useArrayPolymorphism) StructureKind.LIST else StructureKind.MAP
-    }
-    else -> kind
-}
-
-@ExperimentalSerializationApi
-internal val SerialKind.listLike
-    get() = this == StructureKind.LIST || this is PolymorphicKind
-
-@ExperimentalSerializationApi
-internal val SerialKind.objLike
-    get() = this == StructureKind.CLASS || this == StructureKind.OBJECT
 
 /**
  * Decodes the given [config] into a value of type [T] using a deserializer retrieved

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -51,7 +51,7 @@ public sealed class Hocon(
 
         if (configValue !is ConfigObject) {
             throw SerializationException(
-                "Value of type '${configValue.valueType()}' can't be used at the root of HOCON Config." +
+                "Value of type '${configValue.valueType()}' can't be used at the root of HOCON Config. " +
                         "It should be either object or map."
             )
         }

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -32,10 +32,16 @@ public sealed class Hocon(
     override val serializersModule: SerializersModule,
 ) : SerialFormat {
 
+    /**
+     * Decodes the given [config] into a value of type [T] using the given serializer.
+     */
     @ExperimentalSerializationApi
     public fun <T> decodeFromConfig(deserializer: DeserializationStrategy<T>, config: Config): T =
         ConfigReader(config).decodeSerializableValue(deserializer)
 
+    /**
+     * Encodes the given [value] into a [Config] using the given [serializer].
+     */
     @ExperimentalSerializationApi
     public fun <T> encodeToConfig(serializer: SerializationStrategy<T>, value: T): Config {
         lateinit var configValue: ConfigValue
@@ -265,13 +271,17 @@ internal val SerialKind.objLike
     get() = this == StructureKind.CLASS || this == StructureKind.OBJECT
 
 /**
- * Decodes the given [config] into a value of type [T] using a deserialize retrieved
- * from reified type parameter.
+ * Decodes the given [config] into a value of type [T] using a deserializer retrieved
+ * from the reified type parameter.
  */
 @ExperimentalSerializationApi
 public inline fun <reified T> Hocon.decodeFromConfig(config: Config): T =
     decodeFromConfig(serializersModule.serializer(), config)
 
+/**
+ * Encodes the given [value] of type [T] into a [Config] using a serializer retrieved
+ * from the reified type parameter.
+ */
 @ExperimentalSerializationApi
 public inline fun <reified T> Hocon.encodeToConfig(value: T): Config =
     encodeToConfig(serializersModule.serializer(), value)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -155,12 +155,7 @@ public sealed class Hocon(
         }
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
-            val kind = when (descriptor.kind) {
-                is PolymorphicKind -> {
-                    if (useArrayPolymorphism) StructureKind.LIST else StructureKind.MAP
-                }
-                else -> descriptor.kind
-            }
+            val kind = descriptor.hoconKind(useArrayPolymorphism)
 
             return when {
                 kind.listLike -> ListConfigReader(conf.getList(currentTag))
@@ -249,6 +244,14 @@ public sealed class Hocon(
             throw SerializationException("$serialName does not contain element with name '$name'")
         return index
     }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun SerialDescriptor.hoconKind(useArrayPolymorphism: Boolean): SerialKind = when (kind) {
+    is PolymorphicKind -> {
+        if (useArrayPolymorphism) StructureKind.LIST else StructureKind.MAP
+    }
+    else -> kind
 }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -27,6 +27,10 @@ abstract class AbstractHoconEncoder(
 
     private var writeDiscriminator: Boolean = false
 
+    override fun elementName(descriptor: SerialDescriptor, index: Int): String {
+        return descriptor.getConventionElementName(index, hocon.useConfigNamingConvention)
+    }
+
     override fun composeName(parentName: String, childName: String): String = childName
 
     protected abstract fun encodeTaggedConfigValue(tag: String, value: ConfigValue)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -5,6 +5,7 @@ package kotlinx.serialization.hocon
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.internal.NamedValueEncoder
 import kotlinx.serialization.modules.SerializersModule
 
@@ -19,6 +20,10 @@ class HoconConfigEncoder(private val hocon: Hocon) : NamedValueEncoder() {
     override fun encodeTaggedValue(tag: String, value: Any) = withTaggedConfigValue(tag, value)
     override fun encodeTaggedNull(tag: String) = withTaggedConfigValue(tag, null)
     override fun encodeTaggedChar(tag: String, value: Char) = encodeTaggedString(tag, value.toString())
+
+    override fun encodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor, ordinal: Int) {
+        encodeTaggedString(tag, enumDescriptor.getElementName(ordinal))
+    }
 
     private fun withTaggedConfigValue(tag: String, value: Any?) {
         conf = conf.withValue(tag, ConfigValueFactory.fromAnyRef(value))

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -44,6 +44,8 @@ abstract class AbstractHoconEncoder(
         encodeTaggedString(tag, enumDescriptor.getElementName(ordinal))
     }
 
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = hocon.encodeDefaults
+
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
         if (serializer !is AbstractPolymorphicSerializer<*> || hocon.useArrayPolymorphism) {
             serializer.serialize(this, value)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -4,18 +4,12 @@
 
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.ConfigValue
-import com.typesafe.config.ConfigValueFactory
-import com.typesafe.config.ConfigValueType
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerializationStrategy
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.StructureKind
-import kotlinx.serialization.encoding.CompositeEncoder
-import kotlinx.serialization.findPolymorphicSerializer
-import kotlinx.serialization.internal.AbstractPolymorphicSerializer
-import kotlinx.serialization.internal.NamedValueEncoder
-import kotlinx.serialization.modules.SerializersModule
+import com.typesafe.config.*
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.internal.*
+import kotlinx.serialization.modules.*
 
 @ExperimentalSerializationApi
 internal abstract class AbstractHoconEncoder(

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -1,4 +1,6 @@
-@file:OptIn(ExperimentalSerializationApi::class)
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package kotlinx.serialization.hocon
 
@@ -6,7 +8,6 @@ import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueFactory
 import com.typesafe.config.ConfigValueType
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
@@ -16,9 +17,9 @@ import kotlinx.serialization.internal.AbstractPolymorphicSerializer
 import kotlinx.serialization.internal.NamedValueEncoder
 import kotlinx.serialization.modules.SerializersModule
 
-@InternalSerializationApi
-abstract class AbstractHoconEncoder(
-    protected val hocon: Hocon,
+@ExperimentalSerializationApi
+internal abstract class AbstractHoconEncoder(
+    private val hocon: Hocon,
     private val valueConsumer: (ConfigValue) -> Unit,
 ) : NamedValueEncoder() {
 
@@ -86,8 +87,8 @@ abstract class AbstractHoconEncoder(
     private fun configValueOf(value: Any?) = ConfigValueFactory.fromAnyRef(value)
 }
 
-@InternalSerializationApi
-class HoconConfigEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
+@ExperimentalSerializationApi
+internal class HoconConfigEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
     AbstractHoconEncoder(hocon, configConsumer) {
 
     private val configMap = mutableMapOf<String, ConfigValue>()
@@ -99,8 +100,8 @@ class HoconConfigEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
     override fun getCurrent(): ConfigValue = ConfigValueFactory.fromMap(configMap)
 }
 
-@InternalSerializationApi
-class HoconConfigListEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
+@ExperimentalSerializationApi
+internal class HoconConfigListEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
     AbstractHoconEncoder(hocon, configConsumer) {
 
     private val values = mutableListOf<ConfigValue>()
@@ -114,8 +115,8 @@ class HoconConfigListEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit
     override fun getCurrent(): ConfigValue = ConfigValueFactory.fromIterable(values)
 }
 
-@InternalSerializationApi
-class HoconConfigMapEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
+@ExperimentalSerializationApi
+internal class HoconConfigMapEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
     AbstractHoconEncoder(hocon, configConsumer) {
 
     private val configMap = mutableMapOf<String, ConfigValue>()

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -40,6 +40,7 @@ abstract class AbstractHoconEncoder(
 
         return when {
             descriptor.kind.listLike -> HoconConfigListEncoder(hocon, consumer)
+            descriptor.kind.objLike -> HoconConfigEncoder(hocon, consumer)
             else -> this
         }
     }

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -1,0 +1,26 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package kotlinx.serialization.hocon
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.internal.NamedValueEncoder
+import kotlinx.serialization.modules.SerializersModule
+
+class HoconConfigEncoder(private val hocon: Hocon) : NamedValueEncoder() {
+
+    override val serializersModule: SerializersModule
+        get() = hocon.serializersModule
+
+    var conf = ConfigFactory.empty()
+        private set
+
+    override fun encodeTaggedValue(tag: String, value: Any) = withTaggedConfigValue(tag, value)
+    override fun encodeTaggedNull(tag: String) = withTaggedConfigValue(tag, null)
+    override fun encodeTaggedChar(tag: String, value: Char) = encodeTaggedString(tag, value.toString())
+
+    private fun withTaggedConfigValue(tag: String, value: Any?) {
+        conf = conf.withValue(tag, ConfigValueFactory.fromAnyRef(value))
+    }
+}

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -122,7 +122,7 @@ internal class HoconConfigMapEncoder(hocon: Hocon, configConsumer: (ConfigValue)
         if (isKey) {
             key = when (value.valueType()) {
                 ConfigValueType.OBJECT, ConfigValueType.LIST -> throw InvalidKeyKindException(value)
-                else -> value.unwrapped().toString()
+                else -> value.unwrappedNullable().toString()
             }
             isKey = false
         } else {
@@ -132,4 +132,9 @@ internal class HoconConfigMapEncoder(hocon: Hocon, configConsumer: (ConfigValue)
     }
 
     override fun getCurrent(): ConfigValue = ConfigValueFactory.fromMap(configMap)
+
+    // Without cast to `Any?` Kotlin will assume unwrapped value as non-nullable by default
+    // and will call `Any.toString()` instead of extension-function `Any?.toString()`.
+    // We can't cast value in place using `(value.unwrapped() as Any?).toString()` because of warning "No cast needed".
+    private fun ConfigValue.unwrappedNullable(): Any? = unwrapped()
 }

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -127,8 +127,7 @@ internal class HoconConfigMapEncoder(hocon: Hocon, configConsumer: (ConfigValue)
     override fun encodeTaggedConfigValue(tag: String, value: ConfigValue) {
         if (isKey) {
             key = when (value.valueType()) {
-                ConfigValueType.OBJECT -> TODO("Throw reasonable exception")
-                ConfigValueType.LIST -> TODO("Throw reasonable exception")
+                ConfigValueType.OBJECT, ConfigValueType.LIST -> throw InvalidKeyKindException(value)
                 else -> value.unwrapped().toString()
             }
             isKey = false

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconEncoder.kt
@@ -2,30 +2,52 @@
 
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueFactory
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.internal.NamedValueEncoder
 import kotlinx.serialization.modules.SerializersModule
 
-class HoconConfigEncoder(private val hocon: Hocon) : NamedValueEncoder() {
+@InternalSerializationApi
+abstract class AbstractHoconEncoder(
+    protected val hocon: Hocon,
+    private val valueConsumer: (ConfigValue) -> Unit,
+) : NamedValueEncoder() {
 
     override val serializersModule: SerializersModule
         get() = hocon.serializersModule
 
-    var conf = ConfigFactory.empty()
-        private set
+    override fun composeName(parentName: String, childName: String): String = childName
 
-    override fun encodeTaggedValue(tag: String, value: Any) = withTaggedConfigValue(tag, value)
-    override fun encodeTaggedNull(tag: String) = withTaggedConfigValue(tag, null)
+    protected abstract fun encodeTaggedConfigValue(tag: String, value: ConfigValue)
+    protected abstract fun getCurrent(): ConfigValue
+
+    override fun encodeTaggedValue(tag: String, value: Any) = encodeTaggedConfigValue(tag, configValueOf(value))
+    override fun encodeTaggedNull(tag: String) = encodeTaggedConfigValue(tag, configValueOf(null))
     override fun encodeTaggedChar(tag: String, value: Char) = encodeTaggedString(tag, value.toString())
 
     override fun encodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor, ordinal: Int) {
         encodeTaggedString(tag, enumDescriptor.getElementName(ordinal))
     }
 
-    private fun withTaggedConfigValue(tag: String, value: Any?) {
-        conf = conf.withValue(tag, ConfigValueFactory.fromAnyRef(value))
+    override fun endEncode(descriptor: SerialDescriptor) {
+        valueConsumer(getCurrent())
     }
+
+    private fun configValueOf(value: Any?) = ConfigValueFactory.fromAnyRef(value)
+}
+
+@InternalSerializationApi
+class HoconConfigEncoder(hocon: Hocon, configConsumer: (ConfigValue) -> Unit) :
+    AbstractHoconEncoder(hocon, configConsumer) {
+
+    private val configMap = mutableMapOf<String, ConfigValue>()
+
+    override fun encodeTaggedConfigValue(tag: String, value: ConfigValue) {
+        configMap[tag] = value
+    }
+
+    override fun getCurrent(): ConfigValue = ConfigValueFactory.fromMap(configMap)
 }

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconExceptions.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconExceptions.kt
@@ -1,0 +1,19 @@
+package kotlinx.serialization.hocon
+
+import com.typesafe.config.ConfigValue
+import com.typesafe.config.ConfigValueType
+import kotlinx.serialization.SerializationException
+
+internal fun SerializerNotFoundException(type: String?) = SerializationException(
+    "Polymorphic serializer was not found for " +
+            if (type == null) "missing class discriminator ('null')" else "class discriminator '$type'"
+)
+
+internal inline fun <reified T> ConfigValueTypeCastException(valueOrigin: ConfigOrigin) = SerializationException(
+    "${valueOrigin.description()} required to be of type ${T::class.simpleName}."
+)
+
+internal fun InvalidKeyKindException(value: ConfigValue) = SerializationException(
+    "Value of type '${value.valueType()}' can't be used in HOCON as a key in the map. " +
+            "It should have either primitive or enum kind."
+)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconExceptions.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconExceptions.kt
@@ -1,8 +1,11 @@
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.ConfigValue
-import com.typesafe.config.ConfigValueType
-import kotlinx.serialization.SerializationException
+import com.typesafe.config.*
+import kotlinx.serialization.*
 
 internal fun SerializerNotFoundException(type: String?) = SerializationException(
     "Polymorphic serializer was not found for " +

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconSerialKind.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconSerialKind.kt
@@ -1,0 +1,20 @@
+package kotlinx.serialization.hocon
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun SerialDescriptor.hoconKind(useArrayPolymorphism: Boolean): SerialKind = when (kind) {
+    is PolymorphicKind -> {
+        if (useArrayPolymorphism) StructureKind.LIST else StructureKind.MAP
+    }
+    else -> kind
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+internal val SerialKind.listLike
+    get() = this == StructureKind.LIST || this is PolymorphicKind
+
+@OptIn(ExperimentalSerializationApi::class)
+internal val SerialKind.objLike
+    get() = this == StructureKind.CLASS || this == StructureKind.OBJECT

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/NamingConvention.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/NamingConvention.kt
@@ -1,0 +1,13 @@
+package kotlinx.serialization.hocon
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+
+private val NAMING_CONVENTION_REGEX by lazy { "[A-Z]".toRegex() }
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun SerialDescriptor.getConventionElementName(index: Int, useConfigNamingConvention: Boolean): String {
+    val originalName = getElementName(index)
+    return if (!useConfigNamingConvention) originalName
+    else originalName.replace(NAMING_CONVENTION_REGEX) { "-${it.value.lowercase()}" }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -45,6 +45,7 @@ class HoconEncoderTest {
         val array: BooleanArray,
         val set: Set<Int>,
         val list: List<String>,
+        val listNullable: List<Set<SimpleConfig?>?>,
     )
 
     @Test
@@ -53,6 +54,7 @@ class HoconEncoderTest {
             array = booleanArrayOf(true, false),
             set = setOf(3, 1, 4),
             list = listOf("A", "B"),
+            listNullable = listOf(null, setOf(SimpleConfig(42), null)),
         )
         val config = Hocon.encodeToConfig(obj)
 
@@ -61,6 +63,7 @@ class HoconEncoderTest {
                 array = [true, false]
                 set = [3, 1, 4]
                 list = [A, B]
+                listNullable = [null, [{ value: 42 }, null]]
             """
         )
     }
@@ -87,10 +90,19 @@ class HoconEncoderTest {
         val objMap = mapOf(
             "one" to SimpleConfig(1),
             "two" to SimpleConfig(2),
+            "three" to null,
+            null to SimpleConfig(0),
         )
         val config = Hocon.encodeToConfig(objMap)
 
-        config.assertContains("one { value = 1 }, two { value = 2 }")
+        config.assertContains(
+            """
+                one { value = 1 }
+                two { value = 2 }
+                three: null
+                null { value = 0 }
+            """
+        )
     }
 
     @Serializable

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -1,0 +1,36 @@
+package kotlinx.serialization.hocon
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HoconEncoderTest {
+
+    @Serializable
+    data class PrimitivesConfig(
+        val b: Boolean,
+        val i: Int,
+        val d: Double,
+        val c: Char,
+        val s: String,
+        val n: String?,
+    )
+
+    @Test
+    fun `encode simple config`() {
+        // Given
+        val obj = PrimitivesConfig(b = true, i = 42, d = 32.2, c = 'x', s = "string", n = null)
+
+        // When
+        val config = Hocon.encodeToConfig(obj)
+
+        // Then
+        assertConfigEquals("b = true, i = 42, d = 32.2, c = x, s = string, n = null", config)
+    }
+
+    private fun assertConfigEquals(expected: String, actual: Config) {
+        assertEquals(ConfigFactory.parseString(expected), actual)
+    }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -1,9 +1,6 @@
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import kotlinx.serialization.Serializable
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class HoconEncoderTest {
@@ -119,8 +116,4 @@ class HoconEncoderTest {
 
         assertConfigEquals("defInt = 42, defString = \"\"", config)
     }
-}
-
-internal fun assertConfigEquals(expected: String, actual: Config) {
-    assertEquals(ConfigFactory.parseString(expected), actual)
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -116,8 +116,8 @@ class HoconEncoderTest {
         // Then
         assertConfigEquals("one { value = 1 }, two { value = 2 }", config)
     }
+}
 
-    private fun assertConfigEquals(expected: String, actual: Config) {
-        assertEquals(ConfigFactory.parseString(expected), actual)
-    }
+internal fun assertConfigEquals(expected: String, actual: Config) {
+    assertEquals(ConfigFactory.parseString(expected), actual)
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -1,7 +1,7 @@
 package kotlinx.serialization.hocon
 
-import kotlinx.serialization.Serializable
-import org.junit.Test
+import kotlinx.serialization.*
+import org.junit.*
 
 class HoconEncoderTest {
 

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -19,7 +19,7 @@ class HoconEncoderTest {
     )
 
     @Test
-    fun encodeSimpleConfig() {
+    fun testEncodeSimpleConfig() {
         val obj = PrimitivesConfig(b = true, i = 42, d = 32.2, c = 'x', s = "string", n = null)
         val config = Hocon.encodeToConfig(obj)
 
@@ -33,7 +33,7 @@ class HoconEncoderTest {
     enum class RegularEnum { VALUE }
 
     @Test
-    fun encodeConfigWithEnum() {
+    fun testEncodeConfigWithEnum() {
         val obj = ConfigWithEnum(RegularEnum.VALUE)
         val config = Hocon.encodeToConfig(obj)
 
@@ -48,7 +48,7 @@ class HoconEncoderTest {
     )
 
     @Test
-    fun encodeConfigWithIterables() {
+    fun testEncodeConfigWithIterables() {
         val obj = ConfigWithIterables(
             array = booleanArrayOf(true, false),
             set = setOf(3, 1, 4),

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -22,7 +22,7 @@ class HoconEncoderTest {
     )
 
     @Test
-    fun `encode simple config`() {
+    fun encodeSimpleConfig() {
         val obj = PrimitivesConfig(b = true, i = 42, d = 32.2, c = 'x', s = "string", n = null)
         val config = Hocon.encodeToConfig(obj)
 
@@ -36,7 +36,7 @@ class HoconEncoderTest {
     enum class RegularEnum { VALUE }
 
     @Test
-    fun `encode config with enum`() {
+    fun encodeConfigWithEnum() {
         val obj = ConfigWithEnum(RegularEnum.VALUE)
         val config = Hocon.encodeToConfig(obj)
 
@@ -51,7 +51,7 @@ class HoconEncoderTest {
     )
 
     @Test
-    fun `encode config with iterables`() {
+    fun encodeConfigWithIterables() {
         val obj = ConfigWithIterables(
             array = booleanArrayOf(true, false),
             set = setOf(3, 1, 4),
@@ -76,7 +76,7 @@ class HoconEncoderTest {
     )
 
     @Test
-    fun `test nested config encoding`() {
+    fun testNestedConfigEncoding() {
         val obj = ConfigWithNested(
             nested = SimpleConfig(1),
             nestedList = listOf(SimpleConfig(2)),
@@ -87,7 +87,7 @@ class HoconEncoderTest {
     }
 
     @Test
-    fun `test map encoding`() {
+    fun testMapEncoding() {
         val objMap = mapOf(
             "one" to SimpleConfig(1),
             "two" to SimpleConfig(2),
@@ -104,7 +104,7 @@ class HoconEncoderTest {
     )
 
     @Test
-    fun `test defaults shouldn't be encoded by default`() {
+    fun testDefaultsNotEncodedByDefault() {
         val obj = ConfigWithDefaults(defInt = 42)
         val config = Hocon.encodeToConfig(obj)
 
@@ -112,7 +112,7 @@ class HoconEncoderTest {
     }
 
     @Test
-    fun `test defaults should be encoded if enabled`() {
+    fun testDefaultsEncodedIfEnabled() {
         val hocon = Hocon { encodeDefaults = true }
         val obj = ConfigWithDefaults(defInt = 42)
         val config = hocon.encodeToConfig(obj)

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -18,6 +18,12 @@ class HoconEncoderTest {
         val n: String?,
     )
 
+    @Serializable
+    data class ConfigWithEnum(val e: RegularEnum)
+
+    @Serializable
+    enum class RegularEnum { VALUE }
+
     @Test
     fun `encode simple config`() {
         // Given
@@ -28,6 +34,18 @@ class HoconEncoderTest {
 
         // Then
         assertConfigEquals("b = true, i = 42, d = 32.2, c = x, s = string, n = null", config)
+    }
+
+    @Test
+    fun `encode config with enum`() {
+        // Given
+        val obj = ConfigWithEnum(RegularEnum.VALUE)
+
+        // When
+        val config = Hocon.encodeToConfig(obj)
+
+        // Then
+        assertConfigEquals("e = VALUE", config)
     }
 
     private fun assertConfigEquals(expected: String, actual: Config) {

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -102,6 +102,21 @@ class HoconEncoderTest {
         assertConfigEquals("nested { value = 1 }, nestedList = [{ value: 2 }]", config)
     }
 
+    @Test
+    fun `test map encoding`() {
+        // Given
+        val objMap = mapOf(
+            "one" to SimpleConfig(1),
+            "two" to SimpleConfig(2),
+        )
+
+        // When
+        val config = Hocon.encodeToConfig(objMap)
+
+        // Then
+        assertConfigEquals("one { value = 1 }, two { value = 2 }", config)
+    }
+
     private fun assertConfigEquals(expected: String, actual: Config) {
         assertEquals(ConfigFactory.parseString(expected), actual)
     }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -9,6 +9,9 @@ import org.junit.Test
 class HoconEncoderTest {
 
     @Serializable
+    data class SimpleConfig(val value: Int)
+
+    @Serializable
     data class PrimitivesConfig(
         val b: Boolean,
         val i: Int,
@@ -76,6 +79,27 @@ class HoconEncoderTest {
             """.trimIndent(),
             config,
         )
+    }
+
+    @Serializable
+    data class ConfigWithNested(
+        val nested: SimpleConfig,
+        val nestedList: List<SimpleConfig>,
+    )
+
+    @Test
+    fun `test nested config encoding`() {
+        // Given
+        val obj = ConfigWithNested(
+            nested = SimpleConfig(1),
+            nestedList = listOf(SimpleConfig(2)),
+        )
+
+        // When
+        val config = Hocon.encodeToConfig(obj)
+
+        // Then
+        assertConfigEquals("nested { value = 1 }, nestedList = [{ value: 2 }]", config)
     }
 
     private fun assertConfigEquals(expected: String, actual: Config) {

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -23,7 +23,7 @@ class HoconEncoderTest {
         val obj = PrimitivesConfig(b = true, i = 42, d = 32.2, c = 'x', s = "string", n = null)
         val config = Hocon.encodeToConfig(obj)
 
-        assertConfigEquals("b = true, i = 42, d = 32.2, c = x, s = string, n = null", config)
+        config.assertContains("b = true, i = 42, d = 32.2, c = x, s = string, n = null")
     }
 
     @Serializable
@@ -37,7 +37,7 @@ class HoconEncoderTest {
         val obj = ConfigWithEnum(RegularEnum.VALUE)
         val config = Hocon.encodeToConfig(obj)
 
-        assertConfigEquals("e = VALUE", config)
+        config.assertContains("e = VALUE")
     }
 
     @Serializable
@@ -56,13 +56,12 @@ class HoconEncoderTest {
         )
         val config = Hocon.encodeToConfig(obj)
 
-        assertConfigEquals(
+        config.assertContains(
             """
                 array = [true, false]
                 set = [3, 1, 4]
                 list = [A, B]
-            """.trimIndent(),
-            config,
+            """
         )
     }
 
@@ -80,7 +79,7 @@ class HoconEncoderTest {
         )
         val config = Hocon.encodeToConfig(obj)
 
-        assertConfigEquals("nested { value = 1 }, nestedList = [{ value: 2 }]", config)
+        config.assertContains("nested { value = 1 }, nestedList = [{ value: 2 }]")
     }
 
     @Test
@@ -91,7 +90,7 @@ class HoconEncoderTest {
         )
         val config = Hocon.encodeToConfig(objMap)
 
-        assertConfigEquals("one { value = 1 }, two { value = 2 }", config)
+        config.assertContains("one { value = 1 }, two { value = 2 }")
     }
 
     @Serializable
@@ -105,7 +104,7 @@ class HoconEncoderTest {
         val obj = ConfigWithDefaults(defInt = 42)
         val config = Hocon.encodeToConfig(obj)
 
-        assertConfigEquals("defInt = 42", config)
+        config.assertContains("defInt = 42")
     }
 
     @Test
@@ -114,6 +113,6 @@ class HoconEncoderTest {
         val obj = ConfigWithDefaults(defInt = 42)
         val config = hocon.encodeToConfig(obj)
 
-        assertConfigEquals("defInt = 42, defString = \"\"", config)
+        config.assertContains("defInt = 42, defString = \"\"")
     }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -18,19 +18,6 @@ class HoconEncoderTest {
         val n: String?,
     )
 
-    @Serializable
-    data class ConfigWithEnum(val e: RegularEnum)
-
-    @Serializable
-    enum class RegularEnum { VALUE }
-
-    @Serializable
-    class ConfigWithIterables(
-        val array: BooleanArray,
-        val set: Set<Int>,
-        val list: List<String>,
-    )
-
     @Test
     fun `encode simple config`() {
         // Given
@@ -43,6 +30,12 @@ class HoconEncoderTest {
         assertConfigEquals("b = true, i = 42, d = 32.2, c = x, s = string, n = null", config)
     }
 
+    @Serializable
+    data class ConfigWithEnum(val e: RegularEnum)
+
+    @Serializable
+    enum class RegularEnum { VALUE }
+
     @Test
     fun `encode config with enum`() {
         // Given
@@ -54,6 +47,13 @@ class HoconEncoderTest {
         // Then
         assertConfigEquals("e = VALUE", config)
     }
+
+    @Serializable
+    class ConfigWithIterables(
+        val array: BooleanArray,
+        val set: Set<Int>,
+        val list: List<String>,
+    )
 
     @Test
     fun `encode config with iterables`() {

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -23,13 +23,9 @@ class HoconEncoderTest {
 
     @Test
     fun `encode simple config`() {
-        // Given
         val obj = PrimitivesConfig(b = true, i = 42, d = 32.2, c = 'x', s = "string", n = null)
-
-        // When
         val config = Hocon.encodeToConfig(obj)
 
-        // Then
         assertConfigEquals("b = true, i = 42, d = 32.2, c = x, s = string, n = null", config)
     }
 
@@ -41,13 +37,9 @@ class HoconEncoderTest {
 
     @Test
     fun `encode config with enum`() {
-        // Given
         val obj = ConfigWithEnum(RegularEnum.VALUE)
-
-        // When
         val config = Hocon.encodeToConfig(obj)
 
-        // Then
         assertConfigEquals("e = VALUE", config)
     }
 
@@ -60,17 +52,13 @@ class HoconEncoderTest {
 
     @Test
     fun `encode config with iterables`() {
-        // Given
         val obj = ConfigWithIterables(
             array = booleanArrayOf(true, false),
             set = setOf(3, 1, 4),
             list = listOf("A", "B"),
         )
-
-        // When
         val config = Hocon.encodeToConfig(obj)
 
-        // Then
         assertConfigEquals(
             """
                 array = [true, false]
@@ -89,31 +77,23 @@ class HoconEncoderTest {
 
     @Test
     fun `test nested config encoding`() {
-        // Given
         val obj = ConfigWithNested(
             nested = SimpleConfig(1),
             nestedList = listOf(SimpleConfig(2)),
         )
-
-        // When
         val config = Hocon.encodeToConfig(obj)
 
-        // Then
         assertConfigEquals("nested { value = 1 }, nestedList = [{ value: 2 }]", config)
     }
 
     @Test
     fun `test map encoding`() {
-        // Given
         val objMap = mapOf(
             "one" to SimpleConfig(1),
             "two" to SimpleConfig(2),
         )
-
-        // When
         val config = Hocon.encodeToConfig(objMap)
 
-        // Then
         assertConfigEquals("one { value = 1 }, two { value = 2 }", config)
     }
 
@@ -125,26 +105,18 @@ class HoconEncoderTest {
 
     @Test
     fun `test defaults shouldn't be encoded by default`() {
-        // Given
         val obj = ConfigWithDefaults(defInt = 42)
-
-        // When
         val config = Hocon.encodeToConfig(obj)
 
-        // Then
         assertConfigEquals("defInt = 42", config)
     }
 
     @Test
     fun `test defaults should be encoded if enabled`() {
-        // Given
         val hocon = Hocon { encodeDefaults = true }
         val obj = ConfigWithDefaults(defInt = 42)
-
-        // When
         val config = hocon.encodeToConfig(obj)
 
-        // Then
         assertConfigEquals("defInt = 42, defString = \"\"", config)
     }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -116,6 +116,37 @@ class HoconEncoderTest {
         // Then
         assertConfigEquals("one { value = 1 }, two { value = 2 }", config)
     }
+
+    @Serializable
+    data class ConfigWithDefaults(
+        val defInt: Int = 0,
+        val defString: String = "",
+    )
+
+    @Test
+    fun `test defaults shouldn't be encoded by default`() {
+        // Given
+        val obj = ConfigWithDefaults(defInt = 42)
+
+        // When
+        val config = Hocon.encodeToConfig(obj)
+
+        // Then
+        assertConfigEquals("defInt = 42", config)
+    }
+
+    @Test
+    fun `test defaults should be encoded if enabled`() {
+        // Given
+        val hocon = Hocon { encodeDefaults = true }
+        val obj = ConfigWithDefaults(defInt = 42)
+
+        // When
+        val config = hocon.encodeToConfig(obj)
+
+        // Then
+        assertConfigEquals("defInt = 42, defString = \"\"", config)
+    }
 }
 
 internal fun assertConfigEquals(expected: String, actual: Config) {

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconEncoderTest.kt
@@ -24,6 +24,13 @@ class HoconEncoderTest {
     @Serializable
     enum class RegularEnum { VALUE }
 
+    @Serializable
+    class ConfigWithIterables(
+        val array: BooleanArray,
+        val set: Set<Int>,
+        val list: List<String>,
+    )
+
     @Test
     fun `encode simple config`() {
         // Given
@@ -46,6 +53,29 @@ class HoconEncoderTest {
 
         // Then
         assertConfigEquals("e = VALUE", config)
+    }
+
+    @Test
+    fun `encode config with iterables`() {
+        // Given
+        val obj = ConfigWithIterables(
+            array = booleanArrayOf(true, false),
+            set = setOf(3, 1, 4),
+            list = listOf("A", "B"),
+        )
+
+        // When
+        val config = Hocon.encodeToConfig(obj)
+
+        // Then
+        assertConfigEquals(
+            """
+                array = [true, false]
+                set = [3, 1, 4]
+                list = [A, B]
+            """.trimIndent(),
+            config,
+        )
     }
 
     private fun assertConfigEquals(expected: String, actual: Config) {

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconNamingConventionTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconNamingConventionTest.kt
@@ -24,14 +24,14 @@ class HoconNamingConventionTest {
     }
 
     @Test
-    fun `deserialize using naming convention`() {
+    fun testDeserializeUsingNamingConvention() {
         val obj = deserializeConfig("a-char-value = t, a-string-value = test", CaseConfig.serializer(), true)
         assertEquals('t', obj.aCharValue)
         assertEquals("test", obj.aStringValue)
     }
 
     @Test
-    fun `serialize using naming convention`() {
+    fun testSerializeUsingNamingConvention() {
         val obj = CaseConfig(aCharValue = 't', aStringValue = "test")
         val config = hocon.encodeToConfig(obj)
 
@@ -39,13 +39,13 @@ class HoconNamingConventionTest {
     }
 
     @Test
-    fun `deserialize using serial name instead of naming convention`() {
+    fun testDeserializeUsingSerialNameInsteadOfNamingConvention() {
         val obj = deserializeConfig("an-id-value = 42", SerialNameConfig.serializer(), true)
         assertEquals(42, obj.anIDValue)
     }
 
     @Test
-    fun `serialize using serial name instead of naming convention`() {
+    fun testSerializeUsingSerialNameInsteadOfNamingConvention() {
         val obj = SerialNameConfig(anIDValue = 42)
         val config = hocon.encodeToConfig(obj)
 
@@ -53,7 +53,7 @@ class HoconNamingConventionTest {
     }
 
     @Test
-    fun `deserialize inner values using naming convention`() {
+    fun testDeserializeInnerValuesUsingNamingConvention() {
         val configString = "case-config {a-char-value = b, a-string-value = bar}, serial-name-config {an-id-value = 21}"
         val obj = deserializeConfig(configString, CaseWithInnerConfig.serializer(), true)
         with(obj.caseConfig) {
@@ -64,7 +64,7 @@ class HoconNamingConventionTest {
     }
 
     @Test
-    fun `serialize inner values using naming convention`() {
+    fun testSerializeInnerValuesUsingNamingConvention() {
         val obj = CaseWithInnerConfig(
             caseConfig = CaseConfig(aCharValue = 't', aStringValue = "test"),
             serialNameConfig = SerialNameConfig(anIDValue = 42)

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconNamingConventionTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconNamingConventionTest.kt
@@ -35,7 +35,7 @@ class HoconNamingConventionTest {
         val obj = CaseConfig(aCharValue = 't', aStringValue = "test")
         val config = hocon.encodeToConfig(obj)
 
-        assertConfigEquals("a-char-value = t, a-string-value = test", config)
+        config.assertContains("a-char-value = t, a-string-value = test")
     }
 
     @Test
@@ -49,7 +49,7 @@ class HoconNamingConventionTest {
         val obj = SerialNameConfig(anIDValue = 42)
         val config = hocon.encodeToConfig(obj)
 
-        assertConfigEquals("an-id-value = 42", config)
+        config.assertContains("an-id-value = 42")
     }
 
     @Test
@@ -71,12 +71,11 @@ class HoconNamingConventionTest {
         )
         val config = hocon.encodeToConfig(obj)
 
-        assertConfigEquals(
+        config.assertContains(
             """
                 case-config { a-char-value = t, a-string-value = test }
                 serial-name-config { an-id-value = 42 }
-            """,
-            config,
+            """
         )
     }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -166,4 +166,40 @@ class HoconPolymorphismTest {
 
         assertConfigEquals("sealed = [ data_class, { name = testDataClass, intField = 1 } ]", config)
     }
+
+    @Test
+    fun testObjectEncode() {
+        val obj = Sealed.ObjectChild
+        val config = objectHocon.encodeToConfig(Sealed.serializer(), obj)
+
+        assertConfigEquals("type = object", config)
+    }
+
+    @Test
+    fun testDataClassEncode() {
+        val obj = Sealed.DataClassChild("testDataClass")
+        val config = objectHocon.encodeToConfig(Sealed.serializer(), obj)
+
+        assertConfigEquals("type = data_class, name = testDataClass, intField = 1", config)
+    }
+
+    @Test
+    fun testEncodeChangedDiscriminator() {
+        val hocon = Hocon(objectHocon) {
+            classDiscriminator = "key"
+        }
+
+        val obj = Sealed.TypeChild(type = "override")
+        val config = hocon.encodeToConfig(Sealed.serializer(), obj)
+
+        assertConfigEquals("type = override, key = type_child, intField = 2", config)
+    }
+
+    @Test
+    fun testEncodeChangedTypePropertyName() {
+        val obj = Sealed.AnnotatedTypeChild(type = "override")
+        val config = objectHocon.encodeToConfig(Sealed.serializer(), obj)
+
+        assertConfigEquals("type = annotated_type_child, my_type = override, intField = 3", config)
+    }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -39,7 +39,7 @@ class HoconPolymorphismTest {
 
 
     @Test
-    fun testArrayDataClass() {
+    fun testArrayDataClassDecode() {
         val config = ConfigFactory.parseString(
                 """{
                 sealed: [
@@ -58,7 +58,7 @@ class HoconPolymorphismTest {
     }
 
     @Test
-    fun testArrayObject() {
+    fun testArrayObjectDecode() {
         val config = ConfigFactory.parseString(
                 """{
                 sealed: [
@@ -73,7 +73,7 @@ class HoconPolymorphismTest {
     }
 
     @Test
-    fun testObject() {
+    fun testObjectDecode() {
         val config = ConfigFactory.parseString("""{type="object"}""")
         val sealed = objectHocon.decodeFromConfig(Sealed.serializer(), config)
 
@@ -81,7 +81,7 @@ class HoconPolymorphismTest {
     }
 
     @Test
-    fun testNestedDataClass() {
+    fun testNestedDataClassDecode() {
         val config = ConfigFactory.parseString(
                 """{
                 sealed: {
@@ -100,7 +100,7 @@ class HoconPolymorphismTest {
     }
 
     @Test
-    fun testDataClass() {
+    fun testDataClassDecode() {
         val config = ConfigFactory.parseString(
                 """{
                   type="data_class"
@@ -116,7 +116,7 @@ class HoconPolymorphismTest {
     }
 
     @Test
-    fun testChangeDiscriminator() {
+    fun testDecodeChangedDiscriminator() {
         val hocon = Hocon(objectHocon) {
             classDiscriminator = "key"
         }
@@ -136,7 +136,7 @@ class HoconPolymorphismTest {
     }
 
     @Test
-    fun testChangeTypePropertyName() {
+    fun testDecodeChangedTypePropertyName() {
         val config = ConfigFactory.parseString(
                 """{
                   my_type="override"

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -1,7 +1,7 @@
 package kotlinx.serialization.hocon
 
 import kotlinx.serialization.*
-import org.junit.Test
+import org.junit.*
 
 class HoconPolymorphismTest {
     @Serializable

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -1,8 +1,6 @@
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.ConfigFactory
 import kotlinx.serialization.*
-import org.junit.Assert.*
 import org.junit.Test
 
 class HoconPolymorphismTest {
@@ -39,167 +37,69 @@ class HoconPolymorphismTest {
 
 
     @Test
-    fun testArrayDataClassDecode() {
-        val config = ConfigFactory.parseString(
-                """{
-                sealed: [
-                  "data_class"
-                  {name="testArrayDataClass"
-                   intField=10}
-                ]
-                }""")
-        val root = arrayHocon.decodeFromConfig(CompositeClass.serializer(), config)
-        val sealed = root.sealed
-
-        assertTrue(sealed is Sealed.DataClassChild)
-        sealed as Sealed.DataClassChild
-        assertEquals("testArrayDataClass", sealed.name)
-        assertEquals(10, sealed.intField)
+    fun testArrayDataClass() {
+        arrayHocon.assertStringFormAndRestored(
+            expected = "sealed: [ data_class, { name = testDataClass, intField = 1 } ]",
+            original = CompositeClass(Sealed.DataClassChild("testDataClass")),
+            serializer = CompositeClass.serializer(),
+        )
     }
 
     @Test
-    fun testArrayObjectDecode() {
-        val config = ConfigFactory.parseString(
-                """{
-                sealed: [
-                  "object"
-                  {}
-                ]
-                }""")
-        val root = arrayHocon.decodeFromConfig(CompositeClass.serializer(), config)
-        val sealed = root.sealed
-
-        assertSame(Sealed.ObjectChild, sealed)
+    fun testArrayObject() {
+        arrayHocon.assertStringFormAndRestored(
+            expected = "sealed: [ object, {} ]",
+            original = CompositeClass(Sealed.ObjectChild),
+            serializer = CompositeClass.serializer(),
+        )
     }
 
     @Test
-    fun testObjectDecode() {
-        val config = ConfigFactory.parseString("""{type="object"}""")
-        val sealed = objectHocon.decodeFromConfig(Sealed.serializer(), config)
-
-        assertSame(Sealed.ObjectChild, sealed)
+    fun testObject() {
+        objectHocon.assertStringFormAndRestored(
+            expected = "type = object",
+            original = Sealed.ObjectChild,
+            serializer = Sealed.serializer(),
+        )
     }
 
     @Test
-    fun testNestedDataClassDecode() {
-        val config = ConfigFactory.parseString(
-                """{
-                sealed: {
-                  type="data_class"
-                  name="test name"
-                  intField=10
-                }
-                }""")
-        val root = objectHocon.decodeFromConfig(CompositeClass.serializer(), config)
-        val sealed = root.sealed
-
-        assertTrue(sealed is Sealed.DataClassChild)
-        sealed as Sealed.DataClassChild
-        assertEquals("test name", sealed.name)
-        assertEquals(10, sealed.intField)
+    fun testNestedDataClass() {
+        objectHocon.assertStringFormAndRestored(
+            expected = "sealed { type = data_class, name = testDataClass, intField = 1 }",
+            original = CompositeClass(Sealed.DataClassChild("testDataClass")),
+            serializer = CompositeClass.serializer(),
+        )
     }
 
     @Test
     fun testDataClassDecode() {
-        val config = ConfigFactory.parseString(
-                """{
-                  type="data_class"
-                  name="testDataClass"
-                  intField=10
-                }""")
-        val sealed = objectHocon.decodeFromConfig(Sealed.serializer(), config)
-
-        assertTrue(sealed is Sealed.DataClassChild)
-        sealed as Sealed.DataClassChild
-        assertEquals("testDataClass", sealed.name)
-        assertEquals(10, sealed.intField)
+        objectHocon.assertStringFormAndRestored(
+            expected = "type = data_class, name = testDataClass, intField = 1",
+            original = Sealed.DataClassChild("testDataClass"),
+            serializer = Sealed.serializer(),
+        )
     }
 
     @Test
-    fun testDecodeChangedDiscriminator() {
+    fun testChangedDiscriminator() {
         val hocon = Hocon(objectHocon) {
             classDiscriminator = "key"
         }
 
-        val config = ConfigFactory.parseString(
-                """{
-                  type="override"
-                  key="type_child"
-                  intField=11
-                }""")
-        val sealed = hocon.decodeFromConfig(Sealed.serializer(), config)
-
-        assertTrue(sealed is Sealed.TypeChild)
-        sealed as Sealed.TypeChild
-        assertEquals("override", sealed.type)
-        assertEquals(11, sealed.intField)
+        hocon.assertStringFormAndRestored(
+            expected = "type = override, key = type_child, intField = 2",
+            original = Sealed.TypeChild(type = "override"),
+            serializer = Sealed.serializer(),
+        )
     }
 
     @Test
-    fun testDecodeChangedTypePropertyName() {
-        val config = ConfigFactory.parseString(
-                """{
-                  my_type="override"
-                  type="annotated_type_child"
-                  intField=12
-                }""")
-        val sealed = objectHocon.decodeFromConfig(Sealed.serializer(), config)
-
-        assertTrue(sealed is Sealed.AnnotatedTypeChild)
-        sealed as Sealed.AnnotatedTypeChild
-        assertEquals("override", sealed.type)
-        assertEquals(12, sealed.intField)
-    }
-
-    @Test
-    fun testArrayObjectEncode() {
-        val obj = CompositeClass(Sealed.ObjectChild)
-        val config = arrayHocon.encodeToConfig(obj)
-
-        assertConfigEquals("sealed = [ object, {} ]", config)
-    }
-
-    @Test
-    fun testArrayDataClassEncode() {
-        val obj = CompositeClass(Sealed.DataClassChild("testDataClass"))
-        val config = arrayHocon.encodeToConfig(obj)
-
-        assertConfigEquals("sealed = [ data_class, { name = testDataClass, intField = 1 } ]", config)
-    }
-
-    @Test
-    fun testObjectEncode() {
-        val obj = Sealed.ObjectChild
-        val config = objectHocon.encodeToConfig(Sealed.serializer(), obj)
-
-        assertConfigEquals("type = object", config)
-    }
-
-    @Test
-    fun testDataClassEncode() {
-        val obj = Sealed.DataClassChild("testDataClass")
-        val config = objectHocon.encodeToConfig(Sealed.serializer(), obj)
-
-        assertConfigEquals("type = data_class, name = testDataClass, intField = 1", config)
-    }
-
-    @Test
-    fun testEncodeChangedDiscriminator() {
-        val hocon = Hocon(objectHocon) {
-            classDiscriminator = "key"
-        }
-
-        val obj = Sealed.TypeChild(type = "override")
-        val config = hocon.encodeToConfig(Sealed.serializer(), obj)
-
-        assertConfigEquals("type = override, key = type_child, intField = 2", config)
-    }
-
-    @Test
-    fun testEncodeChangedTypePropertyName() {
-        val obj = Sealed.AnnotatedTypeChild(type = "override")
-        val config = objectHocon.encodeToConfig(Sealed.serializer(), obj)
-
-        assertConfigEquals("type = annotated_type_child, my_type = override, intField = 3", config)
+    fun testChangedTypePropertyName() {
+        objectHocon.assertStringFormAndRestored(
+            expected = "type = annotated_type_child, my_type = override, intField = 3",
+            original = Sealed.AnnotatedTypeChild(type = "override"),
+            serializer = Sealed.serializer(),
+        )
     }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -150,4 +150,20 @@ class HoconPolymorphismTest {
         assertEquals("override", sealed.type)
         assertEquals(12, sealed.intField)
     }
+
+    @Test
+    fun testArrayObjectEncode() {
+        val obj = CompositeClass(Sealed.ObjectChild)
+        val config = arrayHocon.encodeToConfig(obj)
+
+        assertConfigEquals("sealed = [ object, {} ]", config)
+    }
+
+    @Test
+    fun testArrayDataClassEncode() {
+        val obj = CompositeClass(Sealed.DataClassChild("testDataClass"))
+        val config = arrayHocon.encodeToConfig(obj)
+
+        assertConfigEquals("sealed = [ data_class, { name = testDataClass, intField = 1 } ]", config)
+    }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconRootObjectsTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconRootObjectsTest.kt
@@ -4,10 +4,9 @@
 
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.ConfigFactory
-import kotlinx.serialization.Serializable
-import org.junit.Ignore
-import org.junit.Test
+import com.typesafe.config.*
+import kotlinx.serialization.*
+import org.junit.*
 import kotlin.test.*
 
 class HoconRootMapTest {

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconRootObjectsTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconRootObjectsTest.kt
@@ -32,8 +32,8 @@ class HoconRootMapTest {
 
     @Serializable
     data class CompositeValue(
-            val a: String,
-            val b: Int
+        val a: String,
+        val b: Int
     )
 
     @Test
@@ -58,6 +58,21 @@ class HoconRootMapTest {
 
         // root-level list in config not supported but nullable list can be decoded from empty object
         assertNull(Hocon.decodeFromConfig<List<String>?>(config))
+    }
+
+    @Test
+    fun testUnsupportedRootObjectsEncode() {
+        assertWrongRootValue("LIST", listOf(1, 1, 2, 3, 5))
+        assertWrongRootValue("NUMBER", 42)
+        assertWrongRootValue("BOOLEAN", false)
+        assertWrongRootValue("NULL", null)
+        assertWrongRootValue("STRING", "string")
+    }
+
+    private fun assertWrongRootValue(type: String, rootValue: Any?) {
+        val message = "Value of type '$type' can't be used at the root of HOCON Config. " +
+                "It should be either object or map."
+        assertFailsWith<SerializationException>(message) { Hocon.encodeToConfig(rootValue) }
     }
 
     @Ignore

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconTesting.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconTesting.kt
@@ -1,0 +1,25 @@
+package kotlinx.serialization.hocon
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import kotlinx.serialization.KSerializer
+import org.junit.Assert.assertEquals
+
+internal inline fun <reified T : Any> Hocon.assertStringFormAndRestored(
+    expected: String,
+    original: T,
+    serializer: KSerializer<T>,
+    printResult: Boolean = false,
+) {
+    val expectedConfig = ConfigFactory.parseString(expected)
+    val config = this.encodeToConfig(serializer, original)
+    if (printResult) println("[Serialized form] $config")
+    assertEquals(expectedConfig, config)
+    val restored = this.decodeFromConfig(serializer, config)
+    if (printResult) println("[Restored form] $restored")
+    assertEquals(original, restored)
+}
+
+internal fun assertConfigEquals(expected: String, actual: Config) {
+    assertEquals(ConfigFactory.parseString(expected), actual)
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconTesting.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconTesting.kt
@@ -20,6 +20,6 @@ internal inline fun <reified T : Any> Hocon.assertStringFormAndRestored(
     assertEquals(original, restored)
 }
 
-internal fun assertConfigEquals(expected: String, actual: Config) {
-    assertEquals(ConfigFactory.parseString(expected), actual)
+internal fun Config.assertContains(expected: String) {
+    assertEquals(ConfigFactory.parseString(expected), this)
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconTesting.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconTesting.kt
@@ -1,8 +1,7 @@
 package kotlinx.serialization.hocon
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import kotlinx.serialization.KSerializer
+import com.typesafe.config.*
+import kotlinx.serialization.*
 import org.junit.Assert.assertEquals
 
 internal inline fun <reified T : Any> Hocon.assertStringFormAndRestored(


### PR DESCRIPTION
Just started to work on Hocon encoder implementation and want to make my work "transparent" to kotlinx.serialization team.
If this feature is not needed I'll stop working on it, otherwise, any comments are welcome!

### Use cases

- **Generate default config.** For now, it is possible only to provide default config files from resources.
- **Edit config from an app.** This feature might be useful for apps having both text config and UI for configuration.

### Essentials

- [x] Primitives encoding
- [x] Lists encoding
- [x] Maps encoding
- [x] Nested objects encoding
- [x] Polymorphic types encoding
- [x] `useConfigNamingConvention` support
- [x] Reasonable exception messages
- [x] Add KDoc comments

### Nice to have

- [x] `encodeDefaults` support
- [ ] Annotation like `JsonClassDiscriminator`
- [ ] Add description (origin) to config values

Closes #1609