### PR TITLE
Fix an example in docs/json.md

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -1094,10 +1094,10 @@ sealed class Response<out T> {
 
 class ResponseSerializer<T>(private val dataSerializer: KSerializer<T>) : KSerializer<Response<T>> {
     override val descriptor: SerialDescriptor = buildSerialDescriptor("Response", PolymorphicKind.SEALED) {
-        element("Ok", buildClassSerialDescriptor("Ok") {
+        element("Ok", dataSerializer.descriptor)
+        element("Error", buildClassSerialDescriptor("Error") {
             element<String>("message")
         })
-        element("Error", dataSerializer.descriptor)
     }
 
     override fun deserialize(decoder: Decoder): Response<T> {


### PR DESCRIPTION
The `Response` example had descriptor elements swapped around