### PR TITLE
Remove decoder optimization that causes invalid decoding

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -30,7 +30,7 @@ internal fun <T> Json.readPolymorphicJson(
     element: JsonObject,
     deserializer: DeserializationStrategy<T>
 ): T {
-    return JsonTreeDecoder(this, element, discriminator, deserializer.descriptor).decodeSerializableValue(deserializer)
+    return JsonTreeDecoder(this, element, discriminator).decodeSerializableValue(deserializer)
 }
 
 private sealed class AbstractJsonTreeDecoder(
@@ -189,8 +189,7 @@ private class JsonPrimitiveDecoder(json: Json, override val value: JsonElement) 
 private open class JsonTreeDecoder(
     json: Json,
     override val value: JsonObject,
-    private val polyDiscriminator: String? = null,
-    private val polyDescriptor: SerialDescriptor? = null
+    private val polyDiscriminator: String? = null
 ) : AbstractJsonTreeDecoder(json, value) {
     private var position = 0
     private var forceNull: Boolean = false
@@ -256,11 +255,6 @@ private open class JsonTreeDecoder(
     override fun currentElement(tag: String): JsonElement = value.getValue(tag)
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
-        /*
-         * For polymorphic serialization we'd like to avoid excessive decoder creating in
-         * beginStructure to properly preserve 'polyDiscriminator' field and filter it out.
-         */
-        if (descriptor === polyDescriptor) return this
         return super.beginStructure(descriptor)
     }
 


### PR DESCRIPTION
This pull request removes the optimization in `JsonTreeDecoder' https://github.com/Kotlin/kotlinx.serialization/blob/5fb55ff49df65a3a57f0aca55fe890b8dbe97045/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt#L258-L265 

It seems this optimization cannot work as `JsonTreeDecoder` has an inner `position` mutable state that is tied to the current object being decoded.  This fixes #2343. #2343 also explains the reasoning in more detail and provides reproducing example.

This pull request also removes the `polyDiscriminator` parameter from the `JsonTreeDecoder` constructor as it is not needed any more.

The original code with the optimization refers to issue #807 . The code example in that issue is not valid any more but with an updated reproducer, it passes when this pull request is applied.

Updated reproducer for #807 
```kotlin

    val json = Json {
        ignoreUnknownKeys = true
    }

    @Serializable
    sealed class Foo {
        @Serializable
        data class Bar(val a: Int) : Foo()
    }
    @Test
    fun testFoo() {
        val jsonElement = json.encodeToJsonElement<Foo>(Foo.Bar(1))
        println(json.decodeFromJsonElement<Foo>(jsonElement))
        println(json.decodeFromJsonElement<Foo>(jsonElement))
    }
```
