### PR TITLE
Add functions that can be used by compiler plugin for intrinsics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,15 @@ buildscript {
     }
     ext.experimentalsEnabled = ["-progressive", "-opt-in=kotlin.Experimental",
                                 "-opt-in=kotlin.ExperimentalMultiplatform",
-                                "-opt-in=kotlinx.serialization.InternalSerializationApi"
+                                "-opt-in=kotlinx.serialization.InternalSerializationApi",
+                                "-P", "plugin:org.jetbrains.kotlinx.serialization:disableIntrinsic=false"
     ]
 
     ext.experimentalsInTestEnabled = ["-progressive", "-opt-in=kotlin.Experimental",
                                       "-opt-in=kotlin.ExperimentalMultiplatform",
                                       "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
-                                      "-opt-in=kotlinx.serialization.InternalSerializationApi"
+                                      "-opt-in=kotlinx.serialization.InternalSerializationApi",
+                                      "-P", "plugin:org.jetbrains.kotlinx.serialization:disableIntrinsic=false"
     ]
     ext.koverEnabled = property('kover.enabled') ?: true
 

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -119,6 +119,9 @@ public abstract interface annotation class kotlinx/serialization/Serializer : ja
 }
 
 public final class kotlinx/serialization/SerializersKt {
+	public static final fun noCompiledSerializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public static final fun noCompiledSerializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
+	public static final fun noCompiledSerializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;

--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -216,3 +216,35 @@ private fun <T : Any> KSerializer<T>.nullable(shouldBeNullable: Boolean): KSeria
     if (shouldBeNullable) return nullable
     return this as KSerializer<T?>
 }
