### PR TITLE
@OptIn for experimental WeakReference

### DIFF
--- a/formats/json/nativeMain/src/kotlinx/serialization/json/JsonSchemaCache.kt
+++ b/formats/json/nativeMain/src/kotlinx/serialization/json/JsonSchemaCache.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.json
 
 import kotlinx.serialization.json.internal.*
+import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.*
 import kotlin.random.*
 import kotlin.native.concurrent.*
@@ -26,6 +27,7 @@ private val jsonToCache: MutableMap<WeakJson, DescriptorSchemaCache> = mutableMa
 /**
  * Because WeakReference itself does not have proper equals/hashCode
  */
+@OptIn(ExperimentalNativeApi::class)
 private class WeakJson(json: Json) {
     private val ref = WeakReference(json)
     private val initialHashCode = json.hashCode()


### PR DESCRIPTION
Native `WeakReference` was made experimental in an effort to stabilize Native stdlib. As a result UserProjects build of the `kotlinx.serialization` started failing.