### PR TITLE
Replace `runCatching-map-getOrDefault` in caching

### DIFF
--- a/core/jvmMain/src/kotlinx/serialization/internal/Caching.kt
+++ b/core/jvmMain/src/kotlinx/serialization/internal/Caching.kt
@@ -17,9 +17,12 @@ import kotlin.reflect.KTypeProjection
  * but ClassValue is not available on Android, thus we attempt to check it dynamically
  * and fallback to ConcurrentHashMap-based cache.
  */
-private val useClassValue = runCatching {
+private val useClassValue = try {
     Class.forName("java.lang.ClassValue")
-}.map { true }.getOrDefault(false)
+    true
+} catch (_: Throwable) {
+    false
+}
 
 /**
  * Creates a **strongly referenced** cache of values associated with [Class].


### PR DESCRIPTION
The `runCatching-map-getOrDefault` logic is too complicated and takes a detour in mind.

A simple `try-catch` returning `true` or `false` should do the trick.