### PR TITLE
Hide json.internal package from Dokka output

### DIFF
--- a/gradle/dokka.gradle
+++ b/gradle/dokka.gradle
@@ -38,6 +38,13 @@ subprojects {
                     suppress.set(true)
                 }
 
+                // Internal JSON API
+                perPackageOption {
+                    matchingRegex.set("kotlinx\\.serialization.json.internal(\$|\\.).*")
+                    suppress.set(true)
+                    reportUndocumented.set(false)
+                }
+
                 // Workaround for typealias
                 perPackageOption {
                     matchingRegex.set("kotlinx\\.serialization.protobuf.internal(\$|\\.).*")


### PR DESCRIPTION
because it has some internal helpers that are public for technical reasons