### PR TITLE
Bump compatibility-validator version to 0.13.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ junit_version=4.12
 jackson_version=2.10.0.pr1
 dokka_version=1.8.10
 native.deploy=
-validator_version=0.11.0
+validator_version=0.13.2
 knit_version=0.4.0
 # Only for tests
 coroutines_version=1.6.4


### PR DESCRIPTION
with support for Kotlin metadata 2.0