### PR TITLE
Fix incorrect behavior while deserializing maps to sealed classes

### DIFF
--- a/formats/json-tests/jvmTest/src/kotlinx/serialization/SealedClassSerializationFromJsonTest.kt
+++ b/formats/json-tests/jvmTest/src/kotlinx/serialization/SealedClassSerializationFromJsonTest.kt
@@ -1,0 +1,33 @@
+package kotlinx.serialization
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SealedClassSerializationFromJsonTest {
+    @Serializable
+    sealed class BaseClass {
+        abstract val firstProperty: Long
+        abstract val secondProperty: String
+    }
+
+    @SerialName("FIRSTCHILD")
+    @Serializable
+    data class FirstChild(override val firstProperty: Long, override val secondProperty: String) : BaseClass()
+
+    @SerialName("SECONDCHILD")
+    @Serializable
+    data class SecondChild(override val firstProperty: Long, override val secondProperty: String) : BaseClass()
+    
+    @Test
+    fun testJsonSerialization() {
+        val json = """{"type": "FIRSTCHILD", "firstProperty": 1, "secondProperty": "one"}"""
+
+        val instance: BaseClass = Json.decodeFromString(json)
+
+        assertIs<FirstChild>(instance)
+        assertEquals(instance.firstProperty, 1)
+        assertEquals(instance.secondProperty, "one")
+    }
+}

--- a/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
@@ -89,6 +89,22 @@ public sealed class Properties(
             return structure(descriptor).also { copyTagsTo(it) }
         }
 
+        final override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+            val type = map["type"]?.toString()
+            var actualSerializer: DeserializationStrategy<out Any>? = null
+
+            if (type != null && deserializer is AbstractPolymorphicSerializer<*>) {
+                actualSerializer = deserializer.findPolymorphicSerializerOrNull(this, type)
+            }
+
+            if (actualSerializer == null) {
+                throw RuntimeException()
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            return actualSerializer.deserialize(this) as T
+        }
+
         final override fun decodeTaggedValue(tag: String): Value {
             return map.getValue(tag)
         }

--- a/formats/properties/commonTest/src/kotlinx/serialization/properties/SealedClassSerializationFromPropertiesTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/properties/SealedClassSerializationFromPropertiesTest.kt
@@ -1,0 +1,38 @@
+package kotlinx.serialization.properties
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SealedClassSerializationFromPropertiesTest {
+    @Serializable
+    sealed class BaseClass {
+        abstract val firstProperty: Long
+        abstract val secondProperty: String
+    }
+
+    @SerialName("FIRSTCHILD")
+    @Serializable
+    data class FirstChild(override val firstProperty: Long, override val secondProperty: String) : BaseClass()
+
+    @SerialName("SECONDCHILD")
+    @Serializable
+    data class SecondChild(override val firstProperty: Long, override val secondProperty: String) : BaseClass()
+
+    @Test
+    fun testPropertiesSerialization() {
+        val props = mapOf(
+            "type" to "FIRSTCHILD",
+            "firstProperty" to 1L,
+            "secondProperty" to "one"
+        )
+
+        val instance: BaseClass = Properties.decodeFromMap(props)
+
+        assertIs<FirstChild>(instance)
+        assertEquals(instance.firstProperty, 1)
+        assertEquals(instance.secondProperty, "one")
+    }
+}


### PR DESCRIPTION
This is an initial attempt at fixing an incompatibility between the deserialization of sealed classes when using json vs map

fix: #2035 

By reusing some of the stuff from [StreamingJsonDecoder](https://github.com/Kotlin/kotlinx.serialization/blob/master/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt) I was able to succesfully deserialize a map that has the same structure as the test json.

Am I in the right path?