### PR TITLE
Changed actual FormatLanguage annotation for JS and native

### DIFF
--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/FormatLanguage.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/FormatLanguage.kt
@@ -7,4 +7,9 @@ package kotlinx.serialization.json.internal;
 import kotlinx.serialization.InternalSerializationApi
 
 @InternalSerializationApi
-public actual typealias FormatLanguage = org.intellij.lang.annotations.Language
+public actual annotation class FormatLanguage(
+    public actual val value: String,
+    // default parameters are not used due to https://youtrack.jetbrains.com/issue/KT-25946/
+    public actual val prefix: String,
+    public actual val suffix: String,
+)

--- a/formats/json/nativeMain/src/kotlinx/serialization/json/internal/FormatLanguage.kt
+++ b/formats/json/nativeMain/src/kotlinx/serialization/json/internal/FormatLanguage.kt
@@ -7,4 +7,9 @@ package kotlinx.serialization.json.internal;
 import kotlinx.serialization.InternalSerializationApi
 
 @InternalSerializationApi
-public actual typealias FormatLanguage = org.intellij.lang.annotations.Language
+public actual annotation class FormatLanguage(
+    public actual val value: String,
+    // default parameters are not used due to https://youtrack.jetbrains.com/issue/KT-25946/
+    public actual val prefix: String,
+    public actual val suffix: String,
+)


### PR DESCRIPTION
The declaration of annotation `org.intellij.lang.annotations.Language` in the JS and native source has been removed, because if this annotation is declared in other dependency, then this leads to compilation errors.

Fixes #2377