### PR TITLE
Remove obsolete no longer supported kotlin.mpp.enableCompatibilityMe…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,11 +24,6 @@ okio_version=3.1.0
 
 kover.enabled=true
 
-kotlin.mpp.enableCompatibilityMetadataVariant=true
-kotlin.mpp.stability.nowarn=true
-
-kotlin.incremental.multiplatform=true
-
 org.gradle.parallel=true
 org.gradle.caching=true
 


### PR DESCRIPTION
…tadataVariant that will be removed in 1.9.20