### PR TITLE
Add polymorphicAllSuperClasses for SerializersModuleBuilder on Jvm

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,6 +10,11 @@ apply from: rootProject.file("gradle/configure-source-sets.gradle")
 
 kotlin {
     sourceSets {
+        jvmMain {
+            dependencies {
+                implementation kotlin("reflect")
+            }
+        }
         jvmTest {
             dependencies {
                 implementation 'io.kotlintest:kotlintest:2.0.7'

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -89,7 +89,7 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
             builder.registerPolymorphicSerializer(
                 baseClass,
                 kclass as KClass<Base>,
-                serializer.cast()
+                serializer // useless cast
             )
         }
 

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -46,9 +46,11 @@ public fun EmptySerializersModule(): SerializersModule = @Suppress("DEPRECATION"
 public class SerializersModuleBuilder @PublishedApi internal constructor() : SerializersModuleCollector {
     private val class2ContextualProvider: MutableMap<KClass<*>, ContextualProvider> = hashMapOf()
     private val polyBase2Serializers: MutableMap<KClass<*>, MutableMap<KClass<*>, KSerializer<*>>> = hashMapOf()
-    private val polyBase2DefaultSerializerProvider: MutableMap<KClass<*>, PolymorphicSerializerProvider<*>> = hashMapOf()
+    private val polyBase2DefaultSerializerProvider: MutableMap<KClass<*>, PolymorphicSerializerProvider<*>> =
+        hashMapOf()
     private val polyBase2NamedSerializers: MutableMap<KClass<*>, MutableMap<String, KSerializer<*>>> = hashMapOf()
-    private val polyBase2DefaultDeserializerProvider: MutableMap<KClass<*>, PolymorphicDeserializerProvider<*>> = hashMapOf()
+    private val polyBase2DefaultDeserializerProvider: MutableMap<KClass<*>, PolymorphicDeserializerProvider<*>> =
+        hashMapOf()
 
     /**
      * Adds [serializer] associated with given [kClass] for contextual serialization.
@@ -183,11 +185,13 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
         polyBase2DefaultDeserializerProvider[baseClass] = defaultDeserializerProvider
     }
 
-    @JvmName("registerPolymorphicSerializer") // Don't mangle method name for prettier stack traces
-    internal fun <Base : Any, Sub : Base> registerPolymorphicSerializer(
-        baseClass: KClass<Base>,
-        concreteClass: KClass<Sub>,
-        concreteSerializer: KSerializer<Sub>,
+    /**
+     * Warn: use [registerPolymorphicSerializerSafely] on common platform
+     */
+    internal fun registerPolymorphicSerializer(
+        baseClass: KClass<*>,
+        concreteClass: KClass<*>,
+        concreteSerializer: KSerializer<*>,
         allowOverwrite: Boolean = false
     ) {
         // Check for overwrite
@@ -227,9 +231,25 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
         names[name] = concreteSerializer
     }
 
+    @JvmName("registerPolymorphicSerializerSafely") // Don't mangle method name for prettier stack traces
+    internal fun <Base : Any, Sub : Base> registerPolymorphicSerializerSafely(
+        baseClass: KClass<Base>,
+        concreteClass: KClass<Sub>,
+        concreteSerializer: KSerializer<Sub>,
+        allowOverwrite: Boolean = false
+    ) {
+        registerPolymorphicSerializer(baseClass, concreteClass, concreteSerializer, allowOverwrite)
+    }
+
     @PublishedApi
     internal fun build(): SerializersModule =
-        SerialModuleImpl(class2ContextualProvider, polyBase2Serializers, polyBase2DefaultSerializerProvider, polyBase2NamedSerializers, polyBase2DefaultDeserializerProvider)
+        SerialModuleImpl(
+            class2ContextualProvider,
+            polyBase2Serializers,
+            polyBase2DefaultSerializerProvider,
+            polyBase2NamedSerializers,
+            polyBase2DefaultDeserializerProvider
+        )
 }
 
 /**

--- a/core/jvmMain/src/kotlinx/serialization/modules/IncorrectInheritanceException.kt
+++ b/core/jvmMain/src/kotlinx/serialization/modules/IncorrectInheritanceException.kt
@@ -1,0 +1,10 @@
+package kotlinx.serialization.modules
+
+import kotlin.reflect.KClass
+
+public class IncorrectInheritanceException internal constructor(msg: String) : IllegalArgumentException(msg) {
+    public constructor(
+        baseClass: KClass<*>,
+        concreteClass: KClass<*>
+    ) : this("$baseClass is not the super class of $concreteClass")
+}

--- a/core/jvmMain/src/kotlinx/serialization/modules/ModuleBuilderExtensions.kt
+++ b/core/jvmMain/src/kotlinx/serialization/modules/ModuleBuilderExtensions.kt
@@ -50,8 +50,9 @@ public fun SerializersModuleBuilder.polymorphicAllSuperClasses(
 @ExperimentalSerializationApi
 public fun SerializersModuleBuilder.polymorphicSuperRecursive(actualClass: KClass<*>) {
     actualClass.allSuperclasses.forEach { superClass ->
-        polymorphicSuperRecursive(superClass)
         polymorphicUnsafely(superClass, actualClass, actualClass.serializer(), true)
+        if (!superClass.isOpen && !superClass.isAbstract && !superClass.isSealed)
+            polymorphicSuperRecursive(superClass)
     }
 }
 

--- a/core/jvmMain/src/kotlinx/serialization/modules/ModuleBuilderExtensions.kt
+++ b/core/jvmMain/src/kotlinx/serialization/modules/ModuleBuilderExtensions.kt
@@ -43,16 +43,4 @@ public fun SerializersModuleBuilder.polymorphicAllSuperClasses(
     }
 }
 
-/**
- * Accept [actualClass], associated with it and its superClasses for polymorphic serialization.
- * Recursively do same thing on all super classes of [actualClass]
- */
-@ExperimentalSerializationApi
-public fun SerializersModuleBuilder.polymorphicSuperRecursive(actualClass: KClass<*>) {
-    actualClass.allSuperclasses.forEach { superClass ->
-        polymorphicUnsafely(superClass, actualClass, actualClass.serializer(), true)
-        if (!superClass.isOpen && !superClass.isAbstract && !superClass.isSealed)
-            polymorphicSuperRecursive(superClass)
-    }
-}
 

--- a/core/jvmMain/src/kotlinx/serialization/modules/ModuleBuilderExtensions.kt
+++ b/core/jvmMain/src/kotlinx/serialization/modules/ModuleBuilderExtensions.kt
@@ -1,0 +1,57 @@
+package kotlinx.serialization.modules
+
+import kotlinx.serialization.*
+import kotlin.reflect.*
+import kotlin.reflect.full.*
+
+
+/**
+ * Accept a serializer, associated with [actualClass] for polymorphic serialization.
+ *
+ * Use this function only if the generic parameters of [baseClass] are erased,
+ * check the inheritance at runtime.
+ *
+ * Otherwise, use [polymorphic].
+ *
+ * If [ignoreIncorrectInheritance] is false, an [IncorrectInheritanceException] throws.
+ */
+@ExperimentalSerializationApi
+public fun SerializersModuleBuilder.polymorphicUnsafely(
+    baseClass: KClass<*>,
+    actualClass: KClass<*>,
+    actualSerializer: KSerializer<*>,
+    allowOverwrite: Boolean = false,
+    ignoreIncorrectInheritance: Boolean = false
+) {
+    if (!actualClass.isSubclassOf(baseClass)) {
+        if (ignoreIncorrectInheritance) return
+        throw IncorrectInheritanceException(baseClass, actualClass)
+    }
+    this.registerPolymorphicSerializer(baseClass, actualClass, actualSerializer, allowOverwrite)
+}
+
+/**
+ * Accept [actualClass], associated with it and its superClasses for polymorphic serialization.
+ */
+@ExperimentalSerializationApi
+public fun SerializersModuleBuilder.polymorphicAllSuperClasses(
+    actualClass: KClass<*>,
+    allowOverwrite: Boolean = false
+) {
+    actualClass.allSuperclasses.forEach { superClass ->
+        polymorphicUnsafely(superClass, actualClass, actualClass.serializer(), allowOverwrite)
+    }
+}
+
+/**
+ * Accept [actualClass], associated with it and its superClasses for polymorphic serialization.
+ * Recursively do same thing on all super classes of [actualClass]
+ */
+@ExperimentalSerializationApi
+public fun SerializersModuleBuilder.polymorphicSuperRecursive(actualClass: KClass<*>) {
+    actualClass.allSuperclasses.forEach { superClass ->
+        polymorphicSuperRecursive(superClass)
+        polymorphicUnsafely(superClass, actualClass, actualClass.serializer(), true)
+    }
+}
+

--- a/core/jvmTest/src/kotlinx/serialization/modules/ModuleBuilderExtensionsKtTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/modules/ModuleBuilderExtensionsKtTest.kt
@@ -14,6 +14,10 @@ class ModuleBuilderExtensionsKtTest {
         val propertyB: UInt
     }
 
+    interface IC : IB {
+        val propertyC: Double
+    }
+
     @Serializable
     open class GrandGrandParent(
         val grandgrand: String
@@ -33,12 +37,15 @@ class ModuleBuilderExtensionsKtTest {
     }
 
     @Serializable
-    open class Parent : GrandParent {
+    open class Parent : GrandParent, IC {
         val parent: Float
 
         constructor(grandgrand: String, grand: Int, parent: Float) : super(grandgrand, grand) {
             this.parent = parent
         }
+
+        override val propertyC: Double
+            get() = 1.5
 
     }
 

--- a/core/jvmTest/src/kotlinx/serialization/modules/ModuleBuilderExtensionsKtTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/modules/ModuleBuilderExtensionsKtTest.kt
@@ -1,0 +1,125 @@
+package kotlinx.serialization.modules
+
+import kotlinx.serialization.*
+import org.junit.*
+
+import kotlin.reflect.KClass
+
+class ModuleBuilderExtensionsKtTest {
+    interface IA {
+        val propertyA: Double
+    }
+
+    interface IB {
+        val propertyB: UInt
+    }
+
+    @Serializable
+    open class GrandGrandParent(
+        val grandgrand: String
+    ) : IA {
+        override val propertyA: Double = 1.0
+    }
+
+    @Serializable
+    open class GrandParent : GrandGrandParent, IB {
+        val grand: Int
+
+        constructor(grandgrand: String, grand: Int) : super(grandgrand) {
+            this.grand = grand
+        }
+
+        override val propertyB: UInt = 4u
+    }
+
+    @Serializable
+    open class Parent : GrandParent {
+        val parent: Float
+
+        constructor(grandgrand: String, grand: Int, parent: Float) : super(grandgrand, grand) {
+            this.parent = parent
+        }
+
+    }
+
+    @Serializable
+    class Child : Parent {
+        constructor(grandgrand: String, grand: Int, parent: Float) : super(grandgrand, grand, parent)
+    }
+
+    private fun <Base : Any, T : Base> SerializersModule.assertPoly(
+        serializer: KSerializer<T>,
+        base: KClass<Base>,
+        obj: T
+    ) =
+        kotlin.test.assertEquals(
+            serializer,
+            getPolymorphic(base, obj),
+            "No serializer for ${obj::class} with base $base in module"
+        )
+
+    @Test
+    fun testPolymorphicUnsafely() {
+        val module = SerializersModule {
+            polymorphicUnsafely(Parent::class, Child::class, Child.serializer())
+            polymorphicUnsafely(Parent::class, Parent::class, Parent.serializer())
+            polymorphicUnsafely(GrandParent::class, Parent::class, Parent.serializer())
+            polymorphicUnsafely(GrandParent::class, Child::class, Child.serializer())
+        }
+        val parent = Parent("gg", 1, 1.1f)
+        val child = Child("gg_child", 2, 2.2f)
+        module.apply {
+            assertPoly(Child.serializer(), Parent::class, child)
+            assertPoly(Child.serializer(), GrandParent::class, child)
+            assertPoly(Parent.serializer(), Parent::class, parent)
+            assertPoly(Parent.serializer(), GrandParent::class, parent)
+        }
+    }
+
+    @Test
+    fun testPolymorphicAllSuperClasses() {
+        val module = SerializersModule {
+            polymorphicAllSuperClasses(Child::class)
+        }
+        val child = Child("gg_child", 2, 2.2f)
+        val childSerializer = Child.serializer()
+        module.apply {
+            assertPoly(childSerializer, Parent::class, child)
+            assertPoly(childSerializer, GrandParent::class, child)
+            assertPoly(childSerializer, GrandGrandParent::class, child)
+            assertPoly(childSerializer, IA::class, child)
+            assertPoly(childSerializer, IB::class, child)
+            assertPoly(childSerializer, Any::class, child)
+        }
+    }
+
+    @Test
+    fun testPolymorphicSuperRecursive() {
+        val module = SerializersModule {
+            polymorphicSuperRecursive(Child::class)
+        }
+        val grandGrandParent = GrandGrandParent("gg")
+        val grandParent = GrandParent("gg_grand", 0)
+        val parent = Parent("gg_parent", 1, 1.1f)
+        val child = Child("gg_child", 2, 2.2f)
+        module.apply {
+            assertPoly(Child.serializer(), Parent::class, child)
+            assertPoly(Child.serializer(), GrandParent::class, child)
+            assertPoly(Child.serializer(), GrandGrandParent::class, child)
+            assertPoly(Child.serializer(), IA::class, child)
+            assertPoly(Child.serializer(), IB::class, child)
+            assertPoly(Child.serializer(), Any::class, child)
+            assertPoly(Parent.serializer(), GrandParent::class, parent)
+            assertPoly(Parent.serializer(), GrandGrandParent::class, parent)
+            assertPoly(Parent.serializer(), IA::class, parent)
+            assertPoly(Parent.serializer(), IB::class, parent)
+            assertPoly(Parent.serializer(), Any::class, parent)
+            assertPoly(GrandParent.serializer(), GrandGrandParent::class, grandParent)
+            assertPoly(GrandParent.serializer(), IA::class, grandParent)
+            assertPoly(GrandParent.serializer(), IB::class, grandParent)
+            assertPoly(GrandParent.serializer(), Any::class, grandParent)
+            assertPoly(GrandGrandParent.serializer(), IA::class, grandGrandParent)
+            assertPoly(GrandGrandParent.serializer(), Any::class, grandGrandParent)
+        }
+    }
+}


### PR DESCRIPTION
Add polymorphicAllSuperClasses for SerializersModuleBuilder on Jvm.
On the jvm platform, the generics in the KClass obtained by reflection will be erased (KClass<*>). We can assert that the KClass of the parent class must be the superClass of the KClass of the child class, so I think we need a function to receive KClass<*>.
The corresponding unit test has included.