### PR TITLE
The idea of optimizing JsonToJavaStreamWriter

### DIFF
--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
@@ -17,20 +17,23 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : JsonWr
     }
 
     override fun write(text: String) {
-        text.forEach(::writeChar)
+        text.codePoints().forEachOrdered{
+            writeUtf8CodePoint(it)
+        }
     }
 
     override fun writeQuoted(text: String) {
         writeUtf8CodePoint('"'.code)
-        text.forEach {
-            val ch = it.code
+        text.codePoints().forEachOrdered { ch ->
             if (ch < ESCAPE_MARKERS.size) {
                 when (val marker = ESCAPE_MARKERS[ch]) {
                     0.toByte() -> {
                         writeUtf8CodePoint(ch)
                     }
                     1.toByte() -> {
-                        ESCAPE_STRINGS[ch]?.forEach(::writeChar)
+                        ESCAPE_STRINGS[ch]?.let{
+                            write(it)
+                        }
                     }
                     else -> {
                         writeUtf8CodePoint('\\'.code)

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
@@ -6,7 +6,6 @@ import java.nio.charset.Charset
 
 internal class JsonToJavaStreamWriter(private val stream: OutputStream) : JsonWriter {
     private val buffer = ByteArrayPool.take()
-    private var charArray = CharArrayPool.take()
     private var indexInBuffer: Int = 0
 
     override fun writeLong(value: Long) {
@@ -18,89 +17,36 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : JsonWr
     }
 
     override fun write(text: String) {
-        val length = text.length
-        ensureTotalCapacity(0, length)
-        text.toCharArray(charArray, 0, 0, length)
-        writeUtf8(charArray, length)
+        text.forEach(::writeChar)
     }
 
     override fun writeQuoted(text: String) {
-        ensureTotalCapacity(0, text.length + 2)
-        val arr = charArray
-        arr[0] = '"'
-        val length = text.length
-        text.toCharArray(arr, 1, 0, length)
-        for (i in 1 until 1 + length) {
-            val ch = arr[i].code
-            // Do we have unescaped symbols?
-            if (ch < ESCAPE_MARKERS.size && ESCAPE_MARKERS[ch] != 0.toByte()) {
-                // Go to slow path
-                return appendStringSlowPath(i, text)
-            }
-        }
-        // Update the state
-        // Capacity is not ensured because we didn't hit the slow path and thus guessed it properly in the beginning
-
-        arr[length + 1] = '"'
-
-        writeUtf8(arr, length + 2)
-        flush()
-    }
-
-    private fun appendStringSlowPath(currentSize: Int, string: String) {
-        var sz = currentSize
-        for (i in currentSize - 1 until string.length) {
-            /*
-             * We ar already on slow path and haven't guessed the capacity properly.
-             * Reserve +2 for backslash-escaped symbols on each iteration
-             */
-            sz = ensureTotalCapacity(sz, 2)
-            val ch = string[i].code
-            // Do we have unescaped symbols?
+        writeUtf8CodePoint('"'.code)
+        text.forEach {
+            val ch = it.code
             if (ch < ESCAPE_MARKERS.size) {
-                /*
-                * Escape markers are populated for backslash-escaped symbols.
-                * E.g. ESCAPE_MARKERS['\b'] == 'b'.toByte()
-                * Everything else is populated with either zeros (no escapes)
-                * or ones (unicode escape)
-                */
                 when (val marker = ESCAPE_MARKERS[ch]) {
                     0.toByte() -> {
-                        charArray[sz++] = ch.toChar()
+                        writeUtf8CodePoint(ch)
                     }
                     1.toByte() -> {
-                        val escapedString = ESCAPE_STRINGS[ch]!!
-                        sz = ensureTotalCapacity(sz, escapedString.length)
-                        escapedString.toCharArray(charArray, sz, 0, escapedString.length)
-                        sz += escapedString.length
+                        ESCAPE_STRINGS[ch]?.forEach(::writeChar)
                     }
                     else -> {
-                        charArray[sz] = '\\'
-                        charArray[sz + 1] = marker.toInt().toChar()
-                        sz += 2
+                        writeUtf8CodePoint('\\'.code)
+                        writeUtf8CodePoint(marker.toInt().toChar().code)
                     }
                 }
             } else {
-                charArray[sz++] = ch.toChar()
+                writeUtf8CodePoint(ch)
             }
         }
-        ensureTotalCapacity(sz, 1)
-        charArray[sz++] = '"'
-        writeUtf8(charArray, sz)
+        writeUtf8CodePoint('"'.code)
         flush()
-    }
-
-    private fun ensureTotalCapacity(oldSize: Int, additional: Int): Int {
-        val newSize = oldSize + additional
-        if (charArray.size <= newSize) {
-            charArray = charArray.copyOf(newSize.coerceAtLeast(oldSize * 2))
-        }
-        return oldSize
     }
 
     override fun release() {
         flush()
-        CharArrayPool.release(charArray)
         ByteArrayPool.release(buffer)
     }
 
@@ -127,81 +73,6 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : JsonWr
     @Suppress("NOTHING_TO_INLINE")
     private inline fun rest(): Int {
         return buffer.size - indexInBuffer
-    }
-
-    /*
-    Sources taken from okio library with minor changes, see https://github.com/square/okio
-     */
-    private fun writeUtf8(string: CharArray, count: Int) {
-        require(count >= 0) { "count < 0" }
-        require(count <= string.size) { "count > string.length: $count > ${string.size}" }
-
-        // Transcode a UTF-16 Java String to UTF-8 bytes.
-        var i = 0
-        while (i < count) {
-            var c = string[i].code
-
-            when {
-                c < 0x80 -> {
-                    // Emit a 7-bit character with 1 byte.
-                    ensure(1)
-                    write(c) // 0xxxxxxx
-                    i++
-                    val runLimit = minOf(count, i + rest())
-
-                    // Fast-path contiguous runs of ASCII characters. This is ugly, but yields a ~4x performance
-                    // improvement over independent calls to writeByte().
-                    while (i < runLimit) {
-                        c = string[i].code
-                        if (c >= 0x80) break
-                        write(c) // 0xxxxxxx
-                        i++
-                    }
-                }
-
-                c < 0x800 -> {
-                    // Emit a 11-bit character with 2 bytes.
-                    ensure(2)
-                    write(c shr 6 or 0xc0) // 110xxxxx
-                    write(c and 0x3f or 0x80) // 10xxxxxx
-                    i++
-                }
-
-                c < 0xd800 || c > 0xdfff -> {
-                    // Emit a 16-bit character with 3 bytes.
-                    ensure(3)
-                    write(c shr 12 or 0xe0) // 1110xxxx
-                    write(c shr 6 and 0x3f or 0x80) // 10xxxxxx
-                    write(c and 0x3f or 0x80) // 10xxxxxx
-                    i++
-                }
-
-                else -> {
-                    // c is a surrogate. Make sure it is a high surrogate & that its successor is a low
-                    // surrogate. If not, the UTF-16 is invalid, in which case we emit a replacement
-                    // character.
-                    val low = (if (i + 1 < count) string[i + 1].code else 0)
-                    if (c > 0xdbff || low !in 0xdc00..0xdfff) {
-                        ensure(1)
-                        write('?'.code)
-                        i++
-                    } else {
-                        // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
-                        // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
-                        // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
-                        val codePoint = 0x010000 + (c and 0x03ff shl 10 or (low and 0x03ff))
-
-                        // Emit a 21-bit character with 4 bytes.
-                        ensure(4)
-                        write(codePoint shr 18 or 0xf0) // 11110xxx
-                        write(codePoint shr 12 and 0x3f or 0x80) // 10xxxxxx
-                        write(codePoint shr 6 and 0x3f or 0x80) // 10xxyyyy
-                        write(codePoint and 0x3f or 0x80) // 10yyyyyy
-                        i += 2
-                    }
-                }
-            }
-        }
     }
 
     /*


### PR DESCRIPTION
The string buffer can be used to get the character code and perform the necessary calculations. Copying to a separate char buffer is an overhead and adds an additional loop pass. The string itself can act as an already formed buffer.

The number of castes, cycles and time variables has been reduced.