### PR TITLE
ObjectSerializer: Respect sequential decoding

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/ObjectSerializer.kt
@@ -41,6 +41,9 @@ internal class ObjectSerializer<T : Any>(serialName: String, private val objectI
 
     override fun deserialize(decoder: Decoder): T {
         decoder.decodeStructure(descriptor) {
+            if (decodeSequentially())
+                return@decodeStructure
+
             when (val index = decodeElementIndex(descriptor)) {
                 CompositeDecoder.DECODE_DONE -> {
                     return@decodeStructure


### PR DESCRIPTION
This was broken in https://github.com/Kotlin/kotlinx.serialization/pull/1916