### PR TITLE
add functions for creating JsonPrimitives from unsigned numbers

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonPrimitiveSerializerTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonPrimitiveSerializerTest.kt
@@ -122,20 +122,50 @@ class JsonPrimitiveSerializerTest : JsonTestBase() {
         }
     }
 
-    @Test
-    fun testEncodeJsonPrimitiveUnsignedNumbers() {
+    /**
+     * Helper function for [testJsonPrimitiveUnsignedNumbers]
+     *
+     * Asserts that an [unsigned number][actual] can be used to create a [JsonPrimitive][actualPrimitive],
+     * which can be decoded correctly.
+     *
+     * @param expected the expected string value of [actual]
+     * @param actual the unsigned number
+     * @param T should be an unsigned number
+     */
+    private inline fun <reified T> assertUnsignedNumberEncoding(
+        expected: String,
+        actual: T,
+        actualPrimitive: JsonPrimitive,
+    ) {
+        assertEquals(
+            expected,
+            actualPrimitive.toString(),
+            "expect ${T::class.simpleName} $actual can be used to create a JsonPrimitive"
+        )
 
-        val expectedActualUBytes: List<Pair<String, UByte>> = listOf(
+        parametrizedTest { mode ->
+            assertEquals(
+                expected,
+                default.encodeToString(JsonElement.serializer(), actualPrimitive, mode),
+                "expect ${T::class.simpleName} primitive can be decoded",
+            )
+        }
+    }
+
+    @Test
+    fun testJsonPrimitiveUnsignedNumbers() {
+
+        val expectedActualUBytes: Map<String, UByte> = mapOf(
             "0" to 0u,
             "1" to 1u,
             "255" to UByte.MAX_VALUE,
         )
 
         expectedActualUBytes.forEach { (expected, actual) ->
-            assertEquals(expected, JsonPrimitive(actual).toString(), "expect UByte $actual is converted to $expected")
+            assertUnsignedNumberEncoding(expected, actual, JsonPrimitive(actual))
         }
 
-        val expectedActualUShorts: List<Pair<String, UShort>> = listOf(
+        val expectedActualUShorts: Map<String, UShort> = mapOf(
             "0" to 0u,
             "1" to 1u,
             "255" to UByte.MAX_VALUE.toUShort(),
@@ -143,10 +173,10 @@ class JsonPrimitiveSerializerTest : JsonTestBase() {
         )
 
         expectedActualUShorts.forEach { (expected, actual) ->
-            assertEquals(expected, JsonPrimitive(actual).toString(), "expect UShort $actual is converted to $expected")
+            assertUnsignedNumberEncoding(expected, actual, JsonPrimitive(actual))
         }
 
-        val expectedActualUInts: List<Pair<String, UInt>> = listOf(
+        val expectedActualUInts: Map<String, UInt> = mapOf(
             "0" to 0u,
             "1" to 1u,
             "255" to UByte.MAX_VALUE.toUInt(),
@@ -155,10 +185,10 @@ class JsonPrimitiveSerializerTest : JsonTestBase() {
         )
 
         expectedActualUInts.forEach { (expected, actual) ->
-            assertEquals(expected, JsonPrimitive(actual).toString(), "expect UInt $actual is converted to $expected")
+            assertUnsignedNumberEncoding(expected, actual, JsonPrimitive(actual))
         }
 
-        val expectedActualULongs: List<Pair<String, ULong>> = listOf(
+        val expectedActualULongs: Map<String, ULong> = mapOf(
             "0" to 0u,
             "1" to 1u,
             "255" to UByte.MAX_VALUE.toULong(),
@@ -168,7 +198,7 @@ class JsonPrimitiveSerializerTest : JsonTestBase() {
         )
 
         expectedActualULongs.forEach { (expected, actual) ->
-            assertEquals(expected, JsonPrimitive(actual).toString(), "expect ULong $actual is converted to $expected")
+            assertUnsignedNumberEncoding(expected, actual, JsonPrimitive(actual))
         }
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonPrimitiveSerializerTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonPrimitiveSerializerTest.kt
@@ -121,4 +121,54 @@ class JsonPrimitiveSerializerTest : JsonTestBase() {
             assertEquals(string, jvmExpectedString)
         }
     }
+
+    @Test
+    fun testEncodeJsonPrimitiveUnsignedNumbers() {
+
+        val expectedActualUBytes: List<Pair<String, UByte>> = listOf(
+            "0" to 0u,
+            "1" to 1u,
+            "255" to UByte.MAX_VALUE,
+        )
+
+        expectedActualUBytes.forEach { (expected, actual) ->
+            assertEquals(expected, JsonPrimitive(actual).toString(), "expect UByte $actual is converted to $expected")
+        }
+
+        val expectedActualUShorts: List<Pair<String, UShort>> = listOf(
+            "0" to 0u,
+            "1" to 1u,
+            "255" to UByte.MAX_VALUE.toUShort(),
+            "65535" to UShort.MAX_VALUE,
+        )
+
+        expectedActualUShorts.forEach { (expected, actual) ->
+            assertEquals(expected, JsonPrimitive(actual).toString(), "expect UShort $actual is converted to $expected")
+        }
+
+        val expectedActualUInts: List<Pair<String, UInt>> = listOf(
+            "0" to 0u,
+            "1" to 1u,
+            "255" to UByte.MAX_VALUE.toUInt(),
+            "65535" to UShort.MAX_VALUE.toUInt(),
+            "4294967295" to UInt.MAX_VALUE,
+        )
+
+        expectedActualUInts.forEach { (expected, actual) ->
+            assertEquals(expected, JsonPrimitive(actual).toString(), "expect UInt $actual is converted to $expected")
+        }
+
+        val expectedActualULongs: List<Pair<String, ULong>> = listOf(
+            "0" to 0u,
+            "1" to 1u,
+            "255" to UByte.MAX_VALUE.toULong(),
+            "65535" to UShort.MAX_VALUE.toULong(),
+            "4294967295" to UInt.MAX_VALUE.toULong(),
+            "18446744073709551615" to ULong.MAX_VALUE,
+        )
+
+        expectedActualULongs.forEach { (expected, actual) ->
+            assertEquals(expected, JsonPrimitive(actual).toString(), "expect ULong $actual is converted to $expected")
+        }
+    }
 }

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -190,6 +190,10 @@ public final class kotlinx/serialization/json/JsonElementKt {
 	public static final fun JsonPrimitive (Ljava/lang/Number;)Lkotlinx/serialization/json/JsonPrimitive;
 	public static final fun JsonPrimitive (Ljava/lang/String;)Lkotlinx/serialization/json/JsonPrimitive;
 	public static final fun JsonPrimitive (Ljava/lang/Void;)Lkotlinx/serialization/json/JsonNull;
+	public static final fun JsonPrimitive-7apg3OU (B)Lkotlinx/serialization/json/JsonPrimitive;
+	public static final fun JsonPrimitive-VKZWuLQ (J)Lkotlinx/serialization/json/JsonPrimitive;
+	public static final fun JsonPrimitive-WZ4Q5Ns (I)Lkotlinx/serialization/json/JsonPrimitive;
+	public static final fun JsonPrimitive-xj2QHRw (S)Lkotlinx/serialization/json/JsonPrimitive;
 	public static final fun JsonUnquotedLiteral (Ljava/lang/String;)Lkotlinx/serialization/json/JsonPrimitive;
 	public static final fun getBoolean (Lkotlinx/serialization/json/JsonPrimitive;)Z
 	public static final fun getBooleanOrNull (Lkotlinx/serialization/json/JsonPrimitive;)Ljava/lang/Boolean;

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -49,33 +49,57 @@ public sealed class JsonPrimitive : JsonElement() {
     public override fun toString(): String = content
 }
 
-/**
- * Creates [JsonPrimitive] from the given boolean.
- */
+/** Creates a [JsonPrimitive] from the given boolean. */
 public fun JsonPrimitive(value: Boolean?): JsonPrimitive {
     if (value == null) return JsonNull
     return JsonLiteral(value, isString = false)
 }
 
-/**
- * Creates [JsonPrimitive] from the given number.
- */
+/** Creates a [JsonPrimitive] from the given number. */
 public fun JsonPrimitive(value: Number?): JsonPrimitive {
     if (value == null) return JsonNull
     return JsonLiteral(value, isString = false)
 }
 
 /**
- * Creates [JsonPrimitive] from the given string.
+ * Creates a numeric [JsonPrimitive] from the given [UByte].
+ *
+ * The value will be encoded as a JSON number.
  */
+@ExperimentalSerializationApi
+public fun JsonPrimitive(value: UByte): JsonPrimitive = JsonPrimitive(value.toULong())
+
+/**
+ * Creates a numeric [JsonPrimitive] from the given [UShort].
+ *
+ * The value will be encoded as a JSON number.
+ */
+@ExperimentalSerializationApi
+public fun JsonPrimitive(value: UShort): JsonPrimitive = JsonPrimitive(value.toULong())
+
+/**
+ * Creates a numeric [JsonPrimitive] from the given [UInt].
+ *
+ * The value will be encoded as a JSON number.
+ */
+@ExperimentalSerializationApi
+public fun JsonPrimitive(value: UInt): JsonPrimitive = JsonPrimitive(value.toULong())
+
+/**
+ * Creates a numeric [JsonPrimitive] from the given [ULong].
+ *
+ * The value will be encoded as a JSON number.
+ */
+@ExperimentalSerializationApi
+public fun JsonPrimitive(value: ULong): JsonPrimitive = JsonUnquotedLiteral(value.toString())
+
+/** Creates a [JsonPrimitive] from the given string. */
 public fun JsonPrimitive(value: String?): JsonPrimitive {
     if (value == null) return JsonNull
     return JsonLiteral(value, isString = true)
 }
 
-/**
- * Creates [JsonNull].
- */
+/** Creates [JsonNull]. */
 @ExperimentalSerializationApi
 @Suppress("FunctionName", "UNUSED_PARAMETER") // allows to call `JsonPrimitive(null)`
 public fun JsonPrimitive(value: Nothing?): JsonNull = JsonNull


### PR DESCRIPTION
fix #2130 

Adds `JsonPrimitive()` overloads for constructing `JsonPrimitive` from unsigned numbers

* Nullable unsigned numbers are purposefully not implemented (see https://github.com/Kotlin/kotlinx.serialization/issues/2130#issuecomment-1385918589)
* I did some minor grammar fixes in the KDoc, and formatting to make it a little smaller (this file is getting large, could it be broken up?)