### PR TITLE
Fix negative valued enums deserializing for protobuf

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -80,7 +80,7 @@ internal open class ProtobufDecoder(
 
     private fun findIndexByTag(descriptor: SerialDescriptor, protoTag: Int): Int {
         // Fast-path: tags are incremental, 1-based
-        if (protoTag < descriptor.elementsCount) {
+        if (protoTag < descriptor.elementsCount && protoTag >= 0) {
             val protoId = extractProtoId(descriptor, protoTag, true)
             if (protoId == protoTag) return protoTag
         }

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/RandomTests.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/RandomTests.kt
@@ -162,11 +162,11 @@ class RandomTest : ShouldSpec() {
             }
         }
 
-        enum class KCoffee { AMERICANO, LATTE, CAPPUCCINO }
+        enum class KCoffee(val value: Int) { AMERICANO(0), LATTE(1), CAPPUCCINO(2), @ProtoNumber(-1) NO_COFFEE(-1) }
 
         @Serializable
         data class KTestEnum(@ProtoNumber(1) val a: KCoffee): IMessage {
-            override fun toProtobufMessage() = TestEnum.newBuilder().setA(TestEnum.Coffee.forNumber(a.ordinal)).build()
+            override fun toProtobufMessage() = TestEnum.newBuilder().setA(TestEnum.Coffee.forNumber(a.value)).build()
 
             companion object : Gen<KTestEnum> {
                 override fun generate(): KTestEnum = KTestEnum(Gen.oneOf<KCoffee>().generate())

--- a/formats/protobuf/testProto/test_data.proto
+++ b/formats/protobuf/testProto/test_data.proto
@@ -59,6 +59,7 @@ message TestEnum {
         Americano = 0;
         Latte = 1;
         Capuccino = 2;
+        NoCoffee = -1;
     }
     required Coffee a = 1;
 }


### PR DESCRIPTION
[From language guide](https://protobuf.dev/programming-guides/proto2/#enum):

> Enumerator constants must be in the range of a 32-bit integer. Since enum values use [varint encoding](https://protobuf.dev/programming-guides/encoding) on the wire, negative values are inefficient and thus not recommended

Previously, I had the following error when trying to deserialize:
```
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 4
	at kotlinx.serialization.internal.PluginGeneratedSerialDescriptor.getElementAnnotations(PluginGeneratedSerialDescriptor.kt:137)
	at kotlinx.serialization.protobuf.internal.HelpersKt.extractProtoId(Helpers.kt:74)
	at kotlinx.serialization.protobuf.internal.ProtobufDecoder.findIndexByTag(ProtobufDecoding.kt:84)
	at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeTaggedEnum(ProtobufDecoding.kt:183)
	at kotlinx.serialization.protobuf.internal.ProtobufTaggedDecoder.decodeEnum(ProtobufTaggedDecoder.kt:40)
```


Added a test case to verify that solution works.