### PR TITLE
fix: Hocon polymorphic serialization

### DIFF
--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -145,7 +145,7 @@ public sealed class Hocon(
 
     }
 
-    private inner class ConfigReader(val conf: Config, private val poly: Boolean = false) : ConfigConverter<String>() {
+    private inner class ConfigReader(val conf: Config, private val isPolymorph: Boolean = false) : ConfigConverter<String>() {
         private var ind = -1
 
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
@@ -162,7 +162,7 @@ public sealed class Hocon(
             if (parentName.isEmpty()) childName else "$parentName.$childName"
 
         override fun SerialDescriptor.getTag(index: Int): String {
-            return if (!poly) composeName(
+            return if (!isPolymorph) composeName(
                 currentTagOrNull.orEmpty(),
                 getConventionElementName(index, useConfigNamingConvention)
             ) else getElementName(index)
@@ -216,7 +216,7 @@ public sealed class Hocon(
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
                 // Polymorph should always be object-like I believe?
-                descriptor.kind.objLike -> ConfigReader(conf, true)
+                descriptor.kind.objLike -> ConfigReader(conf, isPolymorph = true)
                 else -> this
             }
 

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -283,6 +283,7 @@ public sealed class Hocon(
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
+                descriptor.kind is PolymorphicKind -> PolymorphConfigReader((values[currentTag / 2] as ConfigObject).toConfig())
                 descriptor.kind.listLike -> ListConfigReader(values[currentTag / 2] as ConfigList)
                 descriptor.kind.objLike -> ConfigReader((values[currentTag / 2] as ConfigObject).toConfig())
                 descriptor.kind == StructureKind.MAP -> MapConfigReader(values[currentTag / 2] as ConfigObject)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -145,7 +145,7 @@ public sealed class Hocon(
 
     }
 
-    private inner class ConfigReader(val conf: Config, private val isPolymorph: Boolean = false) : ConfigConverter<String>() {
+    private inner class ConfigReader(val conf: Config, private val isPolymorphic: Boolean = false) : ConfigConverter<String>() {
         private var ind = -1
 
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
@@ -162,10 +162,8 @@ public sealed class Hocon(
             if (parentName.isEmpty()) childName else "$parentName.$childName"
 
         override fun SerialDescriptor.getTag(index: Int): String {
-            return if (!isPolymorph) composeName(
-                currentTagOrNull.orEmpty(),
-                getConventionElementName(index, useConfigNamingConvention)
-            ) else getElementName(index)
+            val conventionName = getConventionElementName(index, useConfigNamingConvention)
+            return if (!isPolymorphic) composeName(currentTagOrNull.orEmpty(), conventionName) else conventionName
         }
 
         override fun decodeNotNullMark(): Boolean {
@@ -215,8 +213,7 @@ public sealed class Hocon(
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
-                // Polymorph should always be object-like I believe?
-                descriptor.kind.objLike -> ConfigReader(conf, isPolymorph = true)
+                descriptor.kind.objLike -> ConfigReader(conf, isPolymorphic = true)
                 else -> this
             }
 

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -145,7 +145,7 @@ public sealed class Hocon(
 
     }
 
-    private inner class ConfigReader(val conf: Config) : ConfigConverter<String>() {
+    private inner class ConfigReader(val conf: Config, private val poly: Boolean = false) : ConfigConverter<String>() {
         private var ind = -1
 
         override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
@@ -161,8 +161,12 @@ public sealed class Hocon(
         private fun composeName(parentName: String, childName: String) =
             if (parentName.isEmpty()) childName else "$parentName.$childName"
 
-        override fun SerialDescriptor.getTag(index: Int): String =
-            composeName(currentTagOrNull.orEmpty(), getConventionElementName(index, useConfigNamingConvention))
+        override fun SerialDescriptor.getTag(index: Int): String {
+            return if (!poly) composeName(
+                currentTagOrNull.orEmpty(),
+                getConventionElementName(index, useConfigNamingConvention)
+            ) else getElementName(index)
+        }
 
         override fun decodeNotNullMark(): Boolean {
             // Tag might be null for top-level deserialization
@@ -206,6 +210,28 @@ public sealed class Hocon(
         }
     }
 
+    private inner class PolymorphConfigReader(private val conf: Config) : ConfigConverter<String>() {
+        private var ind = -1
+
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
+            when {
+                // Polymorph should always be object-like I believe?
+                descriptor.kind.objLike -> ConfigReader(conf, true)
+                else -> this
+            }
+
+        override fun SerialDescriptor.getTag(index: Int): String = getElementName(index)
+
+        override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+            ind++
+            return if (ind >= descriptor.elementsCount) DECODE_DONE else ind
+        }
+
+        override fun <E> getValueFromTaggedConfig(tag: String, valueResolver: (Config, String) -> E): E {
+            return valueResolver(conf, tag)
+        }
+    }
+
     private inner class ListConfigReader(private val list: ConfigList) : ConfigConverter<Int>() {
         private var ind = -1
 
@@ -216,6 +242,7 @@ public sealed class Hocon(
 
         override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
             when {
+                descriptor.kind is PolymorphicKind -> PolymorphConfigReader((list[currentTag] as ConfigObject).toConfig())
                 descriptor.kind.listLike -> ListConfigReader(list[currentTag] as ConfigList)
                 descriptor.kind.objLike -> ConfigReader((list[currentTag] as ConfigObject).toConfig())
                 descriptor.kind == StructureKind.MAP -> MapConfigReader(list[currentTag] as ConfigObject)

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -24,6 +24,9 @@ class HoconPolymorphismTest {
     }
 
     @Serializable
+    data class SealedContainer(val sealed: Collection<Sealed>)
+
+    @Serializable
     data class CompositeClass(var sealed: Sealed)
 
 
@@ -100,6 +103,27 @@ class HoconPolymorphismTest {
             expected = "type = annotated_type_child, my_type = override, intField = 3",
             original = Sealed.AnnotatedTypeChild(type = "override"),
             serializer = Sealed.serializer(),
+        )
+    }
+
+    @Test
+    fun testCollectionContainer() {
+        objectHocon.assertStringFormAndRestored(
+            expected = """
+                sealed = [ 
+                    { type = annotated_type_child, my_type = override, intField = 3 }
+                    { type = object }
+                    { type = data_class, name = testDataClass, intField = 1 }
+                ]
+            """.trimIndent(),
+            original = SealedContainer(
+                listOf(
+                    Sealed.AnnotatedTypeChild(type = "override"),
+                    Sealed.ObjectChild,
+                    Sealed.DataClassChild(name = "testDataClass"),
+                )
+            ),
+            serializer = SealedContainer.serializer(),
         )
     }
 }

--- a/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
+++ b/formats/hocon/src/test/kotlin/kotlinx/serialization/hocon/HoconPolymorphismTest.kt
@@ -24,7 +24,10 @@ class HoconPolymorphismTest {
     }
 
     @Serializable
-    data class SealedContainer(val sealed: Collection<Sealed>)
+    data class SealedCollectionContainer(val sealed: Collection<Sealed>)
+
+    @Serializable
+    data class SealedMapContainer(val sealed: Map<String, Sealed>)
 
     @Serializable
     data class CompositeClass(var sealed: Sealed)
@@ -116,14 +119,35 @@ class HoconPolymorphismTest {
                     { type = data_class, name = testDataClass, intField = 1 }
                 ]
             """.trimIndent(),
-            original = SealedContainer(
+            original = SealedCollectionContainer(
                 listOf(
                     Sealed.AnnotatedTypeChild(type = "override"),
                     Sealed.ObjectChild,
                     Sealed.DataClassChild(name = "testDataClass"),
                 )
             ),
-            serializer = SealedContainer.serializer(),
+            serializer = SealedCollectionContainer.serializer(),
+        )
+    }
+
+    @Test
+    fun testMapContainer() {
+        objectHocon.assertStringFormAndRestored(
+            expected = """
+                sealed = { 
+                    "annotated_type_child" = { type = annotated_type_child, my_type = override, intField = 3 }
+                    "object" = { type = object }
+                    "data_class" = { type = data_class, name = testDataClass, intField = 1 }
+                }
+            """.trimIndent(),
+            original = SealedMapContainer(
+                mapOf(
+                    "annotated_type_child" to Sealed.AnnotatedTypeChild(type = "override"),
+                    "object" to Sealed.ObjectChild,
+                    "data_class" to Sealed.DataClassChild(name = "testDataClass"),
+                )
+            ),
+            serializer = SealedMapContainer.serializer(),
         )
     }
 }


### PR DESCRIPTION
Hello!

I know this PR is not exactly what you guys would do to fix the issue with polymorph on HOCON, but I made a quick patch to make it work for us.

The problem is that currently Polymorph kinds are treated as Lists and tries to cast it which won't work since Config will keep it as an object.
Another issue is that the getTag will add a value.tag as the parent when trying to get the correct tag from the config (hence why the ugly and not great boolean "isPolymorph").

That said I would love this issue fixed, so please give me suggestions on how to properly fix it and I'd be more than happy to modify the PR to be up to standards!

This fix refers to #1581.