### PR TITLE
Fix incorrect handling of object end when JsonTreeReader (JsonElement) is used with decodeToSequence

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonTreeReader.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonTreeReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.serialization.json.internal
@@ -34,8 +34,10 @@ internal class JsonTreeReader(
             result[key] = element
             // Verify the next token
             lastToken = lexer.consumeNextToken()
-            if (lastToken != TC_COMMA && lastToken != TC_END_OBJ) {
-                lexer.fail("Expected end of the object or comma")
+            when(lastToken) {
+                TC_COMMA -> Unit // no-op, can continue with `canConsumeValue` that verifies the token after comma
+                TC_END_OBJ -> break // `canConsumeValue` can return incorrect result, since it checks token _after_ TC_END_OBJ
+                else -> lexer.fail("Expected end of the object or comma")
             }
         }
         // Check for the correct ending

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonTreeReader.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonTreeReader.kt
@@ -4,7 +4,7 @@
 
 package kotlinx.serialization.json.internal
 
-import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.*
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -34,7 +34,7 @@ internal class JsonTreeReader(
             result[key] = element
             // Verify the next token
             lastToken = lexer.consumeNextToken()
-            when(lastToken) {
+            when (lastToken) {
                 TC_COMMA -> Unit // no-op, can continue with `canConsumeValue` that verifies the token after comma
                 TC_END_OBJ -> break // `canConsumeValue` can return incorrect result, since it checks token _after_ TC_END_OBJ
                 else -> lexer.fail("Expected end of the object or comma")

--- a/formats/json/jvmTest/src/kotlinx/serialization/features/JsonStreamFlowTest.kt
+++ b/formats/json/jvmTest/src/kotlinx/serialization/features/JsonStreamFlowTest.kt
@@ -8,7 +8,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.features.sealed.SealedChild
+import kotlinx.serialization.features.sealed.SealedParent
 import kotlinx.serialization.json.*
 import kotlinx.serialization.json.internal.JsonDecodingException
 import kotlinx.serialization.test.assertFailsWithMessage
@@ -106,6 +109,29 @@ class JsonStreamFlowTest {
         val input = "{\"data\":\"a\"}   {\"data\":\"b\"}\n\t{\"data\":\"c\"}"
         val ins = ByteArrayInputStream(input.encodeToByteArray())
         assertEquals(inputList, json.decodeToSequence(ins, StringData.serializer()).toList())
+    }
+
+    @Test
+    fun testJsonElement() {
+        val list = listOf<JsonElement>(
+            buildJsonObject { put("foo", "bar") },
+            buildJsonObject { put("foo", "baz") },
+            JsonPrimitive(10),
+            JsonPrimitive("abacaba"),
+            buildJsonObject { put("foo", "qux") }
+        )
+        val input = """${list[0]} ${list[1]} ${list[2]}    ${list[3]}    ${list[4]}"""
+        val decoded = json.decodeToSequence<JsonElement>(input.asInputStream()).toList()
+        assertEquals(list, decoded)
+    }
+
+
+    @Test
+    fun testSealedClasses() {
+        val input = """{"type":"first child","i":1,"j":10} {"type":"first child","i":1,"j":11}"""
+        val iter = json.iterateOverStream(input.asInputStream(), SealedParent.serializer())
+        iter.assertNext(SealedChild(10))
+        iter.assertNext(SealedChild(11))
     }
 
     @Test

--- a/formats/json/jvmTest/src/kotlinx/serialization/features/JsonStreamFlowTest.kt
+++ b/formats/json/jvmTest/src/kotlinx/serialization/features/JsonStreamFlowTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.*
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.features.sealed.SealedChild
 import kotlinx.serialization.features.sealed.SealedParent
@@ -120,9 +119,12 @@ class JsonStreamFlowTest {
             JsonPrimitive("abacaba"),
             buildJsonObject { put("foo", "qux") }
         )
-        val input = """${list[0]} ${list[1]} ${list[2]}    ${list[3]}    ${list[4]}"""
-        val decoded = json.decodeToSequence<JsonElement>(input.asInputStream()).toList()
-        assertEquals(list, decoded)
+        val inputWs = """${list[0]} ${list[1]} ${list[2]}    ${list[3]}    ${list[4]}"""
+        val decodedWs = json.decodeToSequence<JsonElement>(inputWs.asInputStream()).toList()
+        assertEquals(list, decodedWs, "Failed whitespace-separated test")
+        val inputArray = """[${list[0]}, ${list[1]},${list[2]}  ,  ${list[3]}    ,${list[4]}]"""
+        val decodedArrayWrap = json.decodeToSequence<JsonElement>(inputArray.asInputStream()).toList()
+        assertEquals(list, decodedArrayWrap, "Failed array-wrapped test")
     }
 
 


### PR DESCRIPTION
Fixes #1779