### PR TITLE
Minor Kdoc update

### DIFF
--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
@@ -38,8 +38,6 @@ public fun <T> Json.encodeToBufferedSink(
 /**
  * Serializes given [value] to a [target] using UTF-8 encoding and serializer retrieved from the reified type parameter.
  *
- * If [target] is not a [BufferedSink] then called [Sink.buffer] for it to create buffered wrapper.
- *
  * @throws [SerializationException] if the given value cannot be serialized to JSON.
  * @throws [okio.IOException] If an I/O error occurs and sink can't be written to.
  */


### PR DESCRIPTION
Follow up from https://github.com/Kotlin/kotlinx.serialization/pull/1982. Since a `BufferedSink` is now required, no need to add this in the documentation.