### PR TITLE
Deprecate .isNullable in SerialDescriptor builder

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -240,6 +240,7 @@ public class ClassSerialDescriptorBuilder internal constructor(
      * in its [KSerializer] type parameter and handle nulls during encoding and decoding.
      */
     @ExperimentalSerializationApi
+    @Deprecated("isNullable inside buildSerialDescriptor is deprecated. Please use SerialDescriptor.nullable extension on a builder result.", level = DeprecationLevel.ERROR)
     public var isNullable: Boolean = false
 
     /**

--- a/core/commonTest/src/kotlinx/serialization/SerialDescriptorBuilderTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerialDescriptorBuilderTest.kt
@@ -87,4 +87,11 @@ class SerialDescriptorBuilderTest {
         assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor(" ", PrimitiveKind.STRING) }
         assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("\t", PrimitiveKind.STRING) }
     }
+
+    @Test
+    fun testNullableBuild() {
+        val descriptor = buildClassSerialDescriptor("my.Simple") {}.nullable
+        assertTrue(descriptor.isNullable)
+        assertEquals("my.Simple?", descriptor.serialName)
+    }
 }


### PR DESCRIPTION
because it wasn't working properly and better alternative exists.

Fixes #1929