### PR TITLE
Implement addAll functions for JsonArrayBuilder

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -47,29 +47,23 @@ class JsonBuildersTest {
     @Test
     fun testBuildJsonArrayAddAll() {
         assertEquals(
-            """[1,2,3,4,5,null,1,2,3,4,5,null]""",
+            """[1,2,3,4,5,null]""",
             buildJsonArray {
-                assertTrue { addAll(1) }
-                assertTrue { addAll(2, 3, 4, 5, null) }
                 assertTrue { addAll(listOf(1, 2, 3, 4, 5, null)) }
             }.toString()
         )
 
         assertEquals(
-            """["a","b","c",null,"a","b","c",null]""",
+            """["a","b","c",null]""",
             buildJsonArray {
-                assertTrue { addAll("a") }
-                assertTrue { addAll("b", "c", null) }
                 assertTrue { addAll(listOf("a", "b", "c", null)) }
             }.toString()
         )
 
         assertEquals(
-            """[true,true,true,null,false,false,false,null]""",
+            """[true,false,null]""",
             buildJsonArray {
-                assertTrue { addAll(true) }
-                assertTrue { addAll(true, true, null) }
-                assertTrue { addAll(listOf(false, false, false, null)) }
+                assertTrue { addAll(listOf(true, false, null)) }
             }.toString()
         )
 
@@ -90,7 +84,7 @@ class JsonBuildersTest {
                             JsonPrimitive(2),
                             JsonPrimitive("b"),
                             JsonPrimitive(true),
-                            JsonNull
+                            JsonNull,
                         )
                     )
                 }
