### PR TITLE
CBOR: Support maps that have integers as keys

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -249,7 +249,7 @@ internal open class CborReader(private val cbor: Cbor, protected val decoder: Cb
             val knownIndex: Int
             while (true) {
                 if (isDone()) return CompositeDecoder.DECODE_DONE
-                val elemName = decoder.nextString()
+                val elemName = decoder.nextElementName()
                 readProperties++
 
                 val index = descriptor.getElementIndex(elemName)
@@ -263,7 +263,7 @@ internal open class CborReader(private val cbor: Cbor, protected val decoder: Cb
             knownIndex
         } else {
             if (isDone()) return CompositeDecoder.DECODE_DONE
-            val elemName = decoder.nextString()
+            val elemName = decoder.nextElementName()
             readProperties++
             descriptor.getElementIndexOrThrow(elemName)
         }
@@ -381,6 +381,15 @@ internal class CborDecoder(private val input: ByteArrayInput) {
         val ans = arr.decodeToString()
         readByte()
         return ans
+    }
+
+    fun nextElementName(): String {
+        skipOverTags()
+        return if ((curByte and 0b111_00000) == HEADER_STRING.toInt()) {
+            nextString()
+        } else {
+            nextNumber().toString()
+        }
     }
 
     private fun readBytes(): ByteArray =

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborReaderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborReaderTest.kt
@@ -457,6 +457,36 @@ class CborReaderTest {
     }
 
     @Test
+    fun testDecodeCborWithIntegerKeys() {
+        /*
+         *  A2                            # map(2)
+         *     00                         #   unsigned(0)
+         *     61                         #   text(1)
+         *        41                      #     "A"
+         *     25                         #   negative(-6)
+         *     D9 03EC                    #   standard date string, tag(1004)
+         *        6A                      #     text(10)
+         *           323031382d30382d3039 #       "2018-08-09"
+         *                                #     epoch(17,752)
+         */
+        assertEquals(
+            expected = TypeWithMapWithIntegerKeys("A", "2018-08-09"),
+            actual = Cbor.decodeFromHexString(
+                deserializer = TypeWithMapWithIntegerKeys.serializer(),
+                hex = "a200614125d903ec6a323031382d30382d3039"
+            )
+        )
+
+        assertEquals(
+            expected = TypeWithMapWithIntegerKeys("A", "2018-08-09"),
+            actual = ignoreUnknownKeys.decodeFromHexString(
+                deserializer = TypeWithMapWithIntegerKeys.serializer(),
+                hex = "a200614125d903ec6a323031382d30382d3039"
+            )
+        )
+    }
+
+    @Test
     fun testDecodeCborWithUnknownField() {
         assertEquals(
             expected = Simple("123"),

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/SampleClasses.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/SampleClasses.kt
@@ -111,3 +111,6 @@ data class TypeWithCustomByteString(@ByteString val x: CustomByteString)
 
 @Serializable
 data class TypeWithNullableCustomByteString(@ByteString val x: CustomByteString?)
+
+@Serializable
+data class TypeWithMapWithIntegerKeys (@SerialName("0") val zero: String, @SerialName("-6") val negativeSix: String)


### PR DESCRIPTION
As mentioned in https://github.com/Kotlin/kotlinx.serialization/issues/1561,

Standards documents like those for CBOR web tokens (https://datatracker.ietf.org/doc/html/rfc8392) have CBORs with maps that have integer keys.

I'd like to add support for integer element names in CBOR maps
