### PR TITLE
Improve hint when sealed class is not @Serializable

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -104,7 +104,7 @@ internal fun throwSubtypeNotRegistered(subClassName: String?, baseClass: KClass<
             "Class discriminator was missing and no default polymorphic serializers were registered $scope"
         else
             "Class '$subClassName' is not registered for polymorphic serialization $scope.\n" +
-            "Mark the base class as 'sealed' or register the serializer explicitly."
+            "Mark the base class as '@Serializable sealed' or register the serializer explicitly."
     )
 }
 


### PR DESCRIPTION
We've had some cases where we weren't sure why serialization for sealed polymorphic subclasses errored out.

The problem was that we just missed adding `@Serializable` onto the base class. 

