### PR TITLE
KDoc: Transient properties must have default values

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -162,7 +162,7 @@ public annotation class Required
 
 /**
  * Marks this property invisible for the whole serialization process, including [serial descriptors][SerialDescriptor].
- * Transient properties should have default values.
+ * Transient properties must have default values.
  */
 @Target(AnnotationTarget.PROPERTY)
 // @Retention(AnnotationRetention.RUNTIME) still runtime, but KT-41082


### PR DESCRIPTION
The [`@Transient` KDoc](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-transient/) indicates that the transient properties _should_ have default values, 

https://github.com/Kotlin/kotlinx.serialization/blob/0b01b537b05121e5c72696b415268f3a340ae9a7/core/commonMain/src/kotlinx/serialization/Annotations.kt#L165

but in practice I get a compilation error when a default value is missing.

```kotlin
@Serializable
data class ContainsJsonString constructor(val name: String, @Transient val jsonString: String)
```

<img width="657" alt="image" src="https://user-images.githubusercontent.com/897017/215056093-88e1c3f0-0d80-493b-9180-262c266f56e9.png">

This PR changes 'should' to 'must', which better describes the behaviour.
