### PR TITLE
Implemented obtainment of KSerializer by KClass in SerializersModule

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -124,6 +124,7 @@ public final class kotlinx/serialization/SerializersKt {
 	public static final fun noCompiledSerializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializer (Lkotlin/reflect/KClass;Ljava/util/List;Z)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;Ljava/util/List;Z)Lkotlinx/serialization/KSerializer;

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -126,6 +126,7 @@ public final class kotlinx/serialization/SerializersKt {
 	public static final fun serializer (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;Ljava/util/List;Z)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerOrNull (Ljava/lang/reflect/Type;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializerOrNull (Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+
 /*
  * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
@@ -60,6 +62,12 @@ tasks.withType(Jar).named(kotlin.jvm().artifactsTaskName) {
                 "Implementation-Version": version,
                 "Require-Kotlin-Version": "1.4.30-M1",
         )
+    }
+}
+
+tasks.withType(Kotlin2JsCompile.class).configureEach {
+    if (it.name == "compileTestKotlinJsLegacy") {
+        it.exclude("**/SerializersModuleTest.kt")
     }
 }
 

--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -88,7 +88,6 @@ public fun serializer(type: KType): KSerializer<Any?> = EmptySerializersModule()
  * @throws SerializationException if serializer cannot be created (provided [kClass] or its type argument is not serializable)
  * @throws SerializationException if [kClass] is a `kotlin.Array`
  * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
- * @throws IndexOutOfBoundsException if [kClass] has a built-in serializer and size of [typeArgumentsSerializers] does not match the expected generic parameters count
  * @throws IndexOutOfBoundsException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
 @ExperimentalSerializationApi
@@ -153,7 +152,6 @@ public fun SerializersModule.serializer(type: KType): KSerializer<Any?> =
  * @throws SerializationException if serializer cannot be created (provided [kClass] or its type argument is not serializable and is not registered in [this] module)
  * @throws SerializationException if [kClass] is a `kotlin.Array`
  * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
- * @throws IndexOutOfBoundsException if [kClass] has a built-in serializer and size of [typeArgumentsSerializers] does not match the expected generic parameters count
  * @throws IndexOutOfBoundsException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
 @ExperimentalSerializationApi

--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -88,7 +88,6 @@ public fun serializer(type: KType): KSerializer<Any?> = EmptySerializersModule()
  * @throws SerializationException if serializer cannot be created (provided [kClass] or its type argument is not serializable)
  * @throws SerializationException if [kClass] is a `kotlin.Array`
  * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
- * @throws IndexOutOfBoundsException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
 @ExperimentalSerializationApi
 public fun serializer(
@@ -152,7 +151,6 @@ public fun SerializersModule.serializer(type: KType): KSerializer<Any?> =
  * @throws SerializationException if serializer cannot be created (provided [kClass] or its type argument is not serializable and is not registered in [this] module)
  * @throws SerializationException if [kClass] is a `kotlin.Array`
  * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
- * @throws IndexOutOfBoundsException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
 @ExperimentalSerializationApi
 public fun SerializersModule.serializer(
@@ -238,7 +236,7 @@ private fun SerializersModule.serializerByKClassImpl(
                 typeArgumentsSerializers
             )
         } catch (e: IndexOutOfBoundsException) {
-            throw SerializationException("Unable to retrieve a serializer, the number of passed type serializers differs from the actual number of generic parameters")
+            throw SerializationException("Unable to retrieve a serializer, the number of passed type serializers differs from the actual number of generic parameters", e)
         }
 
     }

--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -224,7 +224,6 @@ private fun SerializersModule.serializerByKClassImpl(
     typeArgumentsSerializers: List<KSerializer<Any?>>,
     isNullable: Boolean
 ): KSerializer<Any?>? {
-
     val serializer = if (typeArgumentsSerializers.isEmpty()) {
         rootClass.serializerOrNull() ?: getContextual(rootClass)
     } else {
@@ -238,7 +237,6 @@ private fun SerializersModule.serializerByKClassImpl(
         } catch (e: IndexOutOfBoundsException) {
             throw SerializationException("Unable to retrieve a serializer, the number of passed type serializers differs from the actual number of generic parameters", e)
         }
-
     }
 
     return serializer?.cast<Any>()?.nullable(isNullable)

--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -86,15 +86,17 @@ public fun serializer(type: KType): KSerializer<Any?> = EmptySerializersModule()
  * Caching on JVM platform is disabled for this function, so it may work slower than an overload with [KType].
  *
  * @throws SerializationException if serializer cannot be created (provided [kClass] or its type argument is not serializable)
- * @throws SerializationException if [kClass] is an array class
+ * @throws SerializationException if [kClass] is a `kotlin.Array`
+ * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
+ * @throws IndexOutOfBoundsException if [kClass] has a built-in serializer and size of [typeArgumentsSerializers] does not match the expected generic parameters count
  * @throws IndexOutOfBoundsException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
 @ExperimentalSerializationApi
-public fun serializer(
-    kClass: KClass<*>,
+public fun <T: Any> serializer(
+    kClass: KClass<T>,
     typeArgumentsSerializers: List<KSerializer<*>>,
     isNullable: Boolean
-): KSerializer<Any?> = EmptySerializersModule().serializer(kClass, typeArgumentsSerializers, isNullable)
+): KSerializer<T?> = EmptySerializersModule().serializer(kClass, typeArgumentsSerializers, isNullable)
 
 /**
  * Creates a serializer for the given [type] if possible.
@@ -150,6 +152,8 @@ public fun SerializersModule.serializer(type: KType): KSerializer<Any?> =
  *
  * @throws SerializationException if serializer cannot be created (provided [kClass] or its type argument is not serializable and is not registered in [this] module)
  * @throws SerializationException if [kClass] is a `kotlin.Array`
+ * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
+ * @throws IndexOutOfBoundsException if [kClass] has a built-in serializer and size of [typeArgumentsSerializers] does not match the expected generic parameters count
  * @throws IndexOutOfBoundsException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
 @ExperimentalSerializationApi
@@ -157,8 +161,8 @@ public fun <T : Any> SerializersModule.serializer(
     kClass: KClass<T>,
     typeArgumentsSerializers: List<KSerializer<*>>,
     isNullable: Boolean
-): KSerializer<Any?> =
-    serializerByKClassImpl(kClass as KClass<Any>, typeArgumentsSerializers as List<KSerializer<Any?>>, isNullable)
+): KSerializer<T?> =
+    serializerByKClassImpl(kClass as KClass<Any>, typeArgumentsSerializers as List<KSerializer<Any?>>, isNullable)?.cast()
         ?: kClass.platformSpecificSerializerNotRegistered()
 
 /**

--- a/core/commonMain/src/kotlinx/serialization/SerializersCache.kt
+++ b/core/commonMain/src/kotlinx/serialization/SerializersCache.kt
@@ -32,7 +32,7 @@ private val SERIALIZERS_CACHE_NULLABLE = createCache<Any?> { it.serializerOrNull
 @ThreadLocal
 private val PARAMETRIZED_SERIALIZERS_CACHE = createParametrizedCache { clazz, types ->
     val serializers = EmptySerializersModule().serializersForParameters(types, true)!!
-    clazz.parametrizedSerializerOrNull(types, serializers)
+    clazz.parametrizedSerializerOrNull(serializers) { types[0].classifier }
 }
 
 /**
@@ -41,7 +41,7 @@ private val PARAMETRIZED_SERIALIZERS_CACHE = createParametrizedCache { clazz, ty
 @ThreadLocal
 private val PARAMETRIZED_SERIALIZERS_CACHE_NULLABLE = createParametrizedCache<Any?> { clazz, types ->
     val serializers = EmptySerializersModule().serializersForParameters(types, true)!!
-    clazz.parametrizedSerializerOrNull(types, serializers)?.nullable?.cast()
+    clazz.parametrizedSerializerOrNull(serializers) { types[0].classifier }?.nullable?.cast()
 }
 
 /**

--- a/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
@@ -54,23 +54,20 @@ class SerializersModuleTest {
 
     @Test
     fun testCompiled() = noJsLegacy {
-        val m = SerializersModule { }
-
-        assertSame<KSerializer<*>>(Object.serializer(), m.serializer(Object::class, emptyList(), false))
-        assertSame<KSerializer<*>>(SealedParent.serializer(), m.serializer(SealedParent::class, emptyList(), false))
+        assertSame<KSerializer<*>>(Object.serializer(), serializer(Object::class, emptyList(), false))
+        assertSame<KSerializer<*>>(SealedParent.serializer(), serializer(SealedParent::class, emptyList(), false))
         assertSame<KSerializer<*>>(
             SealedParent.Child.serializer(),
-            m.serializer(SealedParent.Child::class, emptyList(), false)
+            serializer(SealedParent.Child::class, emptyList(), false)
         )
 
-        assertSame<KSerializer<*>>(Abstract.serializer(), m.serializer(Abstract::class, emptyList(), false))
-        assertSame<KSerializer<*>>(SerializableEnum.serializer(), m.serializer(SerializableEnum::class, emptyList(), false))
+        assertSame<KSerializer<*>>(Abstract.serializer(), serializer(Abstract::class, emptyList(), false))
+        assertSame<KSerializer<*>>(SerializableEnum.serializer(), serializer(SerializableEnum::class, emptyList(), false))
     }
 
     @Test
     fun testBuiltIn() {
-        val m = SerializersModule { }
-        assertSame<KSerializer<*>>(Int.serializer(), m.serializer(Int::class, emptyList(), false))
+        assertSame<KSerializer<*>>(Int.serializer(), serializer(Int::class, emptyList(), false))
     }
 
     @Test
@@ -81,13 +78,11 @@ class SerializersModuleTest {
 
     @Test
     fun testParametrized() {
-        val m = SerializersModule { }
-
-        val serializer = m.serializer(Parametrized::class, listOf(Int.serializer()), false)
+        val serializer = serializer(Parametrized::class, listOf(Int.serializer()), false)
         assertEquals<KClass<*>>(Parametrized.serializer(Int.serializer())::class, serializer::class)
         assertEquals(PrimitiveKind.INT, serializer.descriptor.getElementDescriptor(0).kind)
 
-        val mapSerializer = m.serializer(Map::class, listOf(String.serializer(), Int.serializer()), false)
+        val mapSerializer = serializer(Map::class, listOf(String.serializer(), Int.serializer()), false)
         assertIs<MapLikeSerializer<*, *, *, *>>(mapSerializer)
         assertEquals(PrimitiveKind.STRING, mapSerializer.descriptor.getElementDescriptor(0).kind)
         assertEquals(PrimitiveKind.INT, mapSerializer.descriptor.getElementDescriptor(1).kind)
@@ -95,10 +90,8 @@ class SerializersModuleTest {
 
     @Test
     fun testUnsupportedArray() {
-        val m = SerializersModule { }
-
         assertFails {
-            m.serializer(Array::class, listOf(Int.serializer()), false)
+            serializer(Array::class, listOf(Int.serializer()), false)
         }
     }
 

--- a/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
@@ -107,6 +107,7 @@ class SerializersModuleTest {
 
         val boxSerializer = m.serializer(ContextualGenericsTest.ThirdPartyBox::class, listOf(Int.serializer()), false)
         assertIs<ContextualGenericsTest.ThirdPartyBoxSerializer<Int>>(boxSerializer)
+        assertEquals(PrimitiveKind.INT, boxSerializer.descriptor.getElementDescriptor(0).kind)
 
         val parametrizedSerializer = m.serializer(ParametrizedContextual::class, listOf(Int.serializer()), false)
         assertSame<KSerializer<*>>(ParametrizedContextualSerializer, parametrizedSerializer)

--- a/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
@@ -84,7 +84,7 @@ class SerializersModuleTest {
         val m = SerializersModule { }
 
         val serializer = m.serializer(Parametrized::class, listOf(Int.serializer()), false)
-        assertSame<KClass<*>>(Parametrized.serializer(Int.serializer())::class, serializer::class)
+        assertEquals<KClass<*>>(Parametrized.serializer(Int.serializer())::class, serializer::class)
         assertEquals(PrimitiveKind.INT, serializer.descriptor.getElementDescriptor(0).kind)
 
         val mapSerializer = m.serializer(Map::class, listOf(String.serializer(), Int.serializer()), false)

--- a/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
@@ -41,8 +41,13 @@ class SerializersModuleTest {
 
     class ContextualType(val i: Int)
 
+    class ParametrizedContextual<T : Any>(val a: T)
+
     @Serializer(forClass = ContextualType::class)
     object ContextualSerializer
+
+    @Serializer(forClass = ParametrizedContextual::class)
+    object ParametrizedContextualSerializer
 
     class FileContextualType(val i: Int)
 
@@ -95,15 +100,20 @@ class SerializersModuleTest {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun testContextual() {
         val m = SerializersModule {
             contextual<FileContextualType>(FileContextualSerializer)
             contextual<ContextualType>(ContextualSerializer)
+            contextual<ParametrizedContextual<*>>(ParametrizedContextualSerializer as KSerializer<ParametrizedContextual<*>>)
         }
 
         val contextualSerializer = m.serializer(ContextualType::class, emptyList(), false)
         assertSame<KSerializer<*>>(ContextualSerializer, contextualSerializer)
+
+        val parametrizedSerializer = m.serializer(ParametrizedContextual::class, listOf(Int.serializer()), false)
+        assertSame<KSerializer<*>>(ParametrizedContextualSerializer, parametrizedSerializer)
 
         val fileContextualSerializer = m.serializer(FileContextualType::class, emptyList(), false)
         assertSame<KSerializer<*>>(FileContextualSerializer, fileContextualSerializer)

--- a/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersModuleTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:UseContextualSerialization(SerializersModuleTest.FileContextualType::class)
+
+package kotlinx.serialization
+
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.internal.*
+import kotlinx.serialization.modules.*
+import kotlinx.serialization.test.*
+import kotlin.reflect.*
+import kotlin.test.*
+
+class SerializersModuleTest {
+    @Serializable
+    object Object
+
+    @Serializable
+    sealed class SealedParent {
+        @Serializable
+        data class Child(val i: Int) : SealedParent()
+    }
+
+    @Serializable
+    abstract class Abstract
+
+    @Serializable
+    enum class SerializableEnum { A, B }
+
+    @Serializable(CustomSerializer::class)
+    class WithCustomSerializer(val i: Int)
+
+    @Serializer(forClass = WithCustomSerializer::class)
+    object CustomSerializer
+
+    @Serializable
+    class Parametrized<T : Any>(val a: T)
+
+    class ContextualType(val i: Int)
+
+    @Serializer(forClass = ContextualType::class)
+    object ContextualSerializer
+
+    class FileContextualType(val i: Int)
+
+    @Serializer(forClass = FileContextualType::class)
+    object FileContextualSerializer
+
+    @Serializable
+    class ContextualHolder(@Contextual val contextual: ContextualType, val fileContextual: FileContextualType)
+
+    @Test
+    fun testCompiled() = noJsLegacy {
+        val m = SerializersModule { }
+
+        assertSame<KSerializer<*>>(Object.serializer(), m.serializer(Object::class, emptyList(), false))
+        assertSame<KSerializer<*>>(SealedParent.serializer(), m.serializer(SealedParent::class, emptyList(), false))
+        assertSame<KSerializer<*>>(
+            SealedParent.Child.serializer(),
+            m.serializer(SealedParent.Child::class, emptyList(), false)
+        )
+
+        assertSame<KSerializer<*>>(Abstract.serializer(), m.serializer(Abstract::class, emptyList(), false))
+        assertSame<KSerializer<*>>(SerializableEnum.serializer(), m.serializer(SerializableEnum::class, emptyList(), false))
+    }
+
+    @Test
+    fun testBuiltIn() {
+        val m = SerializersModule { }
+        assertSame<KSerializer<*>>(Int.serializer(), m.serializer(Int::class, emptyList(), false))
+    }
+
+    @Test
+    fun testCustom() {
+        val m = SerializersModule { }
+        assertSame<KSerializer<*>>(CustomSerializer, m.serializer(WithCustomSerializer::class, emptyList(), false))
+    }
+
+    @Test
+    fun testParametrized() {
+        val m = SerializersModule { }
+
+        val serializer = m.serializer(Parametrized::class, listOf(Int.serializer()), false)
+        assertSame<KClass<*>>(Parametrized.serializer(Int.serializer())::class, serializer::class)
+        assertEquals(PrimitiveKind.INT, serializer.descriptor.getElementDescriptor(0).kind)
+
+        val mapSerializer = m.serializer(Map::class, listOf(String.serializer(), Int.serializer()), false)
+        assertIs<MapLikeSerializer<*, *, *, *>>(mapSerializer)
+        assertEquals(PrimitiveKind.STRING, mapSerializer.descriptor.getElementDescriptor(0).kind)
+        assertEquals(PrimitiveKind.INT, mapSerializer.descriptor.getElementDescriptor(1).kind)
+    }
+
+    @Test
+    fun testUnsupportedArray() {
+        val m = SerializersModule { }
+
+        assertFails {
+            m.serializer(Array::class, listOf(Int.serializer()), false)
+        }
+    }
+
+    @Test
+    fun testContextual() {
+        val m = SerializersModule {
+            contextual<FileContextualType>(FileContextualSerializer)
+            contextual<ContextualType>(ContextualSerializer)
+        }
+
+        val contextualSerializer = m.serializer(ContextualType::class, emptyList(), false)
+        assertSame<KSerializer<*>>(ContextualSerializer, contextualSerializer)
+
+        val fileContextualSerializer = m.serializer(FileContextualType::class, emptyList(), false)
+        assertSame<KSerializer<*>>(FileContextualSerializer, fileContextualSerializer)
+
+        val holderSerializer = m.serializer(ContextualHolder::class, emptyList(), false)
+        assertSame<KSerializer<*>>(ContextualHolder.serializer(), holderSerializer)
+    }
+
+}
+

--- a/core/jvmTest/src/kotlinx/serialization/CachingTest.kt
+++ b/core/jvmTest/src/kotlinx/serialization/CachingTest.kt
@@ -34,7 +34,7 @@ class CachingTest {
         val cache = createParametrizedCache { clazz, types ->
             factoryCalled += 1
             val serializers = EmptySerializersModule().serializersForParameters(types, true)!!
-            clazz.parametrizedSerializerOrNull(types, serializers)
+            clazz.parametrizedSerializerOrNull(serializers) { types[0].classifier }
         }
 
         repeat(10) {


### PR DESCRIPTION
Resolves #2025

The limitations of this API are the inability to implement stable caching, because serialization runtime does not control the equals function of the received parameters serializers, which can cause a memory leak.

Also, a technical limitation is the inability to create an array serializer.