### PR TITLE
CBOR: Use Serial Labels

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -39,7 +39,11 @@ public sealed class Cbor(
 ) : BinaryFormat {
 
     /**
-     * The default instance of [Cbor]
+     * The default instance of [Cbor], with the following behavior. It ...
+     * - does not encode defaults (see [encodeDefaults])
+     * - does not ignore unknown keys (see [ignoreUnknownKeys])
+     * - does prefer serial labels over names (see [preferSerialLabelsOverNames])
+     * - has an empty serializers module (see [EmptySerializersModule])
      */
     public companion object Default : Cbor(false, false, true, EmptySerializersModule())
 
@@ -105,7 +109,8 @@ public class CborBuilder internal constructor(cbor: Cbor) {
     public var ignoreUnknownKeys: Boolean = cbor.ignoreUnknownKeys
 
     /**
-     * Specifies whether to serialize element labels (i.e. Long from [SerialLabel]) instead of the element names (i.e. String from [SerialName]) for map keys
+     * Specifies whether to serialize element labels (i.e. Long from [SerialLabel])
+     * instead of the element names (i.e. String from [SerialName]) for map keys
      */
     public var preferSerialLabelsOverNames: Boolean = cbor.preferSerialLabelsOverNames
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/SerialLabel.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/SerialLabel.kt
@@ -1,0 +1,8 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+@ExperimentalSerializationApi
+public annotation class SerialLabel(val label: Long)

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -1,0 +1,34 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+@Serializable
+data class CoseHeader(
+    @SerialLabel(4)
+    @SerialName("kid")
+    val kid: String? = null,
+)
+
+class CborSerialLabelTest {
+
+    private val reference = CoseHeader(
+        kid = "11"
+    )
+
+    /*
+        BF         # map(*)
+           04      # unsigned(4)
+           62      # text(2)
+              3131 # "11"
+           FF      # primitive(*)
+     */
+    private val referenceHexString = "bf04623131ff"
+
+
+    @Test
+    fun writeReadVerifyCoseHeader() {
+        assertEquals(referenceHexString, Cbor.encodeToHexString(CoseHeader.serializer(), reference))
+        assertEquals(reference, Cbor.decodeFromHexString(CoseHeader.serializer(), referenceHexString))
+    }
+}

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -44,6 +44,28 @@ class CborSerialLabelTest {
         assertEquals(reference, cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexNameString))
     }
 
+    @Test
+    fun writeReadVerifySerialLabelAndUnknownKeys() {
+        val referenceWithTag = ClassWithSerialLabel(alg = -7)
+
+        /**
+         * A2           # map(2)
+         *    01        # unsigned(1)
+         *    26        # negative(6)
+         *    02        # unsigned(2)
+         *    63        # text(3)
+         *       62617A # "baz"
+         */
+        val referenceHexLabelWithTagString = "a20126026362617a"
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = true
+            ignoreUnknownKeys = true
+        }
+        assertEquals(
+            referenceWithTag,
+            cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexLabelWithTagString)
+        )
+    }
 
     @Serializable
     data class ClassWithSerialLabel(

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -3,32 +3,54 @@ package kotlinx.serialization.cbor
 import kotlinx.serialization.*
 import kotlin.test.*
 
-@Serializable
-data class CoseHeader(
-    @SerialLabel(4)
-    @SerialName("kid")
-    val kid: String? = null,
-)
 
 class CborSerialLabelTest {
 
-    private val reference = CoseHeader(
-        kid = "11"
-    )
+    private val reference = ClassWithSerialLabel(alg = -7)
 
-    /*
-        BF         # map(*)
-           04      # unsigned(4)
-           62      # text(2)
-              3131 # "11"
-           FF      # primitive(*)
+    /**
+     * BF    # map(*)
+     *    01 # unsigned(1)
+     *    26 # negative(6)
+     *    FF # primitive(*)
      */
-    private val referenceHexString = "bf04623131ff"
+    private val referenceHexLabelString = "bf0126ff"
+
+    /**
+     * BF           # map(*)
+     *    63        # text(3)
+     *       616C67 # "alg"
+     *    26        # negative(6)
+     *    FF        # primitive(*)
+     */
+    private val referenceHexNameString = "bf63616c6726ff"
 
 
     @Test
-    fun writeReadVerifyCoseHeader() {
-        assertEquals(referenceHexString, Cbor.encodeToHexString(CoseHeader.serializer(), reference))
-        assertEquals(reference, Cbor.decodeFromHexString(CoseHeader.serializer(), referenceHexString))
+    fun writeReadVerifySerialLabel() {
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = true
+        }
+        assertEquals(referenceHexLabelString, cbor.encodeToHexString(ClassWithSerialLabel.serializer(), reference))
+        assertEquals(reference, cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexLabelString))
     }
+
+    @Test
+    fun writeReadVerifySerialName() {
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = false
+        }
+        assertEquals(referenceHexNameString, cbor.encodeToHexString(ClassWithSerialLabel.serializer(), reference))
+        assertEquals(reference, cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexNameString))
+    }
+
+
+    @Serializable
+    data class ClassWithSerialLabel(
+        @SerialLabel(1)
+        @SerialName("alg")
+        val alg: Int
+    )
+
 }
+


### PR DESCRIPTION
Adds the feature of using serial labels, i.e. numbers, as CBOR map keys instead of the usual strings as serial labels. This is probably useful for supporting COSE structures, or anything related like COSE keys, where numbers are used extensively as map keys.

We could also apply it on top of #2359.