### PR TITLE
Added benchmarks on cacheable child serializers

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/ContextualOverheadBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/ContextualOverheadBenchmark.kt
@@ -1,0 +1,72 @@
+package kotlinx.benchmarks.json
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
+
+@Warmup(iterations = 7, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class ContextualOverheadBenchmark {
+    @Serializable
+    data class Holder(val data: @Contextual Data)
+
+    class Data(val a: Int, val b: String)
+
+    object DataSerializer: KSerializer<Data> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Serializer") {
+            element<Int>("a")
+            element<String>("b")
+        }
+
+        override fun deserialize(decoder: Decoder): Data {
+            return decoder.decodeStructure(descriptor) {
+                var a = 0
+                var b = ""
+                while (true) {
+                    when (val index = decodeElementIndex(descriptor)) {
+                        0 -> a = decodeIntElement(descriptor, 0)
+                        1 -> b = decodeStringElement(descriptor, 1)
+                        CompositeDecoder.DECODE_DONE -> break
+                        else -> error("Unexpected index: $index")
+                    }
+                }
+                Data(a, b)
+            }
+        }
+
+        override fun serialize(encoder: Encoder, value: Data) {
+            encoder.encodeStructure(descriptor) {
+                encodeIntElement(descriptor, 0, value.a)
+                encodeStringElement(descriptor, 1, value.b)
+            }
+        }
+
+    }
+
+    private val module = SerializersModule {
+        contextual(DataSerializer)
+    }
+
+    private val json = Json { serializersModule = module }
+
+    private val holder = Holder(Data(1, "abc"))
+    private val holderString = json.encodeToString(holder)
+    private val holderSerializer = serializer<Holder>()
+
+    @Benchmark
+    fun decode() = json.decodeFromString(holderSerializer, holderString)
+
+    @Benchmark
+    fun encode() = json.encodeToString(holderSerializer, holder)
+
+}

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/PolymorphismOverheadBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/PolymorphismOverheadBenchmark.kt
@@ -19,6 +19,9 @@ open class PolymorphismOverheadBenchmark {
     data class PolymorphicWrapper(val i: @Polymorphic Poly, val i2: Impl) // amortize the cost a bit
 
     @Serializable
+    data class SimpleWrapper(val poly: @Polymorphic Poly)
+
+    @Serializable
     data class BaseWrapper(val i: Impl, val i2: Impl)
 
     @JsonClassDiscriminator("poly")
@@ -40,6 +43,11 @@ open class PolymorphismOverheadBenchmark {
     private val polyString = json.encodeToString<Poly>(impl)
     private val serializer = serializer<Poly>()
 
+    private val wrapper = SimpleWrapper(Impl(1, "abc"))
+    private val wrapperString = json.encodeToString(wrapper)
+    private val wrapperSerializer = serializer<SimpleWrapper>()
+
+
     // 5000
     @Benchmark
     fun base() = json.decodeFromString(Impl.serializer(), implString)
@@ -50,5 +58,13 @@ open class PolymorphismOverheadBenchmark {
     // v2, with skip -- 3000 [withdrawn]
     @Benchmark
     fun poly() = json.decodeFromString(serializer, polyString)
+
+    // test for child polymorphic serializer in decoding
+    @Benchmark
+    fun polyChildDecode() = json.decodeFromString(wrapperSerializer, wrapperString)
+
+    // test for child polymorphic serializer in encoding
+    @Benchmark
+    fun polyChildEncode() = json.encodeToString(wrapperSerializer, wrapper)
 
 }

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/UseSerializerOverheadBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/UseSerializerOverheadBenchmark.kt
@@ -1,0 +1,123 @@
+@file:UseSerializers(UseSerializerOverheadBenchmark.DataClassSerializer::class, UseSerializerOverheadBenchmark.DataObjectSerializer::class)
+package kotlinx.benchmarks.json
+
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
+
+@Warmup(iterations = 7, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class UseSerializerOverheadBenchmark {
+    @Serializable
+    data class HolderForClass(val data: DataForClass)
+
+    @Serializable
+    data class HolderForObject(val data: DataForObject)
+
+    class DataForClass(val a: Int, val b: String)
+
+    class DataForObject(val a: Int, val b: String)
+
+    object DataClassSerializer: KSerializer<DataForClass> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ClassSerializer") {
+            element<Int>("a")
+            element<String>("b")
+        }
+
+        override fun deserialize(decoder: Decoder): DataForClass {
+            return decoder.decodeStructure(descriptor) {
+                var a = 0
+                var b = ""
+                while (true) {
+                    when (val index = decodeElementIndex(ContextualOverheadBenchmark.DataSerializer.descriptor)) {
+                        0 -> a = decodeIntElement(ContextualOverheadBenchmark.DataSerializer.descriptor, 0)
+                        1 -> b = decodeStringElement(ContextualOverheadBenchmark.DataSerializer.descriptor, 1)
+                        CompositeDecoder.DECODE_DONE -> break
+                        else -> error("Unexpected index: $index")
+                    }
+                }
+                DataForClass(a, b)
+            }
+        }
+
+        override fun serialize(encoder: Encoder, value: DataForClass) {
+            encoder.encodeStructure(descriptor) {
+                encodeIntElement(descriptor, 0, value.a)
+                encodeStringElement(descriptor, 1, value.b)
+            }
+        }
+    }
+
+    object DataObjectSerializer: KSerializer<DataForObject> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ObjectSerializer") {
+            element<Int>("a")
+            element<String>("b")
+        }
+
+        override fun deserialize(decoder: Decoder): DataForObject {
+            return decoder.decodeStructure(descriptor) {
+                var a = 0
+                var b = ""
+                while (true) {
+                    when (val index = decodeElementIndex(ContextualOverheadBenchmark.DataSerializer.descriptor)) {
+                        0 -> a = decodeIntElement(ContextualOverheadBenchmark.DataSerializer.descriptor, 0)
+                        1 -> b = decodeStringElement(ContextualOverheadBenchmark.DataSerializer.descriptor, 1)
+                        CompositeDecoder.DECODE_DONE -> break
+                        else -> error("Unexpected index: $index")
+                    }
+                }
+                DataForObject(a, b)
+            }
+        }
+
+        override fun serialize(encoder: Encoder, value: DataForObject) {
+            encoder.encodeStructure(descriptor) {
+                encodeIntElement(descriptor, 0, value.a)
+                encodeStringElement(descriptor, 1, value.b)
+            }
+        }
+    }
+
+    private val module = SerializersModule {
+        contextual(DataClassSerializer)
+    }
+
+    private val json = Json { serializersModule = module }
+
+    private val classHolder = HolderForClass(DataForClass(1, "abc"))
+    private val classHolderString = json.encodeToString(classHolder)
+    private val classHolderSerializer = serializer<HolderForClass>()
+
+    private val objectHolder = HolderForObject(DataForObject(1, "abc"))
+    private val objectHolderString = json.encodeToString(objectHolder)
+    private val objectHolderSerializer = serializer<HolderForObject>()
+
+    @Benchmark
+    fun decodeForClass() = json.decodeFromString(classHolderSerializer, classHolderString)
+
+    @Benchmark
+    fun encodeForClass() = json.encodeToString(classHolderSerializer, classHolder)
+
+    /*
+    Any optimizations should not affect the speed of these tests.
+    It doesn't make sense to cache singleton (`object`) serializer, because the object is accessed instantly
+     */
+
+    @Benchmark
+    fun decodeForObject() = json.decodeFromString(objectHolderSerializer, objectHolderString)
+
+    @Benchmark
+    fun encodeForObject() = json.encodeToString(objectHolderSerializer, objectHolder)
+
+}


