### PR TITLE
Add packed support to the ProtoBufSchemaGenerator.

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
@@ -200,9 +200,10 @@ public object ProtoBufSchemaGenerator {
             val isPackRequested = annotations.filterIsInstance<ProtoPacked>().singleOrNull() != null
 
             when {
-                !isPackRequested -> appendLine(';')
-                !isList -> throw IllegalArgumentException("ProtoPacked annotation provided for ${messageDescriptor.getElementName(index)}: $fieldDescriptor, but packing is only valid on repeated fields (lists)")
-                !fieldDescriptor.getElementDescriptor(0).isPackable -> throw IllegalArgumentException("ProtoPacked annotation provided for ${messageDescriptor.getElementName(index)}: $fieldDescriptor, but packed can only be applied to primitive numeric types")
+                !isPackRequested ||
+                !isList || // ignore as packed only meaningful on repeated types
+                !fieldDescriptor.getElementDescriptor(0).isPackable // Ignore if the type is not allowed to be packed
+                     -> appendLine(';')
                 else -> appendLine(" [packed=true];")
             }
         }

--- a/formats/protobuf/jvmTest/resources/PackedListClass.proto
+++ b/formats/protobuf/jvmTest/resources/PackedListClass.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+package kotlinx.serialization.protobuf.schema.generator;
+
+// serial name 'kotlinx.serialization.protobuf.schema.GenerationTest.PackedListClass'
+message PackedListClass {
+  repeated int32 intList = 1 [packed=true];
+  repeated int32 intArray = 2 [packed=true];
+  // WARNING: nullable elements of collections can not be represented in protobuf
+  repeated int32 boxedIntArray = 3 [packed=true];
+  repeated OptionsClass messageList = 4;
+  repeated OverriddenEnumName enumList = 5;
+}
+
+// serial name 'kotlinx.serialization.protobuf.schema.GenerationTest.OptionsClass'
+message OptionsClass {
+  required int32 i = 1;
+}
+
+enum OverriddenEnumName {
+  FIRST = 0;
+  OverriddenElementName = 1;
+}

--- a/formats/protobuf/jvmTest/resources/common/schema.proto
+++ b/formats/protobuf/jvmTest/resources/common/schema.proto
@@ -42,6 +42,16 @@ message ListClass {
   repeated OverriddenEnumName enumList = 5;
 }
 
+// serial name 'kotlinx.serialization.protobuf.schema.GenerationTest.PackedListClass'
+message PackedListClass {
+  repeated int32 intList = 1 [packed=true];
+  repeated int32 intArray = 2 [packed=true];
+  // WARNING: nullable elements of collections can not be represented in protobuf
+  repeated int32 boxedIntArray = 3 [packed=true];
+  repeated OptionsClass messageList = 4;
+  repeated OverriddenEnumName enumList = 5;
+}
+
 // serial name 'kotlinx.serialization.protobuf.schema.GenerationTest.MapClass'
 message MapClass {
   map<int32, float> scalarMap = 1;

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/schema/GenerationTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/schema/GenerationTest.kt
@@ -3,8 +3,7 @@ package kotlinx.serialization.protobuf.schema
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.protobuf.ProtoIntegerType
-import kotlinx.serialization.protobuf.ProtoNumber
-import kotlinx.serialization.protobuf.ProtoType
+import kotlinx.serialization.protobuf.*
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,6 +15,7 @@ internal val commonClasses = listOf(
     GenerationTest.FieldNumberClass::class,
     GenerationTest.SerialNameClass::class,
     GenerationTest.ListClass::class,
+    GenerationTest.PackedListClass::class,
     GenerationTest.MapClass::class,
     GenerationTest.OptionalClass::class,
     GenerationTest.ContextualHolder::class,
@@ -88,6 +88,15 @@ class GenerationTest {
         val intList: List<Int>,
         val intArray: IntArray,
         val boxedIntArray: Array<Int?>,
+        val messageList: List<OptionsClass>,
+        val enumList: List<SerialNameEnum>
+    )
+
+    @Serializable
+    class PackedListClass(
+        @ProtoPacked val intList: List<Int>,
+        @ProtoPacked val intArray: IntArray,
+        @ProtoPacked val boxedIntArray: Array<Int?>,
         val messageList: List<OptionsClass>,
         val enumList: List<SerialNameEnum>
     )


### PR DESCRIPTION
As packed fields are now supported, also add support for packed fields to the schema generator. Note that the generator will throw exceptions when `@ProtoPacked` is applied to either non-list types or lists of non-numeric types.