### PR TITLE
Fixed NoSuchMethodError when parsing a JSON stream on Java 8

### DIFF
--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/CharsetReader.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/CharsetReader.kt
@@ -103,7 +103,7 @@ internal class CharsetReader(
             val remaining = if (position <= limit) limit - position else 0
             val bytesRead = inputStream.read(byteBuffer.array(), byteBuffer.arrayOffset() + position, remaining)
             if (bytesRead < 0) return bytesRead
-            byteBuffer.position(position + bytesRead)
+            (byteBuffer as Buffer).position(position + bytesRead)
         } finally {
             (byteBuffer as Buffer).flip() // see the `init` block in this class for the reasoning behind the cast
         }

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/CharsetReader.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/CharsetReader.kt
@@ -103,6 +103,7 @@ internal class CharsetReader(
             val remaining = if (position <= limit) limit - position else 0
             val bytesRead = inputStream.read(byteBuffer.array(), byteBuffer.arrayOffset() + position, remaining)
             if (bytesRead < 0) return bytesRead
+            // Method `position(I)LByteBuffer` does not exist in Java 8. For details, see comment for `flip` in `init` method
             (byteBuffer as Buffer).position(position + bytesRead)
         } finally {
             (byteBuffer as Buffer).flip() // see the `init` block in this class for the reasoning behind the cast


### PR DESCRIPTION
Fixed NoSuchMethodError when parsing a JSON stream on Java 8

Fixes #2326

An explicit cast is needed here due to an API change in Java 9, see #2218.
In Java 8 and earlier, the `position(I)` method was final in `Buffer`, and returned a `Buffer`.
In Java 9 and later, the method was opened, and `ByteBuffer` overrides it, returning a `ByteBuffer`.
This causes a `NoSuchMethodError` when running a class, compiled with a newer Java version, on Java 8.