### PR TITLE
add function for removing entry in `JsonObjectBuilder`

### DIFF
--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -324,6 +324,7 @@ public final class kotlinx/serialization/json/JsonObjectBuilder {
 	public fun <init> ()V
 	public final fun build ()Lkotlinx/serialization/json/JsonObject;
 	public final fun put (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/json/JsonElement;
+	public final fun remove (Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
 }
 
 public final class kotlinx/serialization/json/JsonObjectSerializer : kotlinx/serialization/KSerializer {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -68,6 +68,14 @@ public class JsonObjectBuilder @PublishedApi internal constructor() {
      */
     public fun put(key: String, element: JsonElement): JsonElement? = content.put(key, element)
 
+    /**
+     * Remove the JSON Element associated with the given [key].
+     *
+     * Returns the previous value associated with [key], or `null` if the key was not present.
+     */
+    @ExperimentalSerializationApi
+    public fun remove(key: String): JsonElement? = content.remove(key)
+
     @PublishedApi
     internal fun build(): JsonObject = JsonObject(content)
 }


### PR DESCRIPTION
Adds `JsonObjectBuilder.remove(key: String)` to remove an entry from a `JsonObjectBuilder` instance.

My first PR to this repo, so I hope I did everything right. :D
