### PR TITLE
Fix incompatible targets in guide

### DIFF
--- a/guide/build.gradle
+++ b/guide/build.gradle
@@ -5,6 +5,10 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlinx-serialization'
 
+kotlin {
+    jvmToolchain(8)
+}
+
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "org.jetbrains.kotlinx:kotlinx-knit-test:$knit_version"


### PR DESCRIPTION
Fix for the change introduced in Kotlin 1.8.0 via this issue: https://youtrack.jetbrains.com/issue/KT-54993