### PR TITLE
Fix error triggered by 'consume leading class discriminator' polymorphic parsing optimization

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -71,7 +71,7 @@ internal open class StreamingJsonDecoder(
             }
 
             val discriminator = deserializer.descriptor.classDiscriminator(json)
-            val type = lexer.consumeLeadingMatchingValue(discriminator, configuration.isLenient)
+            val type = lexer.peekLeadingMatchingValue(discriminator, configuration.isLenient)
             var actualSerializer: DeserializationStrategy<Any>? = null
             if (type != null) {
                 actualSerializer = deserializer.findPolymorphicSerializerOrNull(this, type)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
@@ -286,7 +286,7 @@ internal abstract class AbstractJsonLexer {
         return current
     }
 
-    abstract fun consumeLeadingMatchingValue(keyToMatch: String, isLenient: Boolean): String?
+    abstract fun peekLeadingMatchingValue(keyToMatch: String, isLenient: Boolean): String?
 
     fun peekString(isLenient: Boolean): String? {
         val token = peekNextToken()
@@ -299,6 +299,10 @@ internal abstract class AbstractJsonLexer {
         }
         peekedString = string
         return string
+    }
+
+    fun discardPeeked() {
+        peekedString = null
     }
 
     open fun indexOf(char: Char, startPos: Int) = source.indexOf(char, startPos)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/JsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/JsonLexer.kt
@@ -179,7 +179,7 @@ internal class ReaderJsonLexer(
     }
 
     // Can be carefully implemented but postponed for now
-    override fun consumeLeadingMatchingValue(keyToMatch: String, isLenient: Boolean): String? = null
+    override fun peekLeadingMatchingValue(keyToMatch: String, isLenient: Boolean): String? = null
 
     fun release() {
         CharArrayPoolBatchSize.release(buffer)


### PR DESCRIPTION
In case of an empty object, no exception should be thrown, it should be treated as missing class discriminator. peekString() correctly handles this case.

Also fixes misplaced calls in lenient vs non-lenient mode.

Fixes #2353