### PR TITLE
Prefer Contextual serializer of default Polymorphic serializer.

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -80,7 +80,7 @@ private fun SerializersModule.serializerByKTypeImpl(
     val typeArguments = type.arguments
         .map { requireNotNull(it.type) { "Star projections in type arguments are not allowed, but had $type" } }
     val result: KSerializer<Any>? = when {
-        typeArguments.isEmpty() -> rootClass.serializerOrNull() ?: getContextual(rootClass)
+        typeArguments.isEmpty() -> getContextual(rootClass) ?: rootClass.serializerOrNull()
         else -> builtinSerializer(typeArguments, rootClass, failOnMissingTypeArgSerializer)
     }?.cast()
     return result?.nullable(isNullable)

--- a/core/commonTest/src/kotlinx/serialization/modules/ContextualInterfaceTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/modules/ContextualInterfaceTest.kt
@@ -1,0 +1,31 @@
+package kotlinx.serialization.modules
+
+import kotlinx.serialization.*
+import kotlinx.serialization.encoding.*
+import kotlin.test.*
+
+open class ContextualInterfaceTest {
+    sealed interface Dummy {
+        val data: String
+    }
+
+    @Serializable
+    data class DummyImpl(override val data: String) : Dummy
+
+    object DummySerializer : KSerializer<Dummy> {
+        override val descriptor = DummyImpl.serializer().descriptor
+
+        override fun serialize(encoder: Encoder, value: Dummy) =
+            DummyImpl.serializer().serialize(encoder, DummyImpl(value.data))
+
+        override fun deserialize(decoder: Decoder): Dummy = DummyImpl.serializer().deserialize(decoder)
+    }
+
+    private val module = SerializersModule { contextual(Dummy::class, DummySerializer) }
+
+    @Test
+    fun testContextualWinsOverCompiled() {
+        val serializer = module.serializer<Dummy>()
+        assertEquals(DummySerializer, serializer, "Contextual serializer should win over polymorphicSerializer.")
+    }
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
@@ -197,24 +197,6 @@ class SerializersLookupTest : JsonTestBase() {
         assertEquals("[[null]]", Json.encodeToString(serializer, listOf(listOf<IntBox?>(null))))
     }
 
-    @Test
-    fun testCompiledWinsOverContextual() {
-        val contextual = object : KSerializer<Int> {
-            override val descriptor: SerialDescriptor = Int.serializer().descriptor
-
-            override fun serialize(encoder: Encoder, value: Int) {
-                fail()
-            }
-
-            override fun deserialize(decoder: Decoder): Int {
-                fail()
-            }
-        }
-        val json = Json { serializersModule = SerializersModule { contextual(contextual) } }
-        assertEquals("[[1]]", json.encodeToString(listOf(listOf<Int>(1))))
-        assertEquals("42", json.encodeToString(42))
-    }
-
     class NonSerializable
 
     class NonSerializableBox<T>(val boxed: T)

--- a/formats/json-tests/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/formats/json-tests/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -238,25 +238,6 @@ class SerializerByTypeTest {
         assertEquals("[[42]]", Json.encodeToString(serializer, listOf(listOf(IntBox(1)))))
     }
 
-    @Test
-    fun testCompiledWinsOverContextual() {
-        val contextual = object : KSerializer<Int> {
-            override val descriptor: SerialDescriptor = Int.serializer().descriptor
-
-            override fun serialize(encoder: Encoder, value: Int) {
-                fail()
-            }
-
-            override fun deserialize(decoder: Decoder): Int {
-                fail()
-            }
-        }
-        val module = SerializersModule { contextual(contextual) }
-        val serializer = module.serializer(typeTokenOf<List<List<Int>>>())
-        assertEquals("[[1]]", Json.encodeToString(serializer, listOf(listOf<Int>(1))))
-        assertEquals("42", Json.encodeToString(module.serializer(typeTokenOf<Int>()), 42))
-    }
-
     class NonSerializable
 
     class NonSerializableBox<T>(val boxed: T)


### PR DESCRIPTION
According to documentation, contextual are preferred over other serializers. However, this was not the case for interfaces.

Polymorphic Serializer was always returned even if a contextual serializer was defined. This change ensures that contextual serializers actually win over other serializers.

Fixes #1645