### PR DESCRIPTION
Relates #1918

Benchmarks for improved serialization plugin

Test | Old, ops/ms | ±, ops/ms |   | New, ops/ms | ±, ops/ms |   | Boost
-- | -- | -- | -- | -- | -- | -- | --
ContextualOverheadBenchmark.decode | 3077.462 | 23.844 |   | 6394.905 | 38.471 |   | 107.80%
ContextualOverheadBenchmark.encode | 4428.256 | 8.527 |   | 15722.271 | 77.355 |   | 255.04%
PolymorphismOverheadBenchmark.base | 10871.82 | 34.643 |   | 11053.065 | 101.819 |   | 1.67%
PolymorphismOverheadBenchmark.poly | 3523.776 | 17.856 |   | 3692.778 | 13.533 |   | 4.80%
PolymorphismOverheadBenchmark.polyChildDecode | 1012.281 | 2.162 |   | 3214.568 | 8.708 |   | 217.56%
PolymorphismOverheadBenchmark.polyChildEncode | 1356.494 | 5.032 |   | 7529.098 | 38.973 |   | 455.04%
UseSerializerOverheadBenchmark.decodeForClass | 7485.336 | 19.212 |   | 8181.806 | 48.467 |   | 9.30%
UseSerializerOverheadBenchmark.decodeForObject | 7586.439 | 21.435 |   | 7877.765 | 13.945 |   | 3.84%
UseSerializerOverheadBenchmark.encodeForClass | 16485.565 | 95.665 |   | 18103.848 | 96.215 |   | 9.82%
UseSerializerOverheadBenchmark.encodeForObject | 12680.371 | 47.56 |   | 13101.02 | 77.441 |   | 3.32%