### PR TITLE
Adapt tests for K2 and upcoming deprecations in K1:

### DIFF
--- a/core/commonTest/src/kotlinx/serialization/MetaSerializableTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/MetaSerializableTest.kt
@@ -4,18 +4,19 @@ import kotlinx.serialization.test.*
 import kotlin.reflect.KClass
 import kotlin.test.*
 
+@MetaSerializable
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+annotation class MySerializable
+
+@MetaSerializable
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+annotation class MySerializableWithInfo(
+    val value: Int,
+    val kclass: KClass<*>
+)
+
+
 class MetaSerializableTest {
-
-    @MetaSerializable
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
-    annotation class MySerializable
-
-    @MetaSerializable
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
-    annotation class MySerializableWithInfo(
-        val value: Int,
-        val kclass: KClass<*>
-    )
 
     @MySerializable
     class Project1(val name: String, val language: String)

--- a/core/commonTest/src/kotlinx/serialization/features/SchemaTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/features/SchemaTest.kt
@@ -7,6 +7,8 @@ package kotlinx.serialization.features
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.test.EnumSerializer
 import kotlin.test.*
@@ -18,15 +20,17 @@ class SchemaTest {
     @Serializable
     data class Box<T>(val boxed: T)
 
-    @Serializable
+    @Serializable(Data1.Companion::class)
     data class Data1(val l: List<Int> = emptyList(), val s: String) {
-        @Serializer(forClass = Data1::class)
-        companion object {
-            // TODO removal of explicit type crashes the compiler
-            override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Data1") {
+        companion object: KSerializer<Data1> {
+            override val descriptor = buildClassSerialDescriptor("Data1") {
                 element("l", listSerialDescriptor<Int>(), isOptional = true)
                 element("s", serialDescriptor<String>())
             }
+
+            override fun serialize(encoder: Encoder, value: Data1) = error("Should not be called")
+
+            override fun deserialize(decoder: Decoder): Data1 = error("Should not be called")
         }
     }
 

--- a/formats/json-tests/build.gradle.kts
+++ b/formats/json-tests/build.gradle.kts
@@ -15,6 +15,8 @@ apply(from = rootProject.file("gradle/configure-source-sets.gradle"))
 tasks.withType<Kotlin2JsCompile> {
     if (this.name == "compileTestKotlinJsLegacy") {
         this.exclude("**/PropertyInitializerTest.kt")
+        // Partially custom serializers without 'implicit customisation by companion' annotation are not supported on Legacy JS
+        this.exclude("**/PartiallyCustomSerializerTest.kt", "**/JsonCustomSerializersTest.kt")
     }
 }
 

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/MetaSerializableJsonTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/MetaSerializableJsonTest.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import kotlin.test.*
 
-class MetaSerializableJsonTest : JsonTestBase() {
-    @MetaSerializable
-    @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-    annotation class JsonComment(val comment: String)
+@MetaSerializable
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+annotation class JsonComment(val comment: String)
 
-    @JsonComment("class_comment")
-    data class IntDataCommented(val i: Int)
+@JsonComment("class_comment")
+data class IntDataCommented(val i: Int)
+
+class MetaSerializableJsonTest : JsonTestBase() {
 
     @Serializable
     data class Carrier(

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/PartiallyCustomSerializerTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/PartiallyCustomSerializerTest.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@Serializable
+@Serializable(WithNull.Companion::class)
 data class WithNull(@SerialName("value") val nullable: String? = null) {
     @Serializer(forClass = WithNull::class)
     companion object : KSerializer<WithNull> {

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
@@ -34,7 +34,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class BList(@Id(1) val bs: List<B>)
 
-    @Serializable
+    @Serializable(C.Companion::class)
     data class C(@Id(1) val a: Int = 31, @Id(2) val b: Int = 42) {
         @Serializer(forClass = C::class)
         companion object : KSerializer<C> {
@@ -50,7 +50,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Serializable
     data class CList1(@Id(1) val c: List<C>)
 
-    @Serializable
+    @Serializable(CList2.Companion::class)
     data class CList2(@Id(1) val d: Int = 5, @Id(2) val c: List<C>) {
         @Serializer(forClass = CList2::class)
         companion object : KSerializer<CList2> {
@@ -63,7 +63,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
         }
     }
 
-    @Serializable
+    @Serializable(CList3.Companion::class)
     data class CList3(@Id(1) val e: List<C> = emptyList(), @Id(2) val f: Int) {
         @Serializer(forClass = CList3::class)
         companion object : KSerializer<CList3> {
@@ -76,7 +76,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
         }
     }
 
-    @Serializable
+    @Serializable(CList4.Companion::class)
     data class CList4(@Id(1) val g: List<C> = emptyList(), @Id(2) val h: Int) {
         @Serializer(forClass = CList4::class)
         companion object : KSerializer<CList4> {
@@ -89,7 +89,7 @@ class JsonCustomSerializersTest : JsonTestBase() {
         }
     }
 
-    @Serializable
+    @Serializable(CList5.Companion::class)
     data class CList5(@Id(1) val g: List<Int> = emptyList(), @Id(2) val h: Int) {
         @Serializer(forClass = CList5::class)
         companion object : KSerializer<CList5> {


### PR DESCRIPTION
- Move meta-serializable annotations to top-level.
- Specify argument for `@Serializable` when companion serializer is used.