### PR TITLE
Docs: Add decodeSequentially possible skipping decodeElementIndex

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/encoding/Decoding.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/Decoding.kt
@@ -411,6 +411,8 @@ public interface CompositeDecoder {
      *     return descriptor.getElementIndex(nextKey) // getElementIndex can return UNKNOWN_NAME
      * }
      * ```
+     *
+     * If [decodeSequentially] returns `true`, the caller might skip calling this method.
      */
     public fun decodeElementIndex(descriptor: SerialDescriptor): Int
 


### PR DESCRIPTION
Already in the KDoc at `decodeSequentially`, but missing at `decodeElementIndex`.