### PR TITLE
Use EnumSerializer for explicitly serializable enum instead of auto-generated

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/Enums.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Enums.kt
@@ -76,14 +76,12 @@ internal fun <T : Enum<T>> createMarkedEnumSerializer(
     return EnumSerializer(serialName, values, descriptor)
 }
 
-// TODO we can create another class for factories, it may be a copy-paste of this class or a subclass for some `AbstractEnumSerializer` with common `serialize`, `deserialize` and `toString` functions
 @PublishedApi
 @OptIn(ExperimentalSerializationApi::class)
 internal class EnumSerializer<T : Enum<T>>(
     serialName: String,
     private val values: Array<T>
 ) : KSerializer<T> {
-    @Volatile
     private var overriddenDescriptor: SerialDescriptor? = null
 
     internal constructor(serialName: String, values: Array<T>, descriptor: SerialDescriptor) : this(serialName, values) {

--- a/core/commonTest/src/kotlinx/serialization/CachedSerializersTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/CachedSerializersTest.kt
@@ -22,9 +22,34 @@ class CachedSerializersTest {
     @Serializable
     abstract class Abstract
 
+    @Serializable
+    enum class SerializableEnum {A, B}
+
+    @SerialInfo
+    annotation class MyAnnotation(val x: Int)
+
+    @Serializable
+    enum class SerializableMarkedEnum {
+        @SerialName("first")
+        @MyAnnotation(1)
+        C,
+        @MyAnnotation(2)
+        D
+    }
+
     @Test
     fun testObjectSerializersAreSame() = noJsLegacy {
         assertSame(Object.serializer(), Object.serializer())
+    }
+
+    @Test
+    fun testSerializableEnumSerializersAreSame() = noJsLegacy {
+        assertSame(SerializableEnum.serializer(), SerializableEnum.serializer())
+    }
+
+    @Test
+    fun testSerializableMarkedEnumSerializersAreSame() = noJsLegacy {
+        assertSame(SerializableMarkedEnum.serializer(), SerializableMarkedEnum.serializer())
     }
 
     @Test

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
@@ -100,17 +100,4 @@ class SerializersLookupEnumTest {
         assertIs<EnumExternalClassSerializer>(EnumExternalClass.serializer())
         assertIs<EnumExternalClassSerializer>(serializer<EnumExternalClass>())
     }
-
-    @Test
-    fun testEnumPolymorphic() {
-        if (isJvm()) {
-            assertEquals(
-                PolymorphicSerializer(EnumPolymorphic::class).descriptor,
-                serializer<EnumPolymorphic>().descriptor
-            )
-        } else {
-            // FIXME serializer<PolymorphicEnum> is broken for K/JS and K/Native. Remove `assertFails` after fix
-            assertFails { serializer<EnumPolymorphic>() }
-        }
-    }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/EnumSerializationTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/EnumSerializationTest.kt
@@ -127,7 +127,7 @@ class EnumSerializationTest : JsonTestBase() {
     fun testStructurallyEqualDescriptors() {
         val libraryGenerated = Wrapper.serializer().descriptor.getElementDescriptor(0)
         val codeGenerated = MyEnum2.serializer().descriptor
-        assertNotEquals(libraryGenerated::class, codeGenerated::class)
+        assertEquals(libraryGenerated::class, codeGenerated::class)
         libraryGenerated.assertDescriptorEqualsTo(codeGenerated)
     }
 }


### PR DESCRIPTION
Resolves Kotlin/kotlinx.serialization#683 Kotlin/kotlinx.serialization#1372