### PR TITLE
Fixed regression with serialization using list parametrized with contextual types

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -193,13 +193,7 @@ private fun SerializersModule.serializerByKTypeImpl(
     val cachedSerializer = if (typeArguments.isEmpty()) {
         findCachedSerializer(rootClass, isNullable)
     } else {
-        val cachedResult = findParametrizedCachedSerializer(rootClass, typeArguments, isNullable)
-        if (failOnMissingTypeArgSerializer) {
-            cachedResult.getOrNull()
-        } else {
-            // return null if error occurred - serializer for parameter(s) was not found
-            cachedResult.getOrElse { return null }
-        }
+        findParametrizedCachedSerializer(rootClass, typeArguments, isNullable).getOrNull()
     }
     cachedSerializer?.let { return it }
 

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
@@ -210,12 +210,38 @@ class SerializersLookupTest : JsonTestBase() {
         }
     }
 
+    class GenericHolder<T>(value: T)
+
+    object GenericSerializer: KSerializer<GenericHolder<*>> {
+        override val descriptor: SerialDescriptor
+            get() = TODO()
+
+        override fun deserialize(decoder: Decoder): GenericHolder<*> {
+            TODO()
+        }
+
+        override fun serialize(encoder: Encoder, value: GenericHolder<*>) {
+            TODO()
+        }
+    }
+
     @Test
     fun testContextualLookup() {
         val module = SerializersModule { contextual(CustomIntSerializer(false).cast<IntBox>()) }
         val json = Json { serializersModule = module }
         val data = listOf(listOf(IntBox(1)))
         assertEquals("[[42]]", json.encodeToString(data))
+    }
+
+    @Test
+    fun testGenericOfContextual() {
+        val module = SerializersModule {
+            contextual(CustomIntSerializer(false).cast<IntBox>())
+            contextual(GenericSerializer)
+        }
+
+        assertNotNull(module.serializerOrNull(typeOf<List<IntBox>>()))
+        assertNotNull(module.serializerOrNull(typeOf<GenericHolder<IntBox>>()))
     }
 
     @Test

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/SerializersLookupTest.kt
@@ -59,6 +59,7 @@ class SerializersLookupTest : JsonTestBase() {
         assertSame(UInt.serializer(), serializer<UInt>())
         assertSame(ULong.serializer(), serializer<ULong>())
     }
+
     @Test
     @OptIn(ExperimentalUnsignedTypes::class)
     fun testUnsignedArrays() {
@@ -212,15 +213,18 @@ class SerializersLookupTest : JsonTestBase() {
 
     class GenericHolder<T>(value: T)
 
-    object GenericSerializer: KSerializer<GenericHolder<*>> {
-        override val descriptor: SerialDescriptor
-            get() = TODO()
+    class GenericSerializer<T>(typeSerializer: KSerializer<T>) : KSerializer<GenericHolder<T>> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor(
+                "Generic Serializer parametrized by ${typeSerializer.descriptor}",
+                PrimitiveKind.STRING
+            )
 
-        override fun deserialize(decoder: Decoder): GenericHolder<*> {
+        override fun deserialize(decoder: Decoder): GenericHolder<T> {
             TODO()
         }
 
-        override fun serialize(encoder: Encoder, value: GenericHolder<*>) {
+        override fun serialize(encoder: Encoder, value: GenericHolder<T>) {
             TODO()
         }
     }
@@ -237,11 +241,19 @@ class SerializersLookupTest : JsonTestBase() {
     fun testGenericOfContextual() {
         val module = SerializersModule {
             contextual(CustomIntSerializer(false).cast<IntBox>())
-            contextual(GenericSerializer)
+            contextual(GenericHolder::class) { args -> GenericSerializer(args[0]) }
         }
 
-        assertNotNull(module.serializerOrNull(typeOf<List<IntBox>>()))
-        assertNotNull(module.serializerOrNull(typeOf<GenericHolder<IntBox>>()))
+        val listSerializer = module.serializerOrNull(typeOf<List<IntBox>>())
+        assertNotNull(listSerializer)
+        assertEquals("kotlin.collections.ArrayList(PrimitiveDescriptor(CIS))", listSerializer.descriptor.toString())
+
+        val genericSerializer = module.serializerOrNull(typeOf<GenericHolder<IntBox>>())
+        assertNotNull(genericSerializer)
+        assertEquals(
+            "PrimitiveDescriptor(Generic Serializer parametrized by PrimitiveDescriptor(CIS))",
+            genericSerializer.descriptor.toString()
+        )
     }
 
     @Test


### PR DESCRIPTION
Fixes #2323

In the current implementation of serializer lookup caching, if the serializer for the parameter was not found, the `serializerOrNull` function always returned null, without further searching for contextual serializers in the current SerializersModule.