### PR TITLE
HOCON: parse strings into integers and booleans if possible

### DIFF
--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -47,18 +47,28 @@ public sealed class Hocon(
         override val serializersModule: SerializersModule
             get() = this@Hocon.serializersModule
 
-        abstract fun getTaggedConfigValue(tag: T): ConfigValue
+        abstract fun <E> getValueFromTaggedConfig(tag: T, valueResolver: (Config, String) -> E): E
 
-        private inline fun <reified E : Any> validateAndCast(tag: T, wrappedType: ConfigValueType): E {
-            val cfValue = getTaggedConfigValue(tag)
-            if (cfValue.valueType() != wrappedType) throw SerializationException("${cfValue.origin().description()} required to be a $wrappedType")
-            return cfValue.unwrapped() as E
+        private inline fun <reified E : Any> validateAndCast(tag: T): E {
+            return try {
+                when (E::class) {
+                    Number::class -> getValueFromTaggedConfig(tag) { config, path -> config.getNumber(path) } as E
+                    Boolean::class -> getValueFromTaggedConfig(tag) { config, path -> config.getBoolean(path) } as E
+                    String::class -> getValueFromTaggedConfig(tag) { config, path -> config.getString(path) } as E
+                    else -> getValueFromTaggedConfig(tag) { config, path -> config.getAnyRef(path) } as E
+                }
+            } catch (e: ConfigException) {
+                val configOrigin = e.origin()
+                val requiredType = E::class.simpleName
+                throw SerializationException("${configOrigin.description()} required to be of type $requiredType")
+            }
         }
 
-        private fun getTaggedNumber(tag: T) = validateAndCast<Number>(tag, ConfigValueType.NUMBER)
+        private fun getTaggedNumber(tag: T) = validateAndCast<Number>(tag)
 
-        override fun decodeTaggedString(tag: T) = validateAndCast<String>(tag, ConfigValueType.STRING)
+        override fun decodeTaggedString(tag: T) = validateAndCast<String>(tag)
 
+        override fun decodeTaggedBoolean(tag: T) = validateAndCast<Boolean>(tag)
         override fun decodeTaggedByte(tag: T): Byte = getTaggedNumber(tag).toByte()
         override fun decodeTaggedShort(tag: T): Short = getTaggedNumber(tag).toShort()
         override fun decodeTaggedInt(tag: T): Int = getTaggedNumber(tag).toInt()
@@ -67,17 +77,17 @@ public sealed class Hocon(
         override fun decodeTaggedDouble(tag: T): Double = getTaggedNumber(tag).toDouble()
 
         override fun decodeTaggedChar(tag: T): Char {
-            val s = validateAndCast<String>(tag, ConfigValueType.STRING)
+            val s = validateAndCast<String>(tag)
             if (s.length != 1) throw SerializationException("String \"$s\" is not convertible to Char")
             return s[0]
         }
 
-        override fun decodeTaggedValue(tag: T): Any = getTaggedConfigValue(tag).unwrapped()
+        override fun decodeTaggedValue(tag: T): Any = getValueFromTaggedConfig(tag) { c, s -> c.getAnyRef(s) }
 
-        override fun decodeTaggedNotNullMark(tag: T) = getTaggedConfigValue(tag).valueType() != ConfigValueType.NULL
+        override fun decodeTaggedNotNullMark(tag: T) = getValueFromTaggedConfig(tag) { c, s -> !c.getIsNull(s) }
 
         override fun decodeTaggedEnum(tag: T, enumDescriptor: SerialDescriptor): Int {
-            val s = validateAndCast<String>(tag, ConfigValueType.STRING)
+            val s = validateAndCast<String>(tag)
             return enumDescriptor.getElementIndexOrThrow(s)
         }
     }
@@ -105,14 +115,6 @@ public sealed class Hocon(
             val originalName = getElementName(index)
             return if (!useConfigNamingConvention) originalName
             else originalName.replace(NAMING_CONVENTION_REGEX) { "-${it.value.lowercase()}" }
-        }
-
-        override fun getTaggedConfigValue(tag: String): ConfigValue {
-            return conf.getValue(tag)
-        }
-
-        override fun decodeTaggedNotNullMark(tag: String): Boolean {
-            return !conf.getIsNull(tag)
         }
 
         override fun decodeNotNullMark(): Boolean {
@@ -159,6 +161,10 @@ public sealed class Hocon(
                 else -> this
             }
         }
+
+        override fun <E> getValueFromTaggedConfig(tag: String, valueResolver: (Config, String) -> E): E {
+            return valueResolver(conf, tag)
+        }
     }
 
     private inner class ListConfigReader(private val list: ConfigList) : ConfigConverter<Int>() {
@@ -179,7 +185,11 @@ public sealed class Hocon(
             return if (ind > list.size - 1) DECODE_DONE else ind
         }
 
-        override fun getTaggedConfigValue(tag: Int): ConfigValue = list[tag]
+        override fun <E> getValueFromTaggedConfig(tag: Int, valueResolver: (Config, String) -> E): E {
+            val tagString = tag.toString()
+            val configValue = valueResolver(list[tag].atKey(tagString), tagString)
+            return configValue
+        }
     }
 
     private inner class MapConfigReader(map: ConfigObject) : ConfigConverter<Int>() {
@@ -210,13 +220,16 @@ public sealed class Hocon(
             return if (ind >= indexSize) DECODE_DONE else ind
         }
 
-        override fun getTaggedConfigValue(tag: Int): ConfigValue {
+        override fun <E> getValueFromTaggedConfig(tag: Int, valueResolver: (Config, String) -> E): E {
             val idx = tag / 2
-            return if (tag % 2 == 0) { // entry as string
-                ConfigValueFactory.fromAnyRef(keys[idx])
+            val tagString = tag.toString()
+            val configValue = if (tag % 2 == 0) { // entry as string
+                ConfigValueFactory.fromAnyRef(keys[idx]).atKey(tagString)
             } else {
-                values[idx]
+                val configValue = values[idx]
+                configValue.atKey(tagString)
             }
+            return valueResolver(configValue, tagString)
         }
     }
 
@@ -237,7 +250,7 @@ public sealed class Hocon(
  */
 @ExperimentalSerializationApi
 public inline fun <reified T> Hocon.decodeFromConfig(config: Config): T =
-    decodeFromConfig(serializersModule.serializer(), config)
+        decodeFromConfig(serializersModule.serializer(), config)
 
 /**
  * Creates an instance of [Hocon] configured from the optionally given [Hocon instance][from]

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -250,7 +250,7 @@ public sealed class Hocon(
  */
 @ExperimentalSerializationApi
 public inline fun <reified T> Hocon.decodeFromConfig(config: Config): T =
-        decodeFromConfig(serializersModule.serializer(), config)
+    decodeFromConfig(serializersModule.serializer(), config)
 
 /**
  * Creates an instance of [Hocon] configured from the optionally given [Hocon instance][from]

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconValuesTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconValuesTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.serialization.hocon
 
+import kotlin.test.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
 import org.junit.*
@@ -80,6 +81,13 @@ class HoconValuesTest {
     }
 
     @Test
+    fun `unparseable data fails with exception`() {
+        val e = assertFailsWith<SerializationException> {
+            deserializeConfig("e = A, b=not-a-boolean", OtherConfig.serializer())
+        }
+    }
+
+    @Test
     fun `deserialize other types from strings`() {
         val obj = deserializeConfig("""e = "A", b="true" """, OtherConfig.serializer())
         assertEquals(Choice.A, obj.e)
@@ -135,9 +143,7 @@ class HoconValuesTest {
     fun `deserialize list of integer string values`() {
         val configString = """i1 = [ "1","3" ]"""
         val obj = deserializeConfig(configString, WithList.serializer())
-        with(obj) {
-            assertEquals(listOf(1, 3), i1)
-        }
+        assertEquals(listOf(1, 3), obj.i1)
     }
 
     @Test

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconValuesTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconValuesTest.kt
@@ -150,17 +150,13 @@ class HoconValuesTest {
     fun `deserialize map with integers`() {
         val configString = """m = { 2: 1, 4: 3 }"""
         val obj = deserializeConfig(configString, WithMap.serializer())
-        with(obj) {
-            assertEquals(mapOf(2 to 1, 4 to 3), m)
-        }
+        assertEquals(mapOf(2 to 1, 4 to 3), obj.m)
     }
 
     @Test
     fun `deserialize map with integers as strings`() {
         val configString = """m = { "2": "1", "4":"3" }"""
         val obj = deserializeConfig(configString, WithMap.serializer())
-        with(obj) {
-            assertEquals(mapOf(2 to 1, 4 to 3), m)
-        }
+        assertEquals(mapOf(2 to 1, 4 to 3), obj.m)
     }
 }


### PR DESCRIPTION
HOCON suggest that parsers should apply certain automatic conversions, especially when reading integers/numbers or booleans from strings ([1]).

This is an attempt to resolve the most pressing issues that would resolve https://github.com/Kotlin/kotlinx.serialization/issues/1439 . 
This PR changes parsing so that it now relies on the parsing capabilities for the `Config` class, and not on the obtained `ConfigValues`.

This PR does not claim to  cover all automatic conversions mentioned in [1], but is focused on parsing numbers and booleans from strings only.

[1]: https://github.com/lightbend/config/blob/main/HOCON.md#automatic-type-conversions