### PR TITLE
Fix issue with registering default polymorphic serializer

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -153,7 +153,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
         defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?,
         allowOverwrite: Boolean
     ) {
-        val previous = polyBase2DefaultDeserializerProvider[baseClass]
+        val previous = polyBase2DefaultSerializerProvider[baseClass]
         if (previous != null && previous != defaultSerializerProvider && !allowOverwrite) {
             throw IllegalArgumentException("Default serializers provider for class $baseClass is already registered: $previous")
         }


### PR DESCRIPTION
It looks like the code was copied and the update `deserializer` -> `serializer` was not made in that single place.

The following would throw an exception (but shouldn't):
```
SerializersModule {
    polymorphicDefaultDeserializer(AutomationActivityV1::class) { AutomationActivityV1Serializer }
    polymorphicDefaultSerializer(AutomationActivityV1::class) { AutomationActivityV1Serializer }
}
```
whereas the following would not (but should):
```
SerializersModule {
    polymorphicDefaultSerializer(AutomationActivityV1::class) { AutomationActivityV1Serializer }
    polymorphicDefaultSerializer(AutomationActivityV1::class) { AutomationActivityV1Serializer }
}
```