### PR TITLE
json-okio: rename `target` variables to `sink`

### DIFF
--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.okio.internal.OkioSerialReader
 import okio.*
 
 /**
- * Serializes the [value] with [serializer] into a [target] using JSON format and UTF-8 encoding.
+ * Serializes the [value] with [serializer] into a [sink] using JSON format and UTF-8 encoding.
  *
  * @throws [SerializationException] if the given value cannot be serialized to JSON.
  * @throws [okio.IOException] If an I/O error occurs and sink can't be written to.
@@ -25,9 +25,9 @@ import okio.*
 public fun <T> Json.encodeToBufferedSink(
     serializer: SerializationStrategy<T>,
     value: T,
-    target: BufferedSink
+    sink: BufferedSink
 ) {
-    val writer = JsonToOkioStreamWriter(target)
+    val writer = JsonToOkioStreamWriter(sink)
     try {
         encodeByWriter(writer, serializer, value)
     } finally {
@@ -36,7 +36,7 @@ public fun <T> Json.encodeToBufferedSink(
 }
 
 /**
- * Serializes given [value] to a [target] using UTF-8 encoding and serializer retrieved from the reified type parameter.
+ * Serializes given [value] to a [sink] using UTF-8 encoding and serializer retrieved from the reified type parameter.
  *
  * @throws [SerializationException] if the given value cannot be serialized to JSON.
  * @throws [okio.IOException] If an I/O error occurs and sink can't be written to.
@@ -44,8 +44,8 @@ public fun <T> Json.encodeToBufferedSink(
 @ExperimentalSerializationApi
 public inline fun <reified T> Json.encodeToBufferedSink(
     value: T,
-    target: BufferedSink
-): Unit = encodeToBufferedSink(serializersModule.serializer(), value, target)
+    sink: BufferedSink
+): Unit = encodeToBufferedSink(serializersModule.serializer(), value, sink)
 
 
 /**

--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/internal/OkioJsonStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/internal/OkioJsonStreams.kt
@@ -11,34 +11,34 @@ import kotlinx.serialization.json.internal.JsonWriter
 import kotlinx.serialization.json.internal.SerialReader
 import okio.*
 
-internal class JsonToOkioStreamWriter(private val target: BufferedSink) : JsonWriter {
+internal class JsonToOkioStreamWriter(private val sink: BufferedSink) : JsonWriter {
     override fun writeLong(value: Long) {
         write(value.toString())
     }
 
     override fun writeChar(char: Char) {
-        target.writeUtf8CodePoint(char.code)
+        sink.writeUtf8CodePoint(char.code)
     }
 
     override fun write(text: String) {
-        target.writeUtf8(text)
+        sink.writeUtf8(text)
     }
 
     override fun writeQuoted(text: String) {
-        target.writeUtf8CodePoint('"'.code)
+        sink.writeUtf8CodePoint('"'.code)
         var lastPos = 0
         for (i in text.indices) {
             val c = text[i].code
             if (c < ESCAPE_STRINGS.size && ESCAPE_STRINGS[c] != null) {
-                target.writeUtf8(text, lastPos, i) // flush prev
-                target.writeUtf8(ESCAPE_STRINGS[c]!!)
+                sink.writeUtf8(text, lastPos, i) // flush prev
+                sink.writeUtf8(ESCAPE_STRINGS[c]!!)
                 lastPos = i + 1
             }
         }
 
-        if (lastPos != 0) target.writeUtf8(text, lastPos, text.length)
-        else target.writeUtf8(text)
-        target.writeUtf8CodePoint('"'.code)
+        if (lastPos != 0) sink.writeUtf8(text, lastPos, text.length)
+        else sink.writeUtf8(text)
+        sink.writeUtf8CodePoint('"'.code)
     }
 
     override fun release() {


### PR DESCRIPTION
The Okio codebase names Sink/BufferedSink variables "sink", so this aligns the naming convention

![okio-sink](https://user-images.githubusercontent.com/1829157/224515202-98309001-96c1-4766-ba94-db075297eb5d.png)
