### PR TITLE
Add third-party library for the JSON5 format

### DIFF
--- a/formats/README.md
+++ b/formats/README.md
@@ -159,3 +159,11 @@ There are still some limitations (ordered properties).
 
 Allows serialization and deserialization of [Fixed Length Format files](https://www.ibm.com/docs/en/psfa/7.2.1?topic=format-fixed-length-files).
 Each property must be annotated with `@FixedLength` and there are still some limitations due to missing delimiters.
+
+### JSON5
+
+* GitHub repo: [xn32/json5k](https://github.com/xn32/json5k)
+* Artifact ID: `io.github.xn32:json5k`
+* Platform: JVM only
+
+Library for the serialization to and deserialization from [JSON5](https://json5.org) text.


### PR DESCRIPTION
This is a third-party library to serialize and deserialize [JSON5](https://json5.org) (as requested in #797).