### PR TITLE
Fix spelling for consistency (serialise -> serialize)

### DIFF
--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
@@ -257,7 +257,7 @@ private class DynamicPrimitiveEncoder(
         if (!json.configuration.isLenient && abs(value) > MAX_SAFE_INTEGER) {
             throw IllegalArgumentException(
                 "$value can't be deserialized to number due to a potential precision loss. " +
-                        "Use the JsonConfiguration option isLenient to serialise anyway"
+                        "Use the JsonConfiguration option isLenient to serialize anyway"
             )
         }
         encodeValue(asDouble)


### PR DESCRIPTION
### Overview

Hi there.

Changed `serialise` to `serialize` for consistency. (Maybe this is typo)

### Search results

- `serialise` (only 1 file)
https://github.com/Kotlin/kotlinx.serialization/search?q=serialise

- `serialize` (116 files)
https://github.com/Kotlin/kotlinx.serialization/search?q=serialize