### PR TITLE
buildClassSerialDescriptor: KDoc typo, listDescriptor -> listSerialDescriptor

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
@@ -116,7 +116,7 @@ import kotlinx.serialization.encoding.*
  * SerialDescriptor("my.package.Data") {
  *     // intField is deliberately ignored by serializer -- not present in the descriptor as well
  *     element<Long>("_longField") // longField is named as _longField
- *     element("stringField", listDescriptor<String>())
+ *     element("stringField", listSerialDescriptor<String>())
  * }
  * ```
  *

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -27,8 +27,8 @@ import kotlin.reflect.*
  * SerialDescriptor("my.package.Data") {
  *     // intField is deliberately ignored by serializer -- not present in the descriptor as well
  *     element<Long>("_longField") // longField is named as _longField
- *     element("stringField", listDescriptor<String>())
- *     element("nullableInt", descriptor<Int>().nullable)
+ *     element("stringField", listSerialDescriptor<String>())
+ *     element("nullableInt", serialDescriptor<Int>().nullable)
  * }
  * ```
  *


### PR DESCRIPTION
`listDescriptor` doesn't exist now. I think it should be `listSerialDescriptor`.