### PR TITLE
Manually apply the `java` plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,11 @@ subprojects {
     if (excludedFromBomProjects.contains(project.name)) return
 
     // Animalsniffer setup
+    // Animalsniffer requires java plugin to be applied, but Kotlin 1.9.20
+    // relies on `java-base` for Kotlin Multiplatforms `withJava` implementation
+    // https://github.com/xvik/gradle-animalsniffer-plugin/issues/84
+    // https://youtrack.jetbrains.com/issue/KT-59595
+    JavaPluginUtil.applyJavaPlugin(project)
     apply plugin: 'ru.vyarus.animalsniffer'
 
     afterEvaluate { // Can be applied only when the project is evaluated

--- a/buildSrc/src/main/kotlin/setupJavaPlugin.kt
+++ b/buildSrc/src/main/kotlin/setupJavaPlugin.kt
@@ -1,0 +1,42 @@
+import org.gradle.api.*
+import org.gradle.api.file.*
+import org.gradle.api.plugins.*
+import org.gradle.api.tasks.*
+import org.gradle.api.tasks.testing.*
+import org.gradle.jvm.tasks.*
+import org.jetbrains.kotlin.gradle.plugin.*
+
+/*
+ * Copyright 2017-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+object JavaPluginUtil {
+
+    @JvmStatic
+    fun Project.applyJavaPlugin() {
+        plugins.apply("java")
+
+        plugins.withId("org.jetbrains.kotlin.multiplatform") {
+            listOf(
+                JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME,
+                JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME
+            ).forEach { outputConfigurationName ->
+                configurations.findByName(outputConfigurationName)?.isCanBeConsumed = false
+            }
+
+            disableJavaPluginTasks(extensions.getByName("sourceSets") as SourceSetContainer)
+        }
+    }
+}
+
+private fun Project.disableJavaPluginTasks(javaSourceSet: SourceSetContainer) {
+    project.tasks.withType(Jar::class.java).named(javaSourceSet.getByName("main").jarTaskName).configure {
+        dependsOn("jvmTest")
+        enabled = false
+    }
+
+    project.tasks.withType(Test::class.java).named(JavaPlugin.TEST_TASK_NAME) {
+        dependsOn("jvmJar")
+        enabled = false
+    }
+}


### PR DESCRIPTION
To support Kotlin Multiplatform 1.9.20 and forward together with the animalsniffer plugin

See:
https://github.com/xvik/gradle-animalsniffer-plugin/issues/84 https://youtrack.jetbrains.com/issue/KT-59595