+
+
+/**
+ * Overloads of [noCompiledSerializer] should never be called directly.
+ * Instead, compiler inserts calls to them when intrinsifying [serializer] function.
+ *
+ * If no serializer has been found in compile time, call to [noCompiledSerializer] inserted instead.
+ */
+@Suppress("unused")
+@PublishedApi
+internal fun noCompiledSerializer(forClass: String): KSerializer<*> {
+    throw SerializationException(
+        "Cannot find serializer for class $forClass.\n" +
+                "Make sure that this class marked with @Serializable annotation," +
+                "or provide serializer explicitly, or use proper SerializersModule"
+    )
+}
+
+// Used when compiler intrinsic is inserted
+@OptIn(ExperimentalSerializationApi::class)
+@Suppress("unused")
+@PublishedApi
+internal fun noCompiledSerializer(module: SerializersModule, kClass: KClass<*>): KSerializer<*> {
+    return module.getContextual(kClass) ?: kClass.serializerNotRegistered()
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@Suppress("unused")
+@PublishedApi
+internal fun noCompiledSerializer(module: SerializersModule, kClass: KClass<*>, argSerializers: Array<KSerializer<*>>): KSerializer<*> {
+    return module.getContextual(kClass, argSerializers.asList()) ?: kClass.serializerNotRegistered()
+}

--- a/core/commonTest/src/kotlinx/serialization/CachedSerializersTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/CachedSerializersTest.kt
@@ -4,8 +4,10 @@
 
 package kotlinx.serialization
 
+import kotlinx.serialization.modules.*
 import kotlinx.serialization.test.noJsLegacy
 import kotlin.test.*
+import kotlin.time.*
 
 class CachedSerializersTest {
     @Serializable
@@ -34,4 +36,22 @@ class CachedSerializersTest {
     fun testAbstractSerializersAreSame() = noJsLegacy {
         assertSame(Abstract.serializer(), Abstract.serializer())
     }
+
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    @Ignore // TODO: Unignore after 1.8.0 update
+    fun testSerializersAreIntrinsified() {
+        val m = SerializersModule {  }
+        val direct = measureTime {
+            Object.serializer()
+        }
+        val directMs = direct.inWholeMicroseconds
+        val indirect = measureTime {
+            m.serializer<Object>()
+        }
+        val indirectMs = indirect.inWholeMicroseconds
+        if (indirectMs > directMs + (directMs / 4)) error("Direct ($directMs) and indirect ($indirectMs) times are too far apart")
+    }
 }
+

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
@@ -74,6 +74,7 @@ class SerializersLookupEnumTest {
     }
 
     @Test
+    @Ignore // @Polymorphic enum doesn't make sense and is not supported in intrinsics
     fun testEnumPolymorphic() {
         if (isJvm()) {
             assertEquals(

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupEnumTest.kt
@@ -44,9 +44,6 @@ class SerializersLookupEnumTest {
         }
     }
 
-    @Polymorphic
-    enum class EnumPolymorphic
-
     @Serializable
     enum class PlainEnum
 
@@ -70,20 +67,6 @@ class SerializersLookupEnumTest {
         } else if (isJsIr() || isNative()) {
             // FIXME serializer<EnumWithClassSerializer> is broken for K/JS and K/Native. Remove `assertFails` after fix
             assertFails { serializer<EnumExternalClass>() }
-        }
-    }
-
-    @Test
-    @Ignore // @Polymorphic enum doesn't make sense and is not supported in intrinsics
-    fun testEnumPolymorphic() {
-        if (isJvm()) {
-            assertEquals(
-                PolymorphicSerializer(EnumPolymorphic::class).descriptor,
-                serializer<EnumPolymorphic>().descriptor
-            )
-        } else {
-            // FIXME serializer<PolymorphicEnum> is broken for K/JS and K/Native. Remove `assertFails` after fix
-            assertFails { serializer<EnumPolymorphic>() }
         }
     }
 }

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupObjectTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupObjectTest.kt
@@ -75,7 +75,8 @@ class SerializersLookupObjectTest {
     }
 
     @Test
-    fun testEnumPolymorphic() {
+    @Ignore // @Polymorphic object doesn't make sense and is not supported in intrinsics
+    fun testObjectPolymorphic() {
         if (isJvm()) {
             assertEquals(
                 PolymorphicSerializer(ObjectPolymorphic::class).descriptor,

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupObjectTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupObjectTest.kt
@@ -43,9 +43,6 @@ class SerializersLookupObjectTest {
         }
     }
 
-    @Polymorphic
-    object ObjectPolymorphic
-
     @Serializable
     object PlainObject
 
@@ -72,20 +69,5 @@ class SerializersLookupObjectTest {
         if (!isJsLegacy()) {
             assertIs<ObjectExternalClassSerializer>(serializer<ObjectExternalClass>())
         }
-    }
-
-    @Test
-    @Ignore // @Polymorphic object doesn't make sense and is not supported in intrinsics
-    fun testObjectPolymorphic() {
-        if (isJvm()) {
-            assertEquals(
-                PolymorphicSerializer(ObjectPolymorphic::class).descriptor,
-                serializer<ObjectPolymorphic>().descriptor
-            )
-        } else {
-            // FIXME serializer<PolymorphicObject> is broken for K/JS and K/Native. Remove `assertFails` after fix
-            assertFails { serializer<ObjectPolymorphic>() }
-        }
-
     }
 }

--- a/formats/json-tests/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
+++ b/formats/json-tests/jvmTest/src/kotlinx/serialization/features/SerializerByTypeTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import java.lang.reflect.*
 import kotlin.reflect.*
 import kotlin.test.*
+import kotlin.time.*
 
 class SerializerByTypeTest {
 
@@ -282,5 +283,20 @@ class SerializerByTypeTest {
         assertFailsWithMessage<SerializationException>("for class 'NonSerializable'") {
             serializer(typeTokenOf<Array<NonSerializable>>())
         }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    @Ignore // TODO: Unignore after 1.8.0 update
+    fun testSerializersAreIntrinsified() {
+        val direct = measureTime {
+            Json.encodeToString(IntData.serializer(), IntData(10))
+        }
+        val directMs = direct.inWholeMicroseconds
+        val indirect = measureTime {
+            Json.encodeToString(IntData(10))
+        }
+        val indirectMs = indirect.inWholeMicroseconds
+        if (indirectMs > directMs + (directMs / 4)) error("Direct ($directMs) and indirect ($indirectMs) times are too far apart")
     }
 }


### PR DESCRIPTION
Intrinsics for `serializer<T>()` function should be available in the compiler plugin in Kotlin 1.8.0