### PR TITLE
Support encode/decode java.time.Period in HOCON

### DIFF
--- a/formats/hocon/api/kotlinx-serialization-hocon.api
+++ b/formats/hocon/api/kotlinx-serialization-hocon.api
@@ -27,3 +27,32 @@ public final class kotlinx/serialization/hocon/HoconKt {
 	public static synthetic fun Hocon$default (Lkotlinx/serialization/hocon/Hocon;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/hocon/Hocon;
 }
 
+public final class kotlinx/serialization/hocon/serializers/ConfigMemorySizeSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/serialization/hocon/serializers/ConfigMemorySizeSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/typesafe/config/ConfigMemorySize;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/typesafe/config/ConfigMemorySize;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class kotlinx/serialization/hocon/serializers/JBeanSerializer : kotlinx/serialization/KSerializer {
+	public static final field Companion Lkotlinx/serialization/hocon/serializers/JBeanSerializer$Companion;
+	public fun <init> (Ljava/lang/Class;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class kotlinx/serialization/hocon/serializers/JBeanSerializer$Companion {
+}
+
+public final class kotlinx/serialization/hocon/serializers/JDurationSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/serialization/hocon/serializers/JDurationSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/Duration;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/time/Duration;)V
+}
+

--- a/formats/hocon/api/kotlinx-serialization-hocon.api
+++ b/formats/hocon/api/kotlinx-serialization-hocon.api
@@ -56,3 +56,12 @@ public final class kotlinx/serialization/hocon/serializers/JDurationSerializer :
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/time/Duration;)V
 }
 
+public final class kotlinx/serialization/hocon/serializers/JPeriodSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/serialization/hocon/serializers/JPeriodSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/Period;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/time/Period;)V
+}
+

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -44,6 +44,9 @@ import kotlinx.serialization.modules.*
  * [Hocon] support decode java objects in Java Bean notation.
  * @see kotlinx.serialization.hocon.serializers.JBeanSerializer
  *
+ * [Hocon] support encode/decode: [java.time.Period].
+ * @see kotlinx.serialization.hocon.serializers.JPeriodSerializer
+ *
  * @param [useConfigNamingConvention] switches naming resolution to config naming convention (hyphen separated).
  * @param serializersModule A [SerializersModule] which should contain registered serializers
  * for [Contextual] and [Polymorphic] serialization, if you have any.

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconExceptions.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/HoconExceptions.kt
@@ -20,3 +20,6 @@ internal fun InvalidKeyKindException(value: ConfigValue) = SerializationExceptio
     "Value of type '${value.valueType()}' can't be used in HOCON as a key in the map. " +
             "It should have either primitive or enum kind."
 )
