### PR TITLE
Use kotlin version as a build number while building in kotlin user projects

### DIFF
--- a/gradle/teamcity.gradle
+++ b/gradle/teamcity.gradle
@@ -3,7 +3,7 @@
  */
 
 def teamcitySuffix = project.findProperty("teamcitySuffix")?.toString()
-if (project.hasProperty("teamcity") && !build_snapshot_train) {
+if (project.hasProperty("teamcity") && !(build_snapshot_train || rootProject.properties['build_snapshot_up'])) {
     // Tell teamcity about version number
     def postfix = (teamcitySuffix == null) ? "" : " ($teamcitySuffix)"
     println("##teamcity[buildNumber '${project.version}${postfix}']")


### PR DESCRIPTION
This commit is needed to unify settings between dev branch and kotlin user projects branch