### PR TITLE
Fix polymorphic serialization in Properties format

### DIFF
--- a/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
@@ -58,6 +58,7 @@ public sealed class Properties(
             if (serializer is AbstractPolymorphicSerializer<*>) {
                 val casted = serializer as AbstractPolymorphicSerializer<Any>
                 val actualSerializer = casted.findPolymorphicSerializer(this, value as Any)
+                map[nested("type")] = encode(actualSerializer.descriptor.serialName)
 
                 return actualSerializer.serialize(this, value)
             }
@@ -102,9 +103,9 @@ public sealed class Properties(
         }
 
         final override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
-            val type = map["type"]?.toString()
 
             if (deserializer is AbstractPolymorphicSerializer<*>) {
+                val type = map[nested("type")]?.toString()
                 val actualSerializer: DeserializationStrategy<Any> = deserializer.findPolymorphicSerializer(this, type)
 
                 @Suppress("UNCHECKED_CAST")

--- a/formats/properties/commonTest/src/kotlinx/serialization/properties/SealedClassSerializationFromPropertiesTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/properties/SealedClassSerializationFromPropertiesTest.kt
@@ -32,19 +32,56 @@ class SealedClassSerializationFromPropertiesTest {
         val instance: BaseClass = Properties.decodeFromMap(props)
 
         assertIs<FirstChild>(instance)
-        assertEquals(instance.firstProperty, 1)
+        assertEquals(instance.firstProperty, 1L)
         assertEquals(instance.secondProperty, "one")
     }
 
     @Test
     fun testPropertiesSerialization() {
         val instance: BaseClass = FirstChild(
-            firstProperty = 1L, secondProperty = "one"
+            firstProperty = 1L,
+            secondProperty = "one"
         )
 
         val instanceProperties = Properties.encodeToMap(instance)
 
+        assertEquals("FIRSTCHILD", instanceProperties["type"])
         assertEquals(1L, instanceProperties["firstProperty"])
         assertEquals("one", instanceProperties["secondProperty"])
+    }
+
+    @Serializable
+    data class CompositeClass(val item: BaseClass)
+
+    @Test
+    fun testCompositeClassPropertiesDeserialization() {
+        val props = mapOf(
+            "item.type" to "SECONDCHILD",
+            "item.firstProperty" to 7L,
+            "item.secondProperty" to "nothing"
+        )
+
+        val composite: CompositeClass = Properties.decodeFromMap(props)
+        val instance = composite.item
+
+        assertIs<SecondChild>(instance)
+        assertEquals(instance.firstProperty, 7L)
+        assertEquals(instance.secondProperty, "nothing")
+    }
+
+    @Test
+    fun testCompositeClassPropertiesSerialization() {
+        val composite = CompositeClass(
+            item = FirstChild(
+                firstProperty = 5L,
+                secondProperty = "something"
+            )
+        )
+
+        val compositeProperties = Properties.encodeToMap(composite)
+
+        assertEquals("FIRSTCHILD", compositeProperties["item.type"])
+        assertEquals(5L, compositeProperties["item.firstProperty"])
+        assertEquals("something", compositeProperties["item.secondProperty"])
     }
 }


### PR DESCRIPTION
When encoding polymorphic types in Properties format there is a missing "type" descriptor for the concrete class being encoded.
When decoding the "type" descriptor was only correctly read for top-level polymorphic deserialization.