### PR TITLE
Removed strict rule `-dontwarn java.lang.ClassValue`

### DIFF
--- a/rules/common.pro
+++ b/rules/common.pro
@@ -29,5 +29,8 @@
 # See also https://github.com/Kotlin/kotlinx.serialization/issues/1900
 -dontnote kotlinx.serialization.**
 
-# Serialization core uses `Class.forName("java.lang.ClassValue")` for caching in JVM-only, so it is an expected situation that this class is not in Android
--dontwarn java.lang.ClassValue
+# Serialization core uses `java.lang.ClassValue` for caching inside these specified classes.
+# If there is no `java.lang.ClassValue` (for example, in Android), then R8/ProGuard will print a warning.
+# However, since in this case they will not be used, we can disable these warnings
+-dontwarn kotlinx.serialization.internal.ClassValueWrapper
+-dontwarn kotlinx.serialization.internal.ParametrizedClassValueWrapper


### PR DESCRIPTION
The `-dontwarn java.lang.ClassValue` rule embedded in serialization may have a side effect for the target application if it uses `java.lang.ClassValue` too. Instead of this rule, it is enough to disable warnings for ClassValue inheritors in the serialization itself.

Resolves #2119