### PR TITLE
Allow Kotlin's null literal in JSON DSL

### DIFF
--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -169,6 +169,7 @@ public final class kotlinx/serialization/json/JsonElementBuildersKt {
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Boolean;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Number;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/String;)Z
+	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Void;)Z
 	public static final fun addJsonArray (Lkotlinx/serialization/json/JsonArrayBuilder;Lkotlin/jvm/functions/Function1;)Z
 	public static final fun addJsonObject (Lkotlinx/serialization/json/JsonArrayBuilder;Lkotlin/jvm/functions/Function1;)Z
 	public static final fun buildJsonArray (Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/json/JsonArray;
@@ -176,6 +177,7 @@ public final class kotlinx/serialization/json/JsonElementBuildersKt {
 	public static final fun put (Lkotlinx/serialization/json/JsonObjectBuilder;Ljava/lang/String;Ljava/lang/Boolean;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun put (Lkotlinx/serialization/json/JsonObjectBuilder;Ljava/lang/String;Ljava/lang/Number;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun put (Lkotlinx/serialization/json/JsonObjectBuilder;Ljava/lang/String;Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
+	public static final fun put (Lkotlinx/serialization/json/JsonObjectBuilder;Ljava/lang/String;Ljava/lang/Void;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun putJsonArray (Lkotlinx/serialization/json/JsonObjectBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun putJsonObject (Lkotlinx/serialization/json/JsonObjectBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/json/JsonElement;
 }
@@ -184,6 +186,7 @@ public final class kotlinx/serialization/json/JsonElementKt {
 	public static final fun JsonPrimitive (Ljava/lang/Boolean;)Lkotlinx/serialization/json/JsonPrimitive;
 	public static final fun JsonPrimitive (Ljava/lang/Number;)Lkotlinx/serialization/json/JsonPrimitive;
 	public static final fun JsonPrimitive (Ljava/lang/String;)Lkotlinx/serialization/json/JsonPrimitive;
+	public static final fun JsonPrimitive (Ljava/lang/Void;)Lkotlinx/serialization/json/JsonNull;
 	public static final fun getBoolean (Lkotlinx/serialization/json/JsonPrimitive;)Z
 	public static final fun getBooleanOrNull (Lkotlinx/serialization/json/JsonPrimitive;)Ljava/lang/Boolean;
 	public static final fun getContentOrNull (Lkotlinx/serialization/json/JsonPrimitive;)Ljava/lang/String;

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -69,7 +69,9 @@ public fun JsonPrimitive(value: String?): JsonPrimitive {
     return JsonLiteral(value, isString = true)
 }
 
-/** Returns [JsonNull]. */
+/**
+ * Creates [JsonNull].
+ */
 @ExperimentalSerializationApi
 @Suppress("FunctionName", "UNUSED_PARAMETER") // allows to call `JsonPrimitive(null)`
 public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -70,7 +70,8 @@ public fun JsonPrimitive(value: String?): JsonPrimitive {
 }
 
 /** Returns [JsonNull]. */
-@Suppress("FunctionName", "UNUSED_PARAMETER")
+@ExperimentalSerializationApi
+@Suppress("FunctionName", "UNUSED_PARAMETER") // allow `JsonPrimitive(null)`
 public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull
 
 // JsonLiteral is deprecated for public use and no longer available. Please use JsonPrimitive instead

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -71,7 +71,7 @@ public fun JsonPrimitive(value: String?): JsonPrimitive {
 
 /** Returns [JsonNull]. */
 @ExperimentalSerializationApi
-@Suppress("FunctionName", "UNUSED_PARAMETER") // allow `JsonPrimitive(null)`
+@Suppress("FunctionName", "UNUSED_PARAMETER") // allows to call `JsonPrimitive(null)`
 public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull
 
 // JsonLiteral is deprecated for public use and no longer available. Please use JsonPrimitive instead

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -76,16 +76,16 @@ public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull
 // JsonLiteral is deprecated for public use and no longer available. Please use JsonPrimitive instead
 internal class JsonLiteral internal constructor(
     body: Any,
-    public override val isString: Boolean
+    override val isString: Boolean
 ) : JsonPrimitive() {
-    public override val content: String = body.toString()
+    override val content: String = body.toString()
 
-    public override fun toString(): String =
+    override fun toString(): String =
         if (isString) buildString { printQuoted(content) }
         else content
 
     // Compare by `content` and `isString`, because body can be kotlin.Long=42 or kotlin.String="42"
-    public override fun equals(other: Any?): Boolean {
+    override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
         other as JsonLiteral
@@ -94,7 +94,7 @@ internal class JsonLiteral internal constructor(
         return true
     }
 
-    public override fun hashCode(): Int {
+    override fun hashCode(): Int {
         var result = isString.hashCode()
         result = 31 * result + content.hashCode()
         return result

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -77,16 +77,16 @@ public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull
 // JsonLiteral is deprecated for public use and no longer available. Please use JsonPrimitive instead
 internal class JsonLiteral internal constructor(
     body: Any,
-    override val isString: Boolean
+    public override val isString: Boolean
 ) : JsonPrimitive() {
-    override val content: String = body.toString()
+    public override val content: String = body.toString()
 
-    override fun toString(): String =
+    public override fun toString(): String =
         if (isString) buildString { printQuoted(content) }
         else content
 
     // Compare by `content` and `isString`, because body can be kotlin.Long=42 or kotlin.String="42"
-    override fun equals(other: Any?): Boolean {
+    public override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
         other as JsonLiteral
@@ -95,7 +95,7 @@ internal class JsonLiteral internal constructor(
         return true
     }
 
-    override fun hashCode(): Int {
+    public override fun hashCode(): Int {
         var result = isString.hashCode()
         result = 31 * result + content.hashCode()
         return result

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -69,6 +69,10 @@ public fun JsonPrimitive(value: String?): JsonPrimitive {
     return JsonLiteral(value, isString = true)
 }
 
+/** Returns [JsonNull]. */
+@Suppress("FunctionName", "UNUSED_PARAMETER")
+public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull
+
 // JsonLiteral is deprecated for public use and no longer available. Please use JsonPrimitive instead
 internal class JsonLiteral internal constructor(
     body: Any,

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -72,7 +72,7 @@ public class JsonObjectBuilder @PublishedApi internal constructor() {
 }
 
 /**
- * Add the [JSON][JsonObject] produced by the [builderAction] function to a resulting json object using the given [key].
+ * Add the [JSON object][JsonObject] produced by the [builderAction] function to a resulting JSON object using the given [key].
  *
  * Returns the previous value associated with [key], or `null` if the key was not present.
  */
@@ -80,7 +80,7 @@ public fun JsonObjectBuilder.putJsonObject(key: String, builderAction: JsonObjec
     put(key, buildJsonObject(builderAction))
 
 /**
- * Add the [JSON array][JsonArray] produced by the [builderAction] function to a resulting json object using the given [key].
+ * Add the [JSON array][JsonArray] produced by the [builderAction] function to a resulting JSON object using the given [key].
  *
  * Returns the previous value associated with [key], or `null` if the key was not present.
  */
@@ -125,7 +125,7 @@ public class JsonArrayBuilder @PublishedApi internal constructor() {
     private val content: MutableList<JsonElement> = mutableListOf()
 
     /**
-     * Adds the given JSON [element] to a resulting array.
+     * Adds the given JSON [element] to a resulting JSON array.
      *
      * Always returns `true` similarly to [ArrayList] specification.
      */
@@ -139,28 +139,28 @@ public class JsonArrayBuilder @PublishedApi internal constructor() {
 }
 
 /**
- * Adds the given boolean [value] to a resulting array.
+ * Adds the given boolean [value] to a resulting JSON array.
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */
 public fun JsonArrayBuilder.add(value: Boolean?): Boolean = add(JsonPrimitive(value))
 
 /**
- * Adds the given numeric [value] to a resulting array.
+ * Adds the given numeric [value] to a resulting JSON array.
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */
 public fun JsonArrayBuilder.add(value: Number?): Boolean = add(JsonPrimitive(value))
 
 /**
- * Adds the given string [value] to a resulting array.
+ * Adds the given string [value] to a resulting JSON array.
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */
 public fun JsonArrayBuilder.add(value: String?): Boolean = add(JsonPrimitive(value))
 
 /**
- * Adds `null` to a resulting array.
+ * Adds `null` to a resulting JSON array.
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */
@@ -168,7 +168,7 @@ public fun JsonArrayBuilder.add(value: String?): Boolean = add(JsonPrimitive(val
 public fun JsonArrayBuilder.add(value: Nothing?): Boolean = add(JsonNull)
 
 /**
- * Adds the [JSON][JsonObject] produced by the [builderAction] function to a resulting array.
+ * Adds the [JSON object][JsonObject] produced by the [builderAction] function to a resulting JSON array.
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */
@@ -176,7 +176,7 @@ public fun JsonArrayBuilder.addJsonObject(builderAction: JsonObjectBuilder.() ->
     add(buildJsonObject(builderAction))
 
 /**
- * Adds the [JSON][JsonArray] produced by the [builderAction] function to a resulting array.
+ * Adds the [JSON array][JsonArray] produced by the [builderAction] function to a resulting JSON array.
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.serialization.json
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.contracts.*
 
 /**
@@ -113,7 +114,8 @@ public fun JsonObjectBuilder.put(key: String, value: String?): JsonElement? = pu
  *
  * Returns the previous value associated with [key], or `null` if the key was not present.
  */
-@Suppress("UNUSED_PARAMETER")
+@ExperimentalSerializationApi
+@Suppress("UNUSED_PARAMETER") // allow `put("key", null)`
 public fun JsonObjectBuilder.put(key: String, value: Nothing?): JsonElement? = put(key, JsonNull)
 
 /**
@@ -164,7 +166,8 @@ public fun JsonArrayBuilder.add(value: String?): Boolean = add(JsonPrimitive(val
  *
  * Always returns `true` similarly to [ArrayList] specification.
  */
-@Suppress("UNUSED_PARAMETER")
+@ExperimentalSerializationApi
+@Suppress("UNUSED_PARAMETER") // allow `add(null)`
 public fun JsonArrayBuilder.add(value: Nothing?): Boolean = add(JsonNull)
 
 /**

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -183,8 +183,6 @@ public fun JsonArrayBuilder.addJsonObject(builderAction: JsonObjectBuilder.() ->
 public fun JsonArrayBuilder.addJsonArray(builderAction: JsonArrayBuilder.() -> Unit): Boolean =
     add(buildJsonArray(builderAction))
 
-private const val infixToDeprecated = "Infix 'to' operator is deprecated for removal for the favour of 'add'"
-private const val unaryPlusDeprecated = "Unary plus is deprecated for removal for the favour of 'add'"
 
 @DslMarker
 internal annotation class JsonDslMarker

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -109,6 +109,14 @@ public fun JsonObjectBuilder.put(key: String, value: Number?): JsonElement? = pu
 public fun JsonObjectBuilder.put(key: String, value: String?): JsonElement? = put(key, JsonPrimitive(value))
 
 /**
+ * Add `null` to a resulting JSON object using the given [key].
+ *
+ * Returns the previous value associated with [key], or `null` if the key was not present.
+ */
+@Suppress("UNUSED_PARAMETER")
+public fun JsonObjectBuilder.put(key: String, value: Nothing?): JsonElement? = put(key, JsonNull)
+
+/**
  * DSL builder for a [JsonArray]. To create an instance of builder, use [buildJsonArray] build function.
  */
 @JsonDslMarker
@@ -150,6 +158,14 @@ public fun JsonArrayBuilder.add(value: Number?): Boolean = add(JsonPrimitive(val
  * Always returns `true` similarly to [ArrayList] specification.
  */
 public fun JsonArrayBuilder.add(value: String?): Boolean = add(JsonPrimitive(value))
+
+/**
+ * Adds `null` to a resulting array.
+ *
+ * Always returns `true` similarly to [ArrayList] specification.
+ */
+@Suppress("UNUSED_PARAMETER")
+public fun JsonArrayBuilder.add(value: Nothing?): Boolean = add(JsonNull)
 
 /**
  * Adds the [JSON][JsonObject] produced by the [builderAction] function to a resulting array.

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -115,7 +115,7 @@ public fun JsonObjectBuilder.put(key: String, value: String?): JsonElement? = pu
  * Returns the previous value associated with [key], or `null` if the key was not present.
  */
 @ExperimentalSerializationApi
-@Suppress("UNUSED_PARAMETER") // allow `put("key", null)`
+@Suppress("UNUSED_PARAMETER") // allows to call `put("key", null)`
 public fun JsonObjectBuilder.put(key: String, value: Nothing?): JsonElement? = put(key, JsonNull)
 
 /**
@@ -167,7 +167,7 @@ public fun JsonArrayBuilder.add(value: String?): Boolean = add(JsonPrimitive(val
  * Always returns `true` similarly to [ArrayList] specification.
  */
 @ExperimentalSerializationApi
-@Suppress("UNUSED_PARAMETER") // allow `add(null)`
+@Suppress("UNUSED_PARAMETER") // allows to call `add(null)`
 public fun JsonArrayBuilder.add(value: Nothing?): Boolean = add(JsonNull)
 
 /**

--- a/formats/json/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -24,8 +24,9 @@ class JsonBuildersTest {
             put("primitive", JsonPrimitive(42))
             put("boolean", true)
             put("literal", "foo")
+            put("null2", null)
         }
-        assertEquals("""{"object":{"k":"v"},"array":[{"nestedLiteral":true}],"null":null,"primitive":42,"boolean":true,"literal":"foo"}""", json.toString())
+        assertEquals("""{"object":{"k":"v"},"array":[{"nestedLiteral":true}],"null":null,"primitive":42,"boolean":true,"literal":"foo","null2":null}""", json.toString())
     }
 
     @Test
@@ -35,10 +36,11 @@ class JsonBuildersTest {
             addJsonArray {
                 for (i in 1..10) add(i)
             }
+            add(null)
             addJsonObject {
                 put("stringKey", "stringValue")
             }
         }
-        assertEquals("""[true,[1,2,3,4,5,6,7,8,9,10],{"stringKey":"stringValue"}]""", json.toString())
+        assertEquals("""[true,[1,2,3,4,5,6,7,8,9,10],null,{"stringKey":"stringValue"}]""", json.toString())
     }
 }


### PR DESCRIPTION
Right now you can not really use Kotlin's `null` literal with the JSON DSL:
```kotlin
val obj = buildJsonObject {
    put("string", "string")
    put("boolean", true)
    put("number", 1)

    // Error: Overload resolution ambiguity. All these functions match.
    // - public fun JsonObjectBuilder.put(key: String, value: Boolean?): JsonElement? defined in kotlinx.serialization.json
    // - public fun JsonObjectBuilder.put(key: String, value: Number?): JsonElement? defined in kotlinx.serialization.json
    // - public fun JsonObjectBuilder.put(key: String, value: String?): JsonElement? defined in kotlinx.serialization.json
    put("null", null)
}

val arr = buildJsonArray {
    add("string")
    add(true)
    add(1)

    // Error: Overload resolution ambiguity. All these functions match.
    // - public fun JsonArrayBuilder.add(value: Boolean?): Boolean defined in kotlinx.serialization.json
    // - public fun JsonArrayBuilder.add(value: Number?): Boolean defined in kotlinx.serialization.json
    // - public fun JsonArrayBuilder.add(value: String?): Boolean defined in kotlinx.serialization.json
    add(null)
}

val p0 = JsonPrimitive("string")
val p1 = JsonPrimitive(true)
val p2 = JsonPrimitive(1)

// Error: Overload resolution ambiguity. All these functions match.
// - public fun JsonPrimitive(value: Boolean?): JsonPrimitive defined in kotlinx.serialization.json
// - public fun JsonPrimitive(value: Number?): JsonPrimitive defined in kotlinx.serialization.json
// - public fun JsonPrimitive(value: String?): JsonPrimitive defined in kotlinx.serialization.json
val p3 = JsonPrimitive(null)
```
All of these errors could be resolved by using a cast like `null as String?` or by using `JsonNull` directly.
However, this is somewhat irritating as other primitives that are supported by JSON (numbers, strings, `true` and `false`) can be used directly while `null` can't.

To resolve the overload resolution ambiguity and allow use of the `null` literal in the JSON DSL, this PR adds overloads for the `JsonObjectBuilder.put()`, `JsonArrayBuilder.add()` and `JsonPrimitve()` functions that take an argument of type `Nothing?`.