### PR TITLE
Support tagged not null marks

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -1087,7 +1087,7 @@ public abstract class kotlinx/serialization/internal/TaggedEncoder : kotlinx/ser
 	public final fun encodeIntElement (Lkotlinx/serialization/descriptors/SerialDescriptor;II)V
 	public final fun encodeLong (J)V
 	public final fun encodeLongElement (Lkotlinx/serialization/descriptors/SerialDescriptor;IJ)V
-	public final fun encodeNotNullMark ()V
+	public fun encodeNotNullMark ()V
 	public fun encodeNull ()V
 	public fun encodeNullableSerializableElement (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
 	public fun encodeNullableSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
@@ -1106,6 +1106,7 @@ public abstract class kotlinx/serialization/internal/TaggedEncoder : kotlinx/ser
 	protected fun encodeTaggedInline (Ljava/lang/Object;Lkotlinx/serialization/descriptors/SerialDescriptor;)Lkotlinx/serialization/encoding/Encoder;
 	protected fun encodeTaggedInt (Ljava/lang/Object;I)V
 	protected fun encodeTaggedLong (Ljava/lang/Object;J)V
+	protected fun encodeTaggedNonNullMark (Ljava/lang/Object;)V
 	protected fun encodeTaggedNull (Ljava/lang/Object;)V
 	protected fun encodeTaggedShort (Ljava/lang/Object;S)V
 	protected fun encodeTaggedString (Ljava/lang/Object;Ljava/lang/String;)V

--- a/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -30,6 +30,7 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
     protected open fun encodeTaggedValue(tag: Tag, value: Any): Unit =
         throw SerializationException("Non-serializable ${value::class} is not supported by ${this::class} encoder")
 
+    protected open fun encodeTaggedNonNullMark(tag: Tag) {}
     protected open fun encodeTaggedNull(tag: Tag): Unit = throw SerializationException("null is not supported")
     protected open fun encodeTaggedInt(tag: Tag, value: Int): Unit = encodeTaggedValue(tag, value)
     protected open fun encodeTaggedByte(tag: Tag, value: Byte): Unit = encodeTaggedValue(tag, value)
@@ -61,7 +62,7 @@ public abstract class TaggedEncoder<Tag : Any?> : Encoder, CompositeEncoder {
         return true
     }
 
-    final override fun encodeNotNullMark() {} // Does nothing, open because is not really required
+    open override fun encodeNotNullMark(): Unit = encodeTaggedNonNullMark(currentTag)
     open override fun encodeNull(): Unit = encodeTaggedNull(popTag())
     final override fun encodeBoolean(value: Boolean): Unit = encodeTaggedBoolean(popTag(), value)
     final override fun encodeByte(value: Byte): Unit = encodeTaggedByte(popTag(), value)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -46,7 +46,10 @@ private sealed class AbstractJsonTreeEncoder(
     abstract fun putElement(key: String, element: JsonElement)
     abstract fun getCurrent(): JsonElement
 
+    // has no tag when encoding a nullable element at root level
+    override fun encodeNotNullMark() {}
 
+    // has no tag when encoding a nullable element at root level
     override fun encodeNull() {
         val tag = currentTagOrNull ?: return nodeConsumer(JsonNull)
         encodeTaggedNull(tag)


### PR DESCRIPTION
Currently, it's not possible to override the not null mark behavior of the tagged encoder. I would like to override it and add an additional parameter `$isNull` with my custom format. This way I can better support nullability.