### PR TITLE
Fix memory leak caused by invalid KTypeWrapper equality

### DIFF
--- a/core/jvmMain/src/kotlinx/serialization/internal/Caching.kt
+++ b/core/jvmMain/src/kotlinx/serialization/internal/Caching.kt
@@ -170,7 +170,7 @@ private class KTypeWrapper(private val origin: KType) : KType {
 
     override fun equals(other: Any?): Boolean {
         if (other == null) return false
-        if (origin != other) return false
+        if (origin != (other as? KTypeWrapper)?.origin) return false
 
         val kClassifier = classifier
         if (kClassifier is KClass<*>) {

--- a/core/jvmTest/src/kotlinx/serialization/CachingTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/CachingTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.internal.StringSerializer
+import kotlinx.serialization.internal.createCache
+import kotlinx.serialization.internal.createParametrizedCache
+import kotlinx.serialization.internal.kclass
+import kotlinx.serialization.modules.*
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
+import kotlin.test.*
+
+class CachingTest {
+    @Test
+    fun testCache() {
+        var factoryCalled = 0
+
+        val cache = createCache {
+            factoryCalled += 1
+            it.serializerOrNull()
+        }
+
+        repeat(10) {
+            cache.get(typeOf<String>().kclass())
+        }
+
+        assertEquals(1, factoryCalled)
+    }
+
+    @Test
+    fun testParameterizedCache() {
+        var factoryCalled = 0
+
+        val cache = createParametrizedCache { clazz, types ->
+            factoryCalled += 1
+            val serializers = EmptySerializersModule().serializersForParameters(types, true)!!
+            clazz.parametrizedSerializerOrNull(types, serializers)
+        }
+
+        repeat(10) {
+            cache.get(typeOf<Map<*, *>>().kclass(), listOf(typeOf<String>(), typeOf<String>()))
+        }
+
+        assertEquals(1, factoryCalled)
+    }
+}


### PR DESCRIPTION
`KTypeWrapper`'s `equals` method was not implemented correctly.

This bug causes a cache miss every time [here](https://github.com/Kotlin/kotlinx.serialization/blob/99496a8cd20fec74d0dabbb2698d48795b405cc5/core/jvmMain/src/kotlinx/serialization/internal/Caching.kt#L196-L197), which leads to a memory leak by registering a new serialiser every time it is looked up.