### PR TITLE
Add info about importing encodeToString()/decodeToString() to docs

### DIFF
--- a/docs/basic-serialization.md
+++ b/docs/basic-serialization.md
@@ -59,7 +59,7 @@ import kotlinx.serialization.json.*
 ### JSON encoding
 
 The whole process of converting data into a specific format is called _encoding_. For JSON we encode data
-using the [Json.encodeToString][kotlinx.serialization.encodeToString] extension function. It serializes
+using the [Json.encodeToString][kotlinx.serialization.encodeToString] extension function. If you don't see the extension function, you might need to add `import kotlinx.serialization.encodeToString`. It serializes
 the object that is passed as its parameter under the hood and encodes it to a JSON string.
 
 Let's start with a class describing a project and try to get its JSON representation.
@@ -115,7 +115,7 @@ up a _serializer_ for this class. Now the output of the example is the correspon
 ### JSON decoding
 
 The reverse process is called _decoding_. To decode a JSON string into an object, we'll
-use the [Json.decodeFromString][kotlinx.serialization.decodeFromString] extension function.
+use the [Json.decodeFromString][kotlinx.serialization.decodeFromString] extension function. If you don't see the extension function, you might need to add `import kotlinx.serialization.decodeFromString`.
 To specify which type we want to get as a result, we provide a type parameter to this function.
 
 As we'll see later, serialization works with different kinds of classes.


### PR DESCRIPTION
I stumbled upon this issue that I haven't used autocompletion, but just typed in the IDE:
```
val data: String // some JSON string
Json.decodeFromString<MyType>(data)
```
so the IDE showed an error:
![image](https://user-images.githubusercontent.com/70261110/184871473-e2ebe7fc-9990-4a0e-b184-dde38570c81a.png)

This happened because in this case the member function was used `Json.decodeFromString(deserializer: DeserializationStrategy<T>, string: String)`, because the extension function `StringFormat.decodeFromString(String)` has not been imported automatically.

All in all, I think it would be helpful for future users who also get stuck on this problem that the documentation at least mentions the correct import. 