### PR TITLE
Increase JS tests timeout to 10s

### DIFF
--- a/gradle/configure-source-sets.gradle
+++ b/gradle/configure-source-sets.gradle
@@ -13,7 +13,13 @@ kotlin {
     }
 
     js {
-        nodejs {}
+        nodejs {
+            testTask {
+                useMocha {
+		    timeout = "10s"
+                }
+            }
+        }
         configure([compilations.main, compilations.test]) {
             kotlinOptions {
                 sourceMap = true


### PR DESCRIPTION
Increase the timeout from the default (2s) to 10 seconds. This should fix the flakiness of kotlinx.serialization.json.JsonHugeDataSerializationTest