### PR TITLE
Provide a way for customization Dokka's HTML output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,3 +188,7 @@ subprojects {
 apply from: rootProject.file('gradle/compiler-version.gradle')
 apply from: rootProject.file("gradle/dokka.gradle")
 apply from: rootProject.file("gradle/benchmark-parsing.gradle")
+
+tasks.named("dokkaHtmlMultiModule") {
+    pluginsMapConfiguration.set(["org.jetbrains.dokka.base.DokkaBase": """{ "templatesDir": "${projectDir.toString().replace('\\', '/')}/dokka-templates" }"""])
+}

--- a/dokka-templates/README.md
+++ b/dokka-templates/README.md
@@ -1,0 +1,12 @@
+# Dokka's template customization
+To provide unified navigation for all parts of [kotlinlang.org](https://kotlinlang.org/),
+the Kotlin Website Team uses this directory to place custom templates in this folder
+during the website build time on TeamCity.
+
+It is not practical to place these templates in the kotlinx.serialization repository because they change from time to time
+and aren't related to the library's release cycle.
+
+The folder is defined as a source for custom templates by the templatesDir property through Dokka's plugin configuration.
+
+[Here](https://kotlin.github.io/dokka/1.7.20-SNAPSHOT/user_guide/output-formats/html/#custom-html-pages), you can
+find more about the customization of Dokka's HTML output.

--- a/gradle/dokka.gradle
+++ b/gradle/dokka.gradle
@@ -20,6 +20,8 @@ subprojects {
 
     tasks.named('dokkaHtmlPartial') {
         outputDirectory = file("build/dokka")
+        pluginsMapConfiguration.set(["org.jetbrains.dokka.base.DokkaBase": """{ "templatesDir": "${rootProject.projectDir.toString().replace('\\', '/')}/dokka-templates" }"""])
+
         dokkaSourceSets {
             configureEach {
                 includes.from(rootProject.file('dokka/moduledoc.md').path)


### PR DESCRIPTION
We want to customize the header and the footer in coroutines API reference on kotlinlang.org to provide a better user experience and consistency between all parts of kotlinlang.org.

Starting from the 1.6.20 version, Dokka supports customization of HTML output. You can read about it [here](https://kotlin.github.io/dokka/1.6.20/user_guide/base-specific/frontend/#custom-html-pages).
To use this opportunity, we need a small preparation on your side.
These changes allow HTML customization.
The rest we will do on our side.