### PR TITLE
Fix beginStructure in JsonTreeDecoder when inner structre descriptor is same as outer

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonTreeDecoderPolymorphicTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonTreeDecoderPolymorphicTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json.polymorphic
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class JsonTreeDecoderPolymorphicTest : JsonTestBase() {
+
+    @Serializable
+    sealed class Sealed
+
+    @Serializable
+    data class ClassContainingItself(
+        val a: String,
+        val b: String,
+        val c: ClassContainingItself? = null,
+        val d: String?
+    ) : Sealed()
+
+    val inner = ClassContainingItself(
+        "InnerA",
+        "InnerB",
+        null,
+        "InnerC"
+    )
+    val outer = ClassContainingItself(
+        "OuterA",
+        "OuterB",
+        inner,
+        "OuterC"
+    )
+
+    @Test
+    fun testDecodingWhenClassContainsItself() = parametrizedTest { jsonTestingMode ->
+        val encoded = default.encodeToString(outer as Sealed, jsonTestingMode)
+        val decoded: Sealed = Json.decodeFromString(encoded, jsonTestingMode)
+        assertEquals(outer, decoded)
+    }
+}


### PR DESCRIPTION
Attempt 2 (previous pull request and discussion here #2344) at solving #2343. This time instead of returning the same instance of decoder (with invalid position) a new instance is created, and `polyDiscriminator` and `polyDescriptor` are passed to the new instance.

This way check for unknown keys in `endStructure` can properly filter out polymorphic discriminator (by default "type) from potential unknown keys.

Added a simple test that fails with the original code and passes with the fix, but I'm not sure what to call it or if it's in the right place.