### PR TITLE
Update test assertions to have clickable assertion failures

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/test/TestingFramework.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/test/TestingFramework.kt
@@ -78,7 +78,7 @@ inline fun assertFailsWithSerialMessage(
     )
     assertTrue(
         exception.message!!.contains(message),
-        "Expected message '${exception.message}' to contain substring '$message'"
+        "expected:<${exception.message}> but was:<$message>"
     )
 }
 inline fun <reified T : Throwable> assertFailsWithMessage(
@@ -89,6 +89,6 @@ inline fun <reified T : Throwable> assertFailsWithMessage(
     val exception = assertFailsWith(T::class, assertionMessage, block)
     assertTrue(
         exception.message!!.contains(message),
-        "Expected message '${exception.message}' to contain substring '$message'"
+        "expected:<${exception.message}> but was:<$message>"
     )
 }


### PR DESCRIPTION
This makes test failures easier to see, because when the test fails IntelliJ will generate a 'click to see difference' link that opens the IntelliJ comparison editor, with the two strings provided.

https://stackoverflow.com/q/10934743/4161471
