### PR TITLE
Mark block in corresponding encodeStructure/decodeStructure extension…

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/encoding/Decoding.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/Decoding.kt
@@ -562,19 +562,12 @@ public interface CompositeDecoder {
  */
 public inline fun <T> Decoder.decodeStructure(
     descriptor: SerialDescriptor,
-    block: CompositeDecoder.() -> T
+    crossinline block: CompositeDecoder.() -> T
 ): T {
     val composite = beginStructure(descriptor)
-    var ex: Throwable? = null
-    try {
-        return composite.block()
-    } catch (e: Throwable) {
-        ex = e
-        throw e
-    } finally {
-        // End structure only if there is no exception, otherwise it can be swallowed
-        if (ex == null) composite.endStructure(descriptor)
-    }
+    val result = composite.block()
+    composite.endStructure(descriptor)
+    return result
 }
 
 private const val decodeMethodDeprecated = "Please migrate to decodeElement method which accepts old value." +

--- a/core/commonMain/src/kotlinx/serialization/encoding/Encoding.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/Encoding.kt
@@ -473,18 +473,13 @@ public interface CompositeEncoder {
 /**
  * Begins a structure, encodes it using the given [block] and ends it.
  */
-public inline fun Encoder.encodeStructure(descriptor: SerialDescriptor, block: CompositeEncoder.() -> Unit) {
+public inline fun Encoder.encodeStructure(
+    descriptor: SerialDescriptor,
+    crossinline block: CompositeEncoder.() -> Unit
+) {
     val composite = beginStructure(descriptor)
-    var ex: Throwable? = null
-    try {
-        composite.block()
-    } catch (e: Throwable) {
-        ex = e
-        throw e
-    } finally {
-        // End structure only if there is no exception, otherwise it can be swallowed
-        if (ex == null) composite.endStructure(descriptor)
-    }
+    composite.block()
+    composite.endStructure(descriptor)
 }
 
 /**
@@ -495,10 +490,9 @@ public inline fun Encoder.encodeCollection(
     collectionSize: Int,
     crossinline block: CompositeEncoder.() -> Unit
 ) {
-    with(beginCollection(descriptor, collectionSize)) {
-        block()
-        endStructure(descriptor)
-    }
+    val composite = beginCollection(descriptor, collectionSize)
+    composite.block()
+    composite.endStructure(descriptor)
 }
 
 /**

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -40,7 +40,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
         var klassName: String? = null
         var value: Any? = null
         if (decodeSequentially()) {
-            return decodeSequentially(this)
+            return@decodeStructure decodeSequentially(this)
         }
 
         mainLoop@ while (true) {


### PR DESCRIPTION
…s as crossinline to reduce amount of bytecode

Fixes #1750