@@ -163,11 +157,6 @@ class JsonBuildersTest {
         assertEquals(
             """[]""",
             buildJsonArray {
-                // varargs
-                assertFalse { addAll(*arrayOf<String>()) }
-                assertFalse { addAll(*arrayOf<Boolean>()) }
-                assertFalse { addAll(*arrayOf<Number>()) }
-
                 // add collections
                 assertFalse { addAll(listOf<Number>()) }
                 assertFalse { addAll(listOf<String>()) }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -68,16 +68,8 @@ class JsonBuildersTest {
         )
 
         assertEquals(
-            """[1,"a",false,null,2,"b",true,null]""",
+            """[2,"b",true,null]""",
             buildJsonArray {
-                assertTrue {
-                    addAll(
-                        JsonPrimitive(1),
-                        JsonPrimitive("a"),
-                        JsonPrimitive(false),
-                        JsonNull,
-                    )
-                }
                 assertTrue {
                     addAll(
                         listOf(
@@ -92,16 +84,8 @@ class JsonBuildersTest {
         )
 
         assertEquals(
-            """[{},{},{},null,{},{},{},null]""",
+            """[{},{},{},null]""",
             buildJsonArray {
-                assertTrue {
-                    addAll(
-                        JsonObject(emptyMap()),
-                        JsonObject(emptyMap()),
-                        JsonObject(emptyMap()),
-                        JsonNull,
-                    )
-                }
                 assertTrue {
                     addAll(
                         listOf(
@@ -116,16 +100,8 @@ class JsonBuildersTest {
         )
 
         assertEquals(
-            """[[],[],[],null,[],[],[],null]""",
+            """[[],[],[],null]""",
             buildJsonArray {
-                assertTrue {
-                    addAll(
-                        JsonArray(emptyList()),
-                        JsonArray(emptyList()),
-                        JsonArray(emptyList()),
-                        JsonNull,
-                    )
-                }
                 assertTrue {
                     addAll(
                         listOf(
@@ -140,11 +116,8 @@ class JsonBuildersTest {
         )
 
         assertEquals(
-            """[null,null,null,null]""",
+            """[null,null]""",
             buildJsonArray {
-                assertTrue {
-                    addAll(JsonNull, JsonNull)
-                }
                 assertTrue {
                     addAll(listOf(JsonNull, JsonNull))
                 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -46,43 +46,103 @@ class JsonBuildersTest {
 
     @Test
     fun testBuildJsonArrayAddAll() {
-        val jsonNumbers = buildJsonArray {
-            addAll(1)
-            addAll(2, 3, 4, 5, null)
-            addAll(listOf(1, 2, 3, 4, 5, null))
-        }
-        assertEquals("""[1,2,3,4,5,null,1,2,3,4,5,null]""", jsonNumbers.toString())
+        assertEquals(
+            """[1,2,3,4,5,null,1,2,3,4,5,null]""",
+            buildJsonArray {
+                assertTrue { addAll(1) }
+                assertTrue { addAll(2, 3, 4, 5, null) }
+                assertTrue { addAll(listOf(1, 2, 3, 4, 5, null)) }
+            }.toString()
+        )
 
-        val jsonStrings = buildJsonArray {
-            addAll("a")
-            addAll("b", "c", null)
-            addAll(listOf("a", "b", "c", null))
-        }
-        assertEquals("""["a","b","c",null,"a","b","c",null]""", jsonStrings.toString())
+        assertEquals(
+            """["a","b","c",null,"a","b","c",null]""",
+            buildJsonArray {
+                assertTrue { addAll("a") }
+                assertTrue { addAll("b", "c", null) }
+                assertTrue { addAll(listOf("a", "b", "c", null)) }
+            }.toString()
+        )
 
-        val jsonBooleans = buildJsonArray {
-            addAll(true)
-            addAll(true, true, null)
-            addAll(listOf(false, false, false, null))
-        }
-        assertEquals("""[true,true,true,null,false,false,false,null]""", jsonBooleans.toString())
+        assertEquals(
+            """[true,true,true,null,false,false,false,null]""",
+            buildJsonArray {
+                assertTrue { addAll(true) }
+                assertTrue { addAll(true, true, null) }
+                assertTrue { addAll(listOf(false, false, false, null)) }
+            }.toString()
+        )
 
-        val jsonPrimitiveElements = buildJsonArray {
-            addAll(JsonPrimitive(1), JsonPrimitive("a"), JsonPrimitive(false), JsonNull)
-            addAll(listOf(JsonPrimitive(2), JsonPrimitive("b"), JsonPrimitive(true), JsonNull))
-        }
-        assertEquals("""[1,"a",false,null,2,"b",true,null]""", jsonPrimitiveElements.toString())
+        assertEquals(
+            """[1,"a",false,null,2,"b",true,null]""",
+            buildJsonArray {
+                assertTrue {
+                    addAll(
+                        JsonPrimitive(1),
+                        JsonPrimitive("a"),
+                        JsonPrimitive(false),
+                        JsonNull,
+                    )
+                }
+                assertTrue {
+                    addAll(
+                        listOf(
+                            JsonPrimitive(2),
+                            JsonPrimitive("b"),
+                            JsonPrimitive(true),
+                            JsonNull
+                        )
+                    )
+                }
+            }.toString()
+        )
 
-        val jsonObjectElements = buildJsonArray {
-            addAll(JsonObject(emptyMap()), JsonObject(emptyMap()), JsonObject(emptyMap()), JsonNull)
-            addAll(listOf(JsonObject(emptyMap()), JsonObject(emptyMap()), JsonObject(emptyMap()), JsonNull))
-        }
-        assertEquals("""[{},{},{},null,{},{},{},null]""", jsonObjectElements.toString())
+        assertEquals(
+            """[{},{},{},null,{},{},{},null]""",
+            buildJsonArray {
+                assertTrue {
+                    addAll(
+                        JsonObject(emptyMap()),
+                        JsonObject(emptyMap()),
+                        JsonObject(emptyMap()),
+                        JsonNull,
+                    )
+                }
+                assertTrue {
+                    addAll(
+                        listOf(
+                            JsonObject(emptyMap()),
+                            JsonObject(emptyMap()),
+                            JsonObject(emptyMap()),
+                            JsonNull
+                        )
+                    )
+                }
+            }.toString()
+        )
 
-        val jsonArrayElements = buildJsonArray {
-            addAll(JsonArray(emptyList()), JsonArray(emptyList()), JsonArray(emptyList()), JsonNull)
-            addAll(listOf(JsonArray(emptyList()), JsonArray(emptyList()), JsonArray(emptyList()), JsonNull))
-        }
-        assertEquals("""[[],[],[],null,[],[],[],null]""", jsonArrayElements.toString())
+        assertEquals(
+            """[[],[],[],null,[],[],[],null]""",
+            buildJsonArray {
+                assertTrue {
+                    addAll(
+                        JsonArray(emptyList()),
+                        JsonArray(emptyList()),
+                        JsonArray(emptyList()),
+                        JsonNull,
+                    )
+                }
+                assertTrue {
+                    addAll(
+                        listOf(
+                            JsonArray(emptyList()),
+                            JsonArray(emptyList()),
+                            JsonArray(emptyList()),
+                            JsonNull
+                        )
+                    )
+                }
+            }.toString()
+        )
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -4,7 +4,8 @@
 
 package kotlinx.serialization.json
 
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class JsonBuildersTest {
 
@@ -26,7 +27,10 @@ class JsonBuildersTest {
             put("literal", "foo")
             put("null2", null)
         }
-        assertEquals("""{"object":{"k":"v"},"array":[{"nestedLiteral":true}],"null":null,"primitive":42,"boolean":true,"literal":"foo","null2":null}""", json.toString())
+        assertEquals(
+            """{"object":{"k":"v"},"array":[{"nestedLiteral":true}],"null":null,"primitive":42,"boolean":true,"literal":"foo","null2":null}""",
+            json.toString()
+        )
     }
 
     @Test
@@ -42,5 +46,47 @@ class JsonBuildersTest {
             }
         }
         assertEquals("""[true,[1,2,3,4,5,6,7,8,9,10],null,{"stringKey":"stringValue"}]""", json.toString())
+    }
+
+    @Test
+    fun testBuildJsonArrayAddAll() {
+        val jsonNumbers = buildJsonArray {
+            addAll(1)
+            addAll(2, 3, 4, 5, null)
+            addAll(listOf(1, 2, 3, 4, 5, null))
+        }
+        assertEquals("""[1,2,3,4,5,null,1,2,3,4,5,null]""", jsonNumbers.toString())
+
+        val jsonStrings = buildJsonArray {
+            addAll("a")
+            addAll("b", "c", null)
+            addAll(listOf("a", "b", "c", null))
+        }
+        assertEquals("""["a","b","c",null,"a","b","c",null]""", jsonStrings.toString())
+
+        val jsonBooleans = buildJsonArray {
+            addAll(true)
+            addAll(true, true, null)
+            addAll(listOf(false, false, false, null))
+        }
+        assertEquals("""[true,true,true,null,false,false,false,null]""", jsonBooleans.toString())
+
+        val jsonPrimitiveElements = buildJsonArray {
+            addAll(JsonPrimitive(1), JsonPrimitive("a"), JsonPrimitive(false), JsonNull)
+            addAll(listOf(JsonPrimitive(2), JsonPrimitive("b"), JsonPrimitive(true), JsonNull))
+        }
+        assertEquals("""[1,"a",false,null,2,"b",true,null]""", jsonPrimitiveElements.toString())
+
+        val jsonObjectElements = buildJsonArray {
+            addAll(JsonObject(emptyMap()), JsonObject(emptyMap()), JsonObject(emptyMap()), JsonNull)
+            addAll(listOf(JsonObject(emptyMap()), JsonObject(emptyMap()), JsonObject(emptyMap()), JsonNull))
+        }
+        assertEquals("""[{},{},{},null,{},{},{},null]""", jsonObjectElements.toString())
+
+        val jsonArrayElements = buildJsonArray {
+            addAll(JsonArray(emptyList()), JsonArray(emptyList()), JsonArray(emptyList()), JsonNull)
+            addAll(listOf(JsonArray(emptyList()), JsonArray(emptyList()), JsonArray(emptyList()), JsonNull))
+        }
+        assertEquals("""[[],[],[],null,[],[],[],null]""", jsonArrayElements.toString())
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -163,11 +163,22 @@ class JsonBuildersTest {
         assertEquals(
             """[]""",
             buildJsonArray {
-                assertFalse { addAll(listOf()) }
-                assertFalse { addAll(listOf<Int>()) }
+                // varargs
+                assertFalse { addAll(*arrayOf<String>()) }
+                assertFalse { addAll(*arrayOf<Boolean>()) }
+                assertFalse { addAll(*arrayOf<Number>()) }
+
+                // add collections
+                assertFalse { addAll(listOf<Number>()) }
                 assertFalse { addAll(listOf<String>()) }
                 assertFalse { addAll(listOf<Boolean>()) }
+
+                // add json elements
+                assertFalse { addAll(listOf()) }
                 assertFalse { addAll(listOf<JsonNull>()) }
+                assertFalse { addAll(listOf<JsonObject>()) }
+                assertFalse { addAll(listOf<JsonArray>()) }
+                assertFalse { addAll(listOf<JsonPrimitive>()) }
             }.toString()
         )
     }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -144,5 +144,17 @@ class JsonBuildersTest {
                 }
             }.toString()
         )
+
+        assertEquals(
+            """[null,null,null,null]""",
+            buildJsonArray {
+                assertTrue {
+                    addAll(JsonNull, JsonNull)
+                }
+                assertTrue {
+                    addAll(listOf(JsonNull, JsonNull))
+                }
+            }.toString()
+        )
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -4,8 +4,7 @@
 
 package kotlinx.serialization.json
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class JsonBuildersTest {
 
@@ -27,10 +26,7 @@ class JsonBuildersTest {
             put("literal", "foo")
             put("null2", null)
         }
-        assertEquals(
-            """{"object":{"k":"v"},"array":[{"nestedLiteral":true}],"null":null,"primitive":42,"boolean":true,"literal":"foo","null2":null}""",
-            json.toString()
-        )
+        assertEquals("""{"object":{"k":"v"},"array":[{"nestedLiteral":true}],"null":null,"primitive":42,"boolean":true,"literal":"foo","null2":null}""", json.toString())
     }
 
     @Test

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonBuildersTest.kt
@@ -157,4 +157,18 @@ class JsonBuildersTest {
             }.toString()
         )
     }
+
+    @Test
+    fun testBuildJsonArrayAddAllNotModified() {
+        assertEquals(
+            """[]""",
+            buildJsonArray {
+                assertFalse { addAll(listOf()) }
+                assertFalse { addAll(listOf<Int>()) }
+                assertFalse { addAll(listOf<String>()) }
+                assertFalse { addAll(listOf<Boolean>()) }
+                assertFalse { addAll(listOf<JsonNull>()) }
+            }.toString()
+        )
+    }
 }

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -70,6 +70,7 @@ public final class kotlinx/serialization/json/JsonArray$Companion {
 public final class kotlinx/serialization/json/JsonArrayBuilder {
 	public fun <init> ()V
 	public final fun add (Lkotlinx/serialization/json/JsonElement;)Z
+	public final fun addAll (Ljava/util/Collection;)Z
 	public final fun build ()Lkotlinx/serialization/json/JsonArray;
 }
 
@@ -173,6 +174,13 @@ public final class kotlinx/serialization/json/JsonElementBuildersKt {
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Number;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/String;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Void;)Z
+	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;Lkotlinx/serialization/json/JsonElement;[Lkotlinx/serialization/json/JsonElement;)Z
+	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/Boolean;)Z
+	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/Number;)Z
+	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/String;)Z
+	public static final fun addAllBooleans (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
+	public static final fun addAllNumbers (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
+	public static final fun addAllStrings (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
 	public static final fun addJsonArray (Lkotlinx/serialization/json/JsonArrayBuilder;Lkotlin/jvm/functions/Function1;)Z
 	public static final fun addJsonObject (Lkotlinx/serialization/json/JsonArrayBuilder;Lkotlin/jvm/functions/Function1;)Z
 	public static final fun buildJsonArray (Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/json/JsonArray;

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -174,10 +174,10 @@ public final class kotlinx/serialization/json/JsonElementBuildersKt {
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Number;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/String;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Void;)Z
-	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;Lkotlinx/serialization/json/JsonElement;[Lkotlinx/serialization/json/JsonElement;)Z
 	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/Boolean;)Z
 	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/Number;)Z
 	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/String;)Z
+	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Lkotlinx/serialization/json/JsonElement;)Z
 	public static final fun addAllBooleans (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
 	public static final fun addAllNumbers (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
 	public static final fun addAllStrings (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -174,7 +174,6 @@ public final class kotlinx/serialization/json/JsonElementBuildersKt {
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Number;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/String;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Void;)Z
-	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Lkotlinx/serialization/json/JsonElement;)Z
 	public static final fun addAllBooleans (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
 	public static final fun addAllNumbers (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
 	public static final fun addAllStrings (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -174,9 +174,6 @@ public final class kotlinx/serialization/json/JsonElementBuildersKt {
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Number;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/String;)Z
 	public static final fun add (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/lang/Void;)Z
-	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/Boolean;)Z
-	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/Number;)Z
-	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Ljava/lang/String;)Z
 	public static final fun addAll (Lkotlinx/serialization/json/JsonArrayBuilder;[Lkotlinx/serialization/json/JsonElement;)Z
 	public static final fun addAllBooleans (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z
 	public static final fun addAllNumbers (Lkotlinx/serialization/json/JsonArrayBuilder;Ljava/util/Collection;)Z

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -6,7 +6,9 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlin.contracts.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.jvm.JvmName
 
 /**
@@ -142,6 +144,7 @@ public class JsonArrayBuilder @PublishedApi internal constructor() {
      *
      * @return `true` if the list was changed as the result of the operation.
      */
+    @ExperimentalSerializationApi
     public fun addAll(elements: Collection<JsonElement>): Boolean =
         content.addAll(elements)
 
@@ -196,38 +199,45 @@ public fun JsonArrayBuilder.addJsonArray(builderAction: JsonArrayBuilder.() -> U
     add(buildJsonArray(builderAction))
 
 /**
- * Adds the given JSON [element] and [elements] to a resulting JSON array.
+ * Adds the given JSON [elements] to a resulting JSON array.
  *
  * @return `true` if the list was changed as the result of the operation.
  */
-public fun JsonArrayBuilder.addAll(element: JsonElement, vararg elements: JsonElement): Boolean {
-    return addAll(listOf(element) + elements)
+@ExperimentalSerializationApi
+public fun JsonArrayBuilder.addAll(vararg elements: JsonElement): Boolean {
+    return addAll(elements.toList())
 }
 
 /** Adds the given string [values] to a resulting JSON array. */
 @JvmName("addAllStrings")
+@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<String?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
 /** Adds the given boolean [values] to a resulting JSON array. */
 @JvmName("addAllBooleans")
+@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<Boolean?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
 /** Adds the given numeric [values] to a resulting JSON array. */
 @JvmName("addAllNumbers")
+@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<Number?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
 /** Adds the given string [values] to a resulting JSON array. */
+@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(vararg values: String?): Boolean =
     addAll(values.toList())
 
 /** Adds the given boolean [values] to a resulting JSON array. */
+@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(vararg values: Boolean?): Boolean =
     addAll(values.toList())
 
 /** Adds the given numeric [values] to a resulting JSON array. */
+@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(vararg values: Number?): Boolean =
     addAll(values.toList())
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -142,9 +142,8 @@ public class JsonArrayBuilder @PublishedApi internal constructor() {
      *
      * @return `true` if the list was changed as the result of the operation.
      */
-    public fun addAll(elements: Collection<JsonElement>): Boolean {
-        return content.addAll(elements)
-    }
+    public fun addAll(elements: Collection<JsonElement>): Boolean =
+        content.addAll(elements)
 
     @PublishedApi
     internal fun build(): JsonArray = JsonArray(content)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -226,20 +226,5 @@ public fun JsonArrayBuilder.addAll(values: Collection<Boolean?>): Boolean =
 public fun JsonArrayBuilder.addAll(values: Collection<Number?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
-/** Adds the given string [values] to a resulting JSON array. */
-@ExperimentalSerializationApi
-public fun JsonArrayBuilder.addAll(vararg values: String?): Boolean =
-    addAll(values.toList())
-
-/** Adds the given boolean [values] to a resulting JSON array. */
-@ExperimentalSerializationApi
-public fun JsonArrayBuilder.addAll(vararg values: Boolean?): Boolean =
-    addAll(values.toList())
-
-/** Adds the given numeric [values] to a resulting JSON array. */
-@ExperimentalSerializationApi
-public fun JsonArrayBuilder.addAll(vararg values: Number?): Boolean =
-    addAll(values.toList())
-
 @DslMarker
 internal annotation class JsonDslMarker

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -6,9 +6,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
+import kotlin.contracts.*
 import kotlin.jvm.JvmName
 
 /**

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -198,19 +198,31 @@ public fun JsonArrayBuilder.addJsonObject(builderAction: JsonObjectBuilder.() ->
 public fun JsonArrayBuilder.addJsonArray(builderAction: JsonArrayBuilder.() -> Unit): Boolean =
     add(buildJsonArray(builderAction))
 
-/** Adds the given string [values] to a resulting JSON array. */
+/**
+ * Adds the given string [values] to a resulting JSON array.
+ *
+ * @return `true` if the list was changed as the result of the operation.
+ */
 @JvmName("addAllStrings")
 @ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<String?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
-/** Adds the given boolean [values] to a resulting JSON array. */
+/**
+ * Adds the given boolean [values] to a resulting JSON array.
+ *
+ * @return `true` if the list was changed as the result of the operation.
+ */
 @JvmName("addAllBooleans")
 @ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<Boolean?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
-/** Adds the given numeric [values] to a resulting JSON array. */
+/**
+ * Adds the given numeric [values] to a resulting JSON array.
+ *
+ * @return `true` if the list was changed as the result of the operation.
+ */
 @JvmName("addAllNumbers")
 @ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<Number?>): Boolean =

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.contracts.*
+import kotlin.jvm.JvmName
 
 /**
  * Builds [JsonObject] with the given [builderAction] builder.
@@ -136,6 +137,15 @@ public class JsonArrayBuilder @PublishedApi internal constructor() {
         return true
     }
 
+    /**
+     * Adds the given JSON [elements] to a resulting JSON array.
+     *
+     * @return `true` if the list was changed as the result of the operation.
+     */
+    public fun addAll(elements: Collection<JsonElement>): Boolean {
+        return content.addAll(elements)
+    }
+
     @PublishedApi
     internal fun build(): JsonArray = JsonArray(content)
 }
@@ -186,6 +196,41 @@ public fun JsonArrayBuilder.addJsonObject(builderAction: JsonObjectBuilder.() ->
 public fun JsonArrayBuilder.addJsonArray(builderAction: JsonArrayBuilder.() -> Unit): Boolean =
     add(buildJsonArray(builderAction))
 
+/**
+ * Adds the given JSON [element] and [elements] to a resulting JSON array.
+ *
+ * @return `true` if the list was changed as the result of the operation.
+ */
+public fun JsonArrayBuilder.addAll(element: JsonElement, vararg elements: JsonElement): Boolean {
+    return addAll(listOf(element) + elements)
+}
+
+/** Adds the given string [values] to a resulting JSON array. */
+@JvmName("addAllStrings")
+public fun JsonArrayBuilder.addAll(values: Collection<String?>): Boolean =
+    addAll(values.map(::JsonPrimitive))
+
+/** Adds the given boolean [values] to a resulting JSON array. */
+@JvmName("addAllBooleans")
+public fun JsonArrayBuilder.addAll(values: Collection<Boolean?>): Boolean =
+    addAll(values.map(::JsonPrimitive))
+
+/** Adds the given numeric [values] to a resulting JSON array. */
+@JvmName("addAllNumbers")
+public fun JsonArrayBuilder.addAll(values: Collection<Number?>): Boolean =
+    addAll(values.map(::JsonPrimitive))
+
+/** Adds the given string [values] to a resulting JSON array. */
+public fun JsonArrayBuilder.addAll(vararg values: String?): Boolean =
+    addAll(values.toList())
+
+/** Adds the given boolean [values] to a resulting JSON array. */
+public fun JsonArrayBuilder.addAll(vararg values: Boolean?): Boolean =
+    addAll(values.toList())
+
+/** Adds the given numeric [values] to a resulting JSON array. */
+public fun JsonArrayBuilder.addAll(vararg values: Number?): Boolean =
+    addAll(values.toList())
 
 @DslMarker
 internal annotation class JsonDslMarker

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -198,16 +198,6 @@ public fun JsonArrayBuilder.addJsonObject(builderAction: JsonObjectBuilder.() ->
 public fun JsonArrayBuilder.addJsonArray(builderAction: JsonArrayBuilder.() -> Unit): Boolean =
     add(buildJsonArray(builderAction))
 
-/**
- * Adds the given JSON [elements] to a resulting JSON array.
- *
- * @return `true` if the list was changed as the result of the operation.
- */
-@ExperimentalSerializationApi
-public fun JsonArrayBuilder.addAll(vararg elements: JsonElement): Boolean {
-    return addAll(elements.toList())
-}
-
 /** Adds the given string [values] to a resulting JSON array. */
 @JvmName("addAllStrings")
 @ExperimentalSerializationApi


### PR DESCRIPTION
Fix #2127

* new `addAll()` method on `JsonArrayBuilder`
* new extension functions for adding booleans, numbers, strings - either as a list, or using `vararg`

Should the new functions be marked with `@ExperimentalSerializationApi`?