+
+internal fun UnsupportedFormatException(serializerName: String) =
+    SerializationException("$serializerName must only be applied to Hocon.")

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/internal/HoconDuration.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/internal/HoconDuration.kt
@@ -1,0 +1,57 @@
+package kotlinx.serialization.hocon.internal
+
+import com.typesafe.config.*
+import java.time.Duration as JDuration
+import kotlin.time.Duration
+import kotlinx.serialization.*
+
+/**
+ * Encode [Duration] objects using time unit short names: d, h, m, s, ms, us, ns.
+ * Example:
+ *     120.seconds -> 2 m
+ *     121.seconds -> 121 s
+ *     120.minutes -> 2 h
+ *     122.minutes -> 122 m
+ *     24.hours -> 1 d
+ * Encoding use the largest time unit.
+ * All restrictions on the maximum and minimum duration are specified in [Duration].
+ * @param value [Duration]
+ * @return encoded value
+ */
+internal fun encodeDuration(value: Duration): String = value.toComponents { seconds, nanoseconds ->
+    when {
+        nanoseconds == 0 -> {
+            if (seconds % 60 == 0L) { // minutes
+                if (seconds % 3600 == 0L) { // hours
+                    if (seconds % 86400 == 0L) { // days
+                        "${seconds / 86400} d"
+                    } else {
+                        "${seconds / 3600} h"
+                    }
+                } else {
+                    "${seconds / 60} m"
+                }
+            } else {
+                "$seconds s"
+            }
+        }
+        nanoseconds % 1_000_000 == 0 -> "${seconds * 1_000 + nanoseconds / 1_000_000} ms"
+        nanoseconds % 1_000 == 0 -> "${seconds * 1_000_000 + nanoseconds / 1_000} us"
+        else -> "${value.inWholeNanoseconds} ns"
+    }
+}
+
+/**
+ * Decode [JDuration] from [Config].
+ * See https://github.com/lightbend/config/blob/main/HOCON.md#duration-format
+ *
+ * @receiver [Config]
+ * @param path in config
+ * @return [JDuration]
+ */
+@SuppressAnimalSniffer
+internal fun Config.decodeDuration(path: String): JDuration = try {
+    getDuration(path)
+} catch (e: ConfigException) {
+    throw SerializationException("Value at $path cannot be read as Duration because it is not a valid HOCON duration value", e)
+}

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/internal/HoconSerialDescriptor.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/internal/HoconSerialDescriptor.kt
@@ -1,0 +1,11 @@
+package kotlinx.serialization.hocon.internal
+
+import kotlin.time.Duration
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+
+/**
+ * Returns `true` if this descriptor is equals to descriptor in [kotlinx.serialization.internal.DurationSerializer].
+ */
+internal val SerialDescriptor.isDuration: Boolean
+    get() = this == Duration.serializer().descriptor

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/ConfigMemorySizeSerializer.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/ConfigMemorySizeSerializer.kt
@@ -1,0 +1,73 @@
+package kotlinx.serialization.hocon.serializers
+
+import com.typesafe.config.*
+import java.math.BigInteger
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.hocon.*
+
+/**
+ * Serializer for [ConfigMemorySize].
+ * For decode using [HOCON Size in bytes format](https://github.com/lightbend/config/blob/main/HOCON.md#size-in-bytes-format).
+ * For encode used format for powers of two: byte, KiB, MiB, GiB, TiB, PiB, EiB, ZiB, YiB.
+ * Encoding use the largest value of format.
+ * Example:
+ *  1024 byte -> 1 KiB
+ *  1024 KiB -> 1 MiB
+ *  1025 KiB -> 1025 KiB
+ * Usage example:
+ * ```
+ * @Serializable
+ * data class ConfigMemory(
+ *      @Serializable(ConfigMemorySizeSerializer::class)
+ *      val size: ConfigMemorySize
+ * )
+ * val config = ConfigFactory.parseString("size = 1 MiB")
+ * val configMemory = Hocon.decodeFromConfig(ConfigMemory.serializer(), config)
+ * val newConfig = Hocon.encodeToConfig(ConfigMemory.serializer(), configMemory)
+ * ```
+ */
+@ExperimentalSerializationApi
+object ConfigMemorySizeSerializer : KSerializer<ConfigMemorySize> {
+
+    // For powers of two.
+    private val memoryUnitFormats = listOf("byte", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
+
+    private val valueResolver: (Config, String) -> ConfigMemorySize = { conf, path -> conf.decodeMemorySize(path) }
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("hocon.com.typesafe.config.ConfigMemorySize", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): ConfigMemorySize {
+        return when (decoder) {
+            is Hocon.ConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            is Hocon.ListConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            is Hocon.MapConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            else -> throw UnsupportedFormatException("ConfigMemorySizeSerializer")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: ConfigMemorySize) {
+        // We determine that it is divisible by 1024 (2^10).
+        // And if it is divisible, then the number itself is shifted to the right by 10.
+        // And so on until we find one that is no longer divisible by 1024.
+        // ((n & ((1 << m) - 1)) == 0)
+        val andVal = BigInteger.valueOf(1023) // ((2^10) - 1) = 0x3ff = 1023
+        var bytes = value.toBytesBigInteger()
+        var unitIndex = 0
+        while (bytes.and(andVal) == BigInteger.ZERO) { // n & 0x3ff == 0
+            if (unitIndex < memoryUnitFormats.lastIndex) {
+                bytes = bytes.shiftRight(10)
+                unitIndex++
+            } else break
+        }
+        encoder.encodeString("$bytes ${memoryUnitFormats[unitIndex]}")
+    }
+
+    private fun Config.decodeMemorySize(path: String): ConfigMemorySize = try {
+        getMemorySize(path)
+    } catch (e: ConfigException) {
+        throw SerializationException("Value at $path cannot be read as ConfigMemorySize because it is not a valid HOCON Size value", e)
+    }
+}

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/JBeanSerializer.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/JBeanSerializer.kt
@@ -1,0 +1,74 @@
+package kotlinx.serialization.hocon.serializers
+
+import com.typesafe.config.*
+import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.hocon.*
+
+/**
+ * Serializer for Java Bean objects. Supports only decoding of objects from [Config].
+ * [JBeanSerializer] using [com.typesafe.config.ConfigBeanFactory.create] to decode Java Bean objects.
+ * To create a [JBeanSerializer], use the method [jBeanSerializer].
+ * Usage example:
+ * Java Bean code
+ * ```
+ * public class TestJavaBean {
+ *  private String name;
+ *  private int age;
+ *  // getters and setters
+ * }
+ * ```
+ * Kotlin code
+ * ```
+ * @Serializable
+ * data class ExampleJavaBean(
+ *  @Contextual
+ *  val bean: TestJavaBean
+ * )
+ * val config = ConfigFactory.parseString("""
+ *  bean: {
+ *      name = Alex
+ *      age = 27
+ *  }
+ * """.trimIndent())
+ * val exampleBean = Hocon {
+ *  serializersModule = serializersModuleOf(JBeanSerializer.jBeanSerializer<TestJavaBean>())
+ * }.decodeFromConfig(ExampleJavaBean.serializer(), config)
+ * ```
+ */
+@ExperimentalSerializationApi
+class JBeanSerializer<T> @PublishedApi internal constructor(private val clazz: Class<T>): KSerializer<T> {
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("hocon.java.bean", PrimitiveKind.STRING)
+
+    private fun valueResolver(conf: Config, path: String): T = try {
+        ConfigBeanFactory.create(conf.getConfig(path), clazz)
+    } catch (e: ConfigException) {
+        throw SerializationException("Error while deserializing java bean class ${clazz.simpleName}.", e)
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        return when (decoder) {
+            is Hocon.ConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), this::valueResolver)
+            is Hocon.ListConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), this::valueResolver)
+            is Hocon.MapConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), this::valueResolver)
+            else -> throw UnsupportedFormatException("JBeanSerializer")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: T) {
+        throw SerializationException("JBeanSerializer is only used for deserialization.")
+    }
+
+    companion object {
+
+        /**
+         * Creates a [JBeanSerializer] using a Java Bean type.
+         * @return [JBeanSerializer]
+         */
+        @ExperimentalSerializationApi
+        inline fun <reified T> jBeanSerializer(): JBeanSerializer<T> = JBeanSerializer(T::class.java)
+    }
+}

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/JDurationSerializer.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/JDurationSerializer.kt
@@ -1,0 +1,59 @@
+package kotlinx.serialization.hocon.serializers
+
+import com.typesafe.config.Config
+import java.time.Duration as JDuration
+import kotlin.time.*
+import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.hocon.*
+import kotlinx.serialization.hocon.internal.*
+
+/**
+ * Serializer for [JDuration].
+ * For decode using [Duration format][https://github.com/lightbend/config/blob/main/HOCON.md#duration-format].
+ * For encode used time unit short names: d, h, m, s, ms, us, ns.
+ * Encoding use the largest time unit.
+ * Example:
+ *      120.seconds -> 2 m
+ *      121.seconds -> 121 s
+ *      120.minutes -> 2 h
+ *      122.minutes -> 122 m
+ *      24.hours -> 1 d
+ * When encoding, there is a conversion to [Duration].
+ * All restrictions on the maximum and minimum duration are specified in [Duration].
+ * Usage example:
+ * ```
+ * @Serializable
+ * data class ExampleDuration(
+ *  @Serializable(JDurationSerializer::class)
+ *   val duration: java.time.Duration
+ * )
+ * val config = ConfigFactory.parseString("duration = 1 day")
+ * val exampleDuration = Hocon.decodeFromConfig(ExampleDuration.serializer(), config)
+ * val newConfig = Hocon.encodeToConfig(ExampleDuration.serializer(), exampleDuration)
+ * ```
+ */
+@ExperimentalSerializationApi
+@SuppressAnimalSniffer
+object JDurationSerializer : KSerializer<JDuration> {
+
+    private val valueResolver: (Config, String) -> JDuration = { conf, path -> conf.decodeDuration(path) }
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("hocon.java.time.Duration", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): JDuration {
+        return when (decoder) {
+            is Hocon.ConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            is Hocon.ListConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            is Hocon.MapConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            else -> throw UnsupportedFormatException("JDurationSerializer")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: JDuration) {
+        encoder.encodeString(encodeDuration(value.toKotlinDuration()))
+    }
+}

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/JPeriodSerializer.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/serializers/JPeriodSerializer.kt
@@ -1,0 +1,71 @@
+package kotlinx.serialization.hocon.serializers
+
+import com.typesafe.config.*
+import java.time.Period
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.hocon.*
+import kotlinx.serialization.hocon.internal.*
+
+/**
+ * Serializer for [Period].
+ * For decode using [Period format][https://github.com/lightbend/config/blob/main/HOCON.md#period-format].
+ * For encode used unit strings for period: d, m, y.
+ * Encoding use the largest period unit.
+ * Encoding [Period] that contains a day along with a month or year is not possible, because only one period unit is allowed in HOCON.
+ * Example:
+ *      12 months -> 1 year
+ *      1 year 6 months -> 18 months
+ *      12 days -> 12 days
+ *      1 year 12 days -> throw SerializationException
+ *      10 months 2 days -> throw SerializationException
+ *      1 year 5 month 5 days -> throw SerializationException
+ * Usage example:
+ * ```
+ * @Serializable
+ * data class ExamplePeriod(
+ *         @Serializable(JPeriodSerializer::class)
+ *         val period: Period
+ * )
+ * val config = ConfigFactory.parseString("period = 1 y")
+ * val examplePeriod = Hocon.decodeFromConfig(ExamplePeriod.serializer(), config)
+ * val newConfig = Hocon.encodeToConfig(ExamplePeriod.serializer(), examplePeriod)
+ * ```
+ */
+@ExperimentalSerializationApi
+@SuppressAnimalSniffer
+object JPeriodSerializer : KSerializer<Period> {
+
+    private val valueResolver: (Config, String) -> Period = { conf, path -> conf.decodePeriod(path) }
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("hocon.java.time.Period", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Period {
+        return when (decoder) {
+            is Hocon.ConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            is Hocon.ListConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            is Hocon.MapConfigReader -> decoder.getValueFromTaggedConfig(decoder.getCurrentTag(), valueResolver)
+            else -> throw UnsupportedFormatException("JPeriodSerializer")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: Period) {
+        val normalized = value.normalized()
+        val result = if (normalized.years == 0 && normalized.months == 0) {
+            "${normalized.days} d"
+        } else if (normalized.days == 0) {
+            if (normalized.months == 0) "${normalized.years} y"
+            else "${normalized.toTotalMonths()} m"
+        } else throw SerializationException("Not possible to serialize java.time.Period because only one time unit can be specified in HOCON")
+        encoder.encodeString(result)
+    }
+
+    private fun Config.decodePeriod(path: String): Period = try {
+        getPeriod(path)
+    } catch (e: ConfigException) {
+        throw SerializationException("Value at $path cannot be read as java.time.Period because it is not a valid HOCON Period Format value", e)
+    }
+}

--- a/formats/hocon/src/test/java/kotlinx/serialization/hocon/TestJavaBean.java
+++ b/formats/hocon/src/test/java/kotlinx/serialization/hocon/TestJavaBean.java
@@ -1,0 +1,39 @@
+package kotlinx.serialization.hocon;
+
+import java.util.Objects;
+
+public class TestJavaBean {
+
+    private String name;
+
+    private int age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestJavaBean that = (TestJavaBean) o;
+        return age == that.age && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, age);
+    }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconDurationTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconDurationTest.kt
@@ -188,7 +188,7 @@ class HoconDurationTest {
 
     @Test
     fun testThrowsWhenNotTimeUnitHocon() {
-        val message = "Value at d cannot be read as kotlin.Duration because it is not a valid HOCON duration value"
+        val message = "Value at d cannot be read as Duration because it is not a valid HOCON duration value"
         assertFailsWith<SerializationException>(message) {
             deserializeConfig("d = 10 unknown", Simple.serializer())
         }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconJBeanTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconJBeanTest.kt
@@ -1,0 +1,101 @@
+package kotlinx.serialization.hocon
+
+import kotlinx.serialization.*
+import kotlinx.serialization.hocon.serializers.JBeanSerializer.Companion.jBeanSerializer
+import kotlinx.serialization.modules.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoconJBeanTest {
+
+    @Serializable
+    data class TestData(@Contextual val d: TestJavaBean)
+    @Serializable
+    data class TestNullableData(@Contextual val d: TestJavaBean?)
+    @Serializable
+    data class ConfigList(val ld: List<@Contextual TestJavaBean>)
+    @Serializable
+    data class ConfigMap(val mp: Map<String, @Contextual TestJavaBean>)
+
+    @Serializable
+    data class Complex(
+        val i: Int,
+        val s: TestData,
+        val n: TestNullableData,
+        val l: List<TestData>,
+        val ln: List<TestNullableData>,
+        val f: Boolean,
+        val ld: List<@Contextual TestJavaBean>,
+        val mp: Map<String, @Contextual TestJavaBean>
+    )
+
+    private val strConfig = """
+        d: {
+            name = Alex
+            age = 27
+        }
+        """.trimIndent()
+    private val bean = TestJavaBean().apply {
+        name = "Alex"
+        age = 27
+    }
+
+    private inline fun <reified T> deserializeJBeanConfig(
+        configString: String,
+        deserializer: DeserializationStrategy<T>,
+    ): T = deserializeConfig(configString, deserializer, false, serializersModuleOf(jBeanSerializer<TestJavaBean>()))
+
+    @Test
+    fun testDeserializeJBean() {
+        val obj = deserializeJBeanConfig(strConfig, TestData.serializer())
+        assertEquals(TestData(bean), obj)
+    }
+
+    @Test
+    fun testDeserializeNullableJBean() {
+        var obj = deserializeJBeanConfig("d: null", TestNullableData.serializer())
+        assertNull(obj.d)
+        obj = deserializeJBeanConfig(strConfig, TestNullableData.serializer())
+        assertEquals(TestNullableData(bean), obj)
+    }
+
+    @Test
+    fun testDeserializeListOfJBean() {
+        val obj = deserializeJBeanConfig("""
+            ld: [
+                { name = Alex, age = 27 },
+                { name = Alex, age = 27 }
+            ]
+        """.trimIndent(), ConfigList.serializer())
+        assertEquals(listOf(bean, bean), obj.ld)
+    }
+
+    @Test
+    fun testDeserializeMapOfJBean() {
+        val obj = deserializeJBeanConfig("""
+            mp: { first = { name = Alex, age = 27 }, second = { name = Alex, age = 27 } }
+        """.trimIndent(), ConfigMap.serializer())
+        assertEquals(mapOf("first" to bean, "second" to bean), obj.mp)
+    }
+
+    @Test
+    fun testDeserializeComplexJBean() {
+        val obj = deserializeJBeanConfig("""
+            i = 6
+            s: { d: { name = Alex, age = 27 } }
+            n: { d: null }
+            l: [ { d: { name = Alex, age = 27 } }, { d: { name = Alex, age = 27 } } ]
+            ln: [ { d: null }, { d: { name = Alex, age = 27 } } ]
+            f = true
+            ld: [ { name = Alex, age = 27 }, { name = Alex, age = 27 } ]
+            mp: { first = { name = Alex, age = 27 } }
+        """.trimIndent(), Complex.serializer())
+        assertEquals(bean, obj.s.d)
+        assertNull(obj.n.d)
+        assertEquals(listOf(TestData(bean), TestData(bean)), obj.l)
+        assertEquals(listOf(TestNullableData(null), TestNullableData(bean)), obj.ln)
+        assertTrue(obj.f)
+        assertEquals(listOf(bean, bean), obj.ld)
+        assertEquals(mapOf("first" to bean), obj.mp)
+    }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconJDurationTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconJDurationTest.kt
@@ -1,0 +1,188 @@
+@file:UseSerializers(JDurationSerializer::class)
+package kotlinx.serialization.hocon
+
+import java.time.Duration
+import java.time.Duration.*
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.*
+import kotlinx.serialization.hocon.serializers.JDurationSerializer
+import org.junit.*
+import org.junit.Assert.*
+
+class HoconJDurationTest {
+
+    @Serializable
+    data class Simple(val d: Duration)
+
+    @Serializable
+    data class Nullable(val d: Duration?)
+
+    @Serializable
+    data class ConfigList(val ld: List<Duration>)
+
+    @Serializable
+    data class ConfigMap(val mp: Map<String, Duration>)
+
+    @Serializable
+    data class ConfigMapDurationKey(val mp: Map<Duration, Duration>)
+
+    @Serializable
+    data class Complex(
+        val i: Int,
+        val s: Simple,
+        val n: Nullable,
+        val l: List<Simple>,
+        val ln: List<Nullable>,
+        val f: Boolean,
+        val ld: List<@Contextual Duration>,
+        val mp: Map<String, @Contextual Duration>,
+        val mpp: Map<@Contextual Duration, @Contextual Duration>
+    )
+
+    @Test
+    fun testSerializeDuration() {
+        Hocon.encodeToConfig(Simple(ofMinutes(10))).assertContains("d = 10 m")
+        Hocon.encodeToConfig(Simple(ofSeconds(120))).assertContains("d = 2 m")
+
+        Hocon.encodeToConfig(Simple(ofHours(1))).assertContains("d = 1 h")
+        Hocon.encodeToConfig(Simple(ofMinutes(120))).assertContains("d = 2 h")
+        Hocon.encodeToConfig(Simple(ofSeconds(3600 * 3))).assertContains("d = 3 h")
+
+        Hocon.encodeToConfig(Simple(ofDays(3))).assertContains("d = 3 d")
+        Hocon.encodeToConfig(Simple(ofHours(24))).assertContains("d = 1 d")
+        Hocon.encodeToConfig(Simple(ofMinutes(1440 * 2))).assertContains("d = 2 d")
+        Hocon.encodeToConfig(Simple(ofSeconds(86400 * 4))).assertContains("d = 4 d")
+
+        Hocon.encodeToConfig(Simple(ofSeconds(1))).assertContains("d = 1 s")
+        Hocon.encodeToConfig(Simple(ofMinutes(2).plusSeconds(1))).assertContains("d = 121 s")
+        Hocon.encodeToConfig(Simple(ofHours(1).plusSeconds(1))).assertContains("d = 3601 s")
+        Hocon.encodeToConfig(Simple(ofDays(1).plusSeconds(5))).assertContains("d = 86405 s")
+
+        Hocon.encodeToConfig(Simple(ofNanos(9))).assertContains("d = 9 ns")
+        Hocon.encodeToConfig(Simple(ofNanos(1_000_000).plusSeconds(5))).assertContains("d = 5001 ms")
+        Hocon.encodeToConfig(Simple(ofNanos(1_000).plusSeconds(9))).assertContains("d = 9000001 us")
+        Hocon.encodeToConfig(Simple(ofNanos(1_000_005).plusSeconds(5))).assertContains("d = 5001000005 ns")
+        Hocon.encodeToConfig(Simple(ofNanos(1_002).plusSeconds(9))).assertContains("d = 9000001002 ns")
+        Hocon.encodeToConfig(Simple(ofNanos(1_000_000_001))).assertContains("d = 1000000001 ns")
+
+        Hocon.encodeToConfig(Simple(ofDays(-10))).assertContains("d = -10 d")
+    }
+
+    @Test
+    fun testSerializeNullableDuration() {
+        Hocon.encodeToConfig(Nullable(null)).assertContains("d = null")
+        Hocon.encodeToConfig(Nullable(ofSeconds(6))).assertContains("d = 6 s")
+    }
+
+    @Test
+    fun testSerializeListOfDuration() {
+        Hocon.encodeToConfig(ConfigList(listOf(ofDays(1), ofMinutes(1), ofNanos(5)))).assertContains("ld: [ 1 d, 1 m, 5 ns ]")
+    }
+
+    @Test
+    fun testSerializeMapOfDuration() {
+        Hocon.encodeToConfig(ConfigMap(mapOf("day" to ofDays(2), "hour" to ofHours(5), "minute" to ofMinutes(3))))
+            .assertContains("mp: { day = 2 d, hour = 5 h, minute = 3 m }")
+        Hocon.encodeToConfig(ConfigMapDurationKey(mapOf(ofHours(1) to ofSeconds(3600))))
+            .assertContains("mp: { 1 h = 1 h }")
+    }
+
+    @Test
+    fun testSerializeComplexDuration() {
+        val obj = Complex(
+            i = 6,
+            s = Simple(ofMinutes(5)),
+            n = Nullable(null),
+            l = listOf(Simple(ofMinutes(1)), Simple(ofSeconds(2))),
+            ln = listOf(Nullable(null), Nullable(ofHours(6))),
+            f = true,
+            ld = listOf(ofDays(1), ofMinutes(1), ofNanos(5)),
+            mp = mapOf("day" to ofDays(2), "hour" to ofHours(5), "minute" to ofMinutes(3)),
+            mpp = mapOf(ofHours(1) to ofSeconds(3600))
+        )
+        Hocon.encodeToConfig(obj)
+            .assertContains("""
+                i = 6
+                s: { d = 5 m }
+                n: { d = null }
+                l: [ { d = 1 m }, { d = 2 s } ]
+                ln: [ { d = null }, { d = 6 h } ]
+                f = true
+                ld: [ 1 d, 1 m, 5 ns ]
+                mp: { day = 2 d, hour = 5 h, minute = 3 m }
+                mpp: { 1 h = 1 h }
+            """.trimIndent())
+    }
+
+    @Test
+    fun testDeserializeDuration() {
+        var obj = deserializeConfig("d = 10s", Simple.serializer())
+        assertEquals(ofSeconds(10), obj.d)
+        obj = deserializeConfig("d = 10 hours", Simple.serializer())
+        assertEquals(ofHours(10), obj.d)
+        obj = deserializeConfig("d = 5 ms", Simple.serializer())
+        assertEquals(ofMillis(5), obj.d)
+        obj = deserializeConfig("d = -5 days", Simple.serializer())
+        assertEquals(ofDays(-5), obj.d)
+    }
+
+    @Test
+    fun testDeserializeNullableDuration() {
+        var obj = deserializeConfig("d = null", Nullable.serializer())
+        assertNull(obj.d)
+
+        obj = deserializeConfig("d = 5 days", Nullable.serializer())
+        assertEquals(ofDays(5), obj.d!!)
+    }
+
+    @Test
+    fun testDeserializeListOfDuration() {
+        val obj = deserializeConfig("ld: [ 1d, 1m, 5ns ]", ConfigList.serializer())
+        assertEquals(listOf(ofDays(1), ofMinutes(1), ofNanos(5)), obj.ld)
+    }
+
+    @Test
+    fun testDeserializeMapOfDuration() {
+        val obj = deserializeConfig("""
+             mp: { day = 2d, hour = 5 hours, minute = 3 minutes }
+        """.trimIndent(), ConfigMap.serializer())
+        assertEquals(mapOf("day" to ofDays(2), "hour" to ofHours(5), "minute" to ofMinutes(3)), obj.mp)
+
+        val objDurationKey = deserializeConfig("""
+             mp: { 1 hour = 3600s }
+        """.trimIndent(), ConfigMapDurationKey.serializer())
+        assertEquals(mapOf(ofHours(1) to ofSeconds(3600)), objDurationKey.mp)
+    }
+
+    @Test
+    fun testDeserializeComplexDuration() {
+        val obj = deserializeConfig("""
+            i = 6
+            s: { d = 5m }
+            n: { d = null }
+            l: [ { d = 1m }, { d = 2s } ]
+            ln: [ { d = null }, { d = 6h } ]
+            f = true
+            ld: [ 1d, 1m, 5ns ]
+            mp: { day = 2d, hour = 5 hours, minute = 3 minutes }
+            mpp: { 1 hour = 3600s }
+        """.trimIndent(), Complex.serializer())
+        assertEquals(ofMinutes(5), obj.s.d)
+        assertNull(obj.n.d)
+        assertEquals(listOf(Simple(ofMinutes(1)), Simple(ofSeconds(2))), obj.l)
+        assertEquals(listOf(Nullable(null), Nullable(ofHours(6))), obj.ln)
+        assertEquals(6, obj.i)
+        assertTrue(obj.f)
+        assertEquals(listOf(ofDays(1), ofMinutes(1), ofNanos(5)), obj.ld)
+        assertEquals(mapOf("day" to ofDays(2), "hour" to ofHours(5), "minute" to ofMinutes(3)), obj.mp)
+        assertEquals(mapOf(ofHours(1) to ofSeconds(3600)), obj.mpp)
+    }
+
+    @Test
+    fun testThrowsWhenNotTimeUnitHocon() {
+        val message = "Value at d cannot be read as Duration because it is not a valid HOCON duration value"
+        assertFailsWith<SerializationException>(message) {
+            deserializeConfig("d = 10 unknown", Simple.serializer())
+        }
+    }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconJPeriodTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconJPeriodTest.kt
@@ -1,0 +1,182 @@
+@file:UseSerializers(JPeriodSerializer::class)
+package kotlinx.serialization.hocon
+
+import java.time.Period
+import java.time.Period.*
+import kotlinx.serialization.*
+import kotlinx.serialization.hocon.serializers.JPeriodSerializer
+import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class HoconJPeriodTest {
+
+    @Serializable
+    data class Simple(val d: Period)
+
+    @Serializable
+    data class Nullable(val d: Period?)
+
+    @Serializable
+    data class ConfigList(val ld: List<Period>)
+
+    @Serializable
+    data class ConfigMap(val mp: Map<String, Period>)
+
+    @Serializable
+    data class ConfigMapPeriodKey(val mp: Map<Period, Period>)
+
+    @Serializable
+    data class Complex(
+        val i: Int,
+        val s: Simple,
+        val n: Nullable,
+        val l: List<Simple>,
+        val ln: List<Nullable>,
+        val f: Boolean,
+        val ld: List<Period>,
+        val mp: Map<String, Period>,
+        val mpp: Map<Period, Period>
+    )
+
+    @Test
+    fun testSerializePeriod() {
+        Hocon.encodeToConfig(Simple(ofDays(360))).assertContains("d = 360 d")
+        Hocon.encodeToConfig(Simple(ofMonths(5))).assertContains("d = 5 m")
+        Hocon.encodeToConfig(Simple(ofWeeks(-6))).assertContains("d = -42 d")
+        Hocon.encodeToConfig(Simple(ofYears(3))).assertContains("d = 3 y")
+        Hocon.encodeToConfig(Simple(of(2, 6, 0))).assertContains("d = 30 m")
+        Hocon.encodeToConfig(Simple(ofMonths(24))).assertContains("d = 2 y")
+        Hocon.encodeToConfig(Simple(ofMonths(25))).assertContains("d = 25 m")
+    }
+
+    @Test
+    fun testThrowsWhenSeveralTimeUnits() {
+        val message = "Not possible to serialize java.time.Period because only one time unit can be specified in HOCON"
+        assertFailsWith<SerializationException>(message) {
+            Hocon.encodeToConfig(Simple(of(2, 6, 5)))
+        }
+    }
+
+    @Test
+    fun testSerializeNullablePeriod() {
+        Hocon.encodeToConfig(Nullable(null)).assertContains("d = null")
+        Hocon.encodeToConfig(Nullable(ofMonths(5))).assertContains("d = 5 m")
+    }
+
+    @Test
+    fun testSerializeListOfPeriod() {
+        Hocon.encodeToConfig(ConfigList(listOf(ofDays(1), ofMonths(1), ofYears(5))))
+            .assertContains("ld: [ 1 d, 1 m, 5 y ]")
+    }
+
+    @Test
+    fun testSerializeMapOfPeriod() {
+        Hocon.encodeToConfig(ConfigMap(mapOf("day" to ofDays(2), "year" to ofYears(5), "month" to ofMonths(3))))
+            .assertContains("mp: { day = 2 d, year = 5 y, month = 3 m }")
+        Hocon.encodeToConfig(ConfigMapPeriodKey(mapOf(ofYears(1) to ofMonths(12))))
+            .assertContains("mp: { 1 y = 1 y }")
+    }
+
+    @Test
+    fun testSerializeComplexPeriod() {
+        val obj = Complex(
+            i = 6,
+            s = Simple(ofMonths(5)),
+            n = Nullable(null),
+            l = listOf(Simple(ofMonths(1)), Simple(ofDays(2))),
+            ln = listOf(Nullable(null), Nullable(ofDays(6))),
+            f = true,
+            ld = listOf(ofDays(1), ofYears(1), ofMonths(5)),
+            mp = mapOf("day" to ofDays(2), "year" to ofYears(5), "month" to ofMonths(3)),
+            mpp = mapOf(ofYears(1) to ofMonths(16))
+        )
+        Hocon.encodeToConfig(obj)
+            .assertContains("""
+                i = 6
+                s: { d = 5 m }
+                n: { d = null }
+                l: [ { d = 1 m }, { d = 2 d } ]
+                ln: [ { d = null }, { d = 6 d } ]
+                f = true
+                ld: [ 1 d, 1 y, 5 m ]
+                mp: { day = 2 d, year = 5 y, month = 3 m }
+                mpp: { 1 y = 16 m }
+            """.trimIndent())
+    }
+
+    @Test
+    fun testDeserializePeriod() {
+        var obj = deserializeConfig("d = 10 d", Simple.serializer())
+        assertEquals(ofDays(10), obj.d)
+
+        obj = deserializeConfig("d = 2 w", Simple.serializer())
+        assertEquals(ofWeeks(2), obj.d)
+
+        obj = deserializeConfig("d = 18 m", Simple.serializer())
+        assertEquals(ofMonths(18), obj.d)
+
+        obj = deserializeConfig("d = 6 y", Simple.serializer())
+        assertEquals(ofYears(6), obj.d)
+    }
+
+    @Test
+    fun testDeserializeNullablePeriod() {
+        var obj = deserializeConfig("d = null", Nullable.serializer())
+        assertNull(obj.d)
+
+        obj = deserializeConfig("d = 18 m", Nullable.serializer())
+        assertEquals(ofMonths(18), obj.d)
+    }
+
+    @Test
+    fun testDeserializeListOfPeriod() {
+        val obj = deserializeConfig("ld: [ 1d, 1m, 5y ]", ConfigList.serializer())
+        assertEquals(listOf(ofDays(1), ofMonths(1), ofYears(5)), obj.ld)
+    }
+
+    @Test
+    fun testDeserializeMapOfPeriod() {
+        val obj = deserializeConfig("""
+             mp: { day = 2d, year = 5 y, month = 3 months }
+        """.trimIndent(), ConfigMap.serializer())
+        assertEquals(mapOf("day" to ofDays(2), "year" to ofYears(5), "month" to ofMonths(3)), obj.mp)
+
+        val objDurationKey = deserializeConfig("""
+             mp: { 1 year = 12 months }
+        """.trimIndent(), ConfigMapPeriodKey.serializer())
+        assertEquals(mapOf(ofYears(1) to ofMonths(12)), objDurationKey.mp)
+    }
+
+    @Test
+    fun testDeserializeComplexPeriod() {
+        val obj = deserializeConfig("""
+            i = 6
+            s: { d = 5m }
+            n: { d = null }
+            l: [ { d = 1m }, { d = 2y } ]
+            ln: [ { d = null }, { d = 6d } ]
+            f = true
+            ld: [ 1d, 1m, 5y ]
+            mp: { day = 2d, year = 5 y, month = 3 months }
+            mpp: { 1 year = 12 months }
+        """.trimIndent(), Complex.serializer())
+        assertEquals(ofMonths(5), obj.s.d)
+        assertNull(obj.n.d)
+        assertEquals(listOf(Simple(ofMonths(1)), Simple(ofYears(2))), obj.l)
+        assertEquals(listOf(Nullable(null), Nullable(ofDays(6))), obj.ln)
+        assertEquals(6, obj.i)
+        assertTrue(obj.f)
+        assertEquals(listOf(ofDays(1), ofMonths(1), ofYears(5)), obj.ld)
+        assertEquals(mapOf("day" to ofDays(2), "year" to ofYears(5), "month" to ofMonths(3)), obj.mp)
+        assertEquals(mapOf(ofYears(1) to ofMonths(12)), obj.mpp)
+    }
+
+    @Test
+    fun testThrowsWhenNotPeriodFormatHocon() {
+        val message = "Value at d cannot be read as java.time.Period because it is not a valid HOCON Period Format value"
+        assertFailsWith<SerializationException>(message) {
+            deserializeConfig("d = 10 unknown", Simple.serializer())
+        }
+    }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconMemorySizeTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconMemorySizeTest.kt
@@ -1,0 +1,171 @@
+@file:UseSerializers(ConfigMemorySizeSerializer::class)
+package kotlinx.serialization.hocon
+
+import com.typesafe.config.*
+import com.typesafe.config.ConfigMemorySize.ofBytes
+import java.math.BigInteger
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.hocon.serializers.ConfigMemorySizeSerializer
+import kotlinx.serialization.modules.*
+import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class HoconMemorySizeTest {
+
+    @Serializable
+    data class Simple(val size: ConfigMemorySize)
+
+    @Serializable
+    data class Nullable(val size: ConfigMemorySize?)
+
+    @Serializable
+    data class ConfigList(val l: List<ConfigMemorySize>)
+
+    @Serializable
+    data class ConfigMap(val mp: Map<String, ConfigMemorySize>)
+
+    @Serializable
+    data class ConfigMapMemoryKey(val mp: Map<ConfigMemorySize, ConfigMemorySize>)
+
+    @Serializable
+    data class Complex(
+        val i: Int,
+        val s: Simple,
+        val n: Nullable,
+        val l: List<Simple>,
+        val ln: List<Nullable>,
+        val f: Boolean,
+        val ld: List<ConfigMemorySize>,
+        val mp: Map<String, ConfigMemorySize>,
+        val mpp: Map<ConfigMemorySize, ConfigMemorySize>
+    )
+
+    @Test
+    fun testSerializeMemorySize() {
+        Hocon.encodeToConfig(Simple(ofBytes(10))).assertContains("size = 10 byte")
+        Hocon.encodeToConfig(Simple(ofBytes(1000))).assertContains("size = 1000 byte")
+        val oneKib = BigInteger.valueOf(1024)
+        Hocon.encodeToConfig(Simple(ofBytes(oneKib))).assertContains("size = 1 KiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneKib + BigInteger.ONE))).assertContains("size = 1025 byte")
+        val oneMib = oneKib * oneKib
+        Hocon.encodeToConfig(Simple(ofBytes(oneMib))).assertContains("size = 1 MiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneMib + BigInteger.ONE))).assertContains("size = ${oneMib + BigInteger.ONE} byte")
+        Hocon.encodeToConfig(Simple(ofBytes(oneMib + oneKib))).assertContains("size = 1025 KiB")
+        val oneGib = oneMib * oneKib
+        Hocon.encodeToConfig(Simple(ofBytes(oneGib))).assertContains("size = 1 GiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneGib + BigInteger.ONE))).assertContains("size = ${oneGib + BigInteger.ONE} byte")
+        Hocon.encodeToConfig(Simple(ofBytes(oneGib + oneKib))).assertContains("size = ${oneMib + BigInteger.ONE} KiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneGib + oneMib))).assertContains("size = 1025 MiB")
+        val oneTib = oneGib * (oneKib)
+        Hocon.encodeToConfig(Simple(ofBytes(oneTib))).assertContains("size = 1 TiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneTib + BigInteger.ONE))).assertContains("size = ${oneTib.add(BigInteger.ONE)} byte")
+        Hocon.encodeToConfig(Simple(ofBytes(oneTib + oneKib))).assertContains("size = ${oneGib + BigInteger.ONE} KiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneTib + oneMib))).assertContains("size = ${oneMib + BigInteger.ONE} MiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneTib + oneGib))).assertContains("size = 1025 GiB")
+        val onePib = oneTib * oneKib
+        Hocon.encodeToConfig(Simple(ofBytes(onePib))).assertContains("size = 1 PiB")
+        Hocon.encodeToConfig(Simple(ofBytes(onePib + BigInteger.ONE))).assertContains("size = ${onePib + BigInteger.ONE} byte")
+        val oneEib = onePib * oneKib
+        Hocon.encodeToConfig(Simple(ofBytes(oneEib))).assertContains("size = 1 EiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneEib + BigInteger.ONE))).assertContains("size = ${oneEib + BigInteger.ONE} byte")
+        val oneZib = oneEib * oneKib
+        Hocon.encodeToConfig(Simple(ofBytes(oneZib))).assertContains("size = 1 ZiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneZib + BigInteger.ONE))).assertContains("size = ${oneZib + BigInteger.ONE} byte")
+        val oneYib = oneZib * oneKib
+        Hocon.encodeToConfig(Simple(ofBytes(oneYib))).assertContains("size = 1 YiB")
+        Hocon.encodeToConfig(Simple(ofBytes(oneYib + BigInteger.ONE))).assertContains("size = ${oneYib + BigInteger.ONE} byte")
+        Hocon.encodeToConfig(Simple(ofBytes(oneYib * oneKib))).assertContains("size = $oneKib YiB")
+    }
+
+    @Test
+    fun testSerializeNullableMemorySize() {
+        Hocon.encodeToConfig(Nullable(null)).assertContains("size = null")
+        Hocon.encodeToConfig(Nullable(ofBytes(1024 * 6))).assertContains("size = 6 KiB")
+    }
+
+    @Test
+    fun testSerializeListOfMemorySize() {
+        Hocon.encodeToConfig(ConfigList(listOf(ofBytes(1), ofBytes(1024 * 1024), ofBytes(1024))))
+            .assertContains("l: [ 1 byte, 1 MiB, 1 KiB ]")
+    }
+
+    @Test
+    fun testSerializeMapOfMemorySize() {
+        Hocon.encodeToConfig(ConfigMap(mapOf("one" to ofBytes(2000), "two" to ofBytes(1024 * 1024 * 1024))))
+            .assertContains("mp: { one = 2000 byte, two = 1 GiB }")
+        Hocon.encodeToConfig(ConfigMapMemoryKey((mapOf(ofBytes(1024) to ofBytes(1024)))))
+            .assertContains("mp: { 1 KiB = 1 KiB }")
+    }
+
+    @Test
+    fun testDeserializeMemorySize() {
+        var obj = deserializeConfig("size = 1 Ki", Simple.serializer())
+        assertEquals(ofBytes(1024), obj.size)
+        obj = deserializeConfig("size = 1 MB", Simple.serializer())
+        assertEquals(ofBytes(1_000_000), obj.size)
+        obj = deserializeConfig("size = 1 byte", Simple.serializer())
+        assertEquals(ofBytes(1), obj.size)
+    }
+
+    @Test
+    fun testDeserializeNullableMemorySize() {
+        var obj = deserializeConfig("size = null", Nullable.serializer())
+        assertNull(obj.size)
+        obj = deserializeConfig("size = 5 byte", Nullable.serializer())
+        assertEquals(ofBytes(5), obj.size)
+    }
+
+    @Test
+    fun testDeserializeListOfMemorySize() {
+        val obj = deserializeConfig("l: [ 1b, 1MB, 1Ki ]", ConfigList.serializer())
+        assertEquals(listOf(ofBytes(1), ofBytes(1_000_000), ofBytes(1024)), obj.l)
+    }
+
+    @Test
+    fun testDeserializeMapOfMemorySize() {
+        val obj = deserializeConfig("""
+             mp: { one = 2kB, two = 5 MB }
+        """.trimIndent(), ConfigMap.serializer())
+        assertEquals(mapOf("one" to ofBytes(2000), "two" to ofBytes(5_000_000)), obj.mp)
+
+        val objDurationKey = deserializeConfig("""
+             mp: { 1024b = 1Ki }
+        """.trimIndent(), ConfigMapMemoryKey.serializer())
+        assertEquals(mapOf(ofBytes(1024) to ofBytes(1024)), objDurationKey.mp)
+    }
+
+    @Test
+    fun testDeserializeComplexMemorySize() {
+        val obj = deserializeConfig("""
+            i = 6
+            s: { size = 5 MB }
+            n: { size = null }
+            l: [ { size = 1 kB }, { size = 2b } ]
+            ln: [ { size = null }, { size = 1 Mi } ]
+            f = true
+            ld: [ 1 kB, 1 m]
+            mp: { one = 2kB, two = 5 MB }
+            mpp: { 1024b = 1Ki }
+        """.trimIndent(), Complex.serializer())
+        assertEquals(ofBytes(5_000_000), obj.s.size)
+        assertNull(obj.n.size)
+        assertEquals(listOf(Simple(ofBytes(1000)), Simple(ofBytes(2))), obj.l)
+        assertEquals(listOf(Nullable(null), Nullable(ofBytes(1024 * 1024))), obj.ln)
+        assertEquals(6, obj.i)
+        assertTrue(obj.f)
+        assertEquals(listOf(ofBytes(1000), ofBytes(1048576)), obj.ld)
+        assertEquals(mapOf("one" to ofBytes(2000), "two" to ofBytes(5_000_000)), obj.mp)
+        assertEquals(mapOf(ofBytes(1024) to ofBytes(1024)), obj.mpp)
+    }
+
+    @Test
+    fun testThrowsWhenNotSizeFormatHocon() {
+        val message = "Value at size cannot be read as ConfigMemorySize because it is not a valid HOCON Size value"
+        assertFailsWith<SerializationException>(message) {
+            deserializeConfig("size = 1 unknown", Simple.serializer())
+        }
+    }
+}

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconObjectsTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconObjectsTest.kt
@@ -6,17 +6,21 @@ package kotlinx.serialization.hocon
 
 import com.typesafe.config.*
 import kotlinx.serialization.*
+import kotlinx.serialization.modules.*
 import org.junit.*
 import org.junit.Assert.*
 
 internal inline fun <reified T> deserializeConfig(
     configString: String,
     deserializer: DeserializationStrategy<T>,
-    useNamingConvention: Boolean = false
+    useNamingConvention: Boolean = false,
+    modules: SerializersModule = Hocon.serializersModule
 ): T {
     val ucnc = useNamingConvention
-    return Hocon { useConfigNamingConvention = ucnc }
-        .decodeFromConfig(deserializer, ConfigFactory.parseString(configString))
+    return Hocon {
+        useConfigNamingConvention = ucnc
+        serializersModule = modules
+    }.decodeFromConfig(deserializer, ConfigFactory.parseString(configString))
 }
 
 class ConfigParserObjectsTest {


### PR DESCRIPTION
Hocon supports the period format. [Documentation](https://github.com/lightbend/config/blob/main/HOCON.md#period-format).

Depends on: #2094