### PR TITLE
Update Knit to 0.5.0-Beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ jackson_version=2.10.0.pr1
 dokka_version=1.8.10
 native.deploy=
 validator_version=0.13.2
-knit_version=0.4.0
+knit_version=0.5.0-Beta
 # Only for tests
 coroutines_version=1.6.4
 kover_version=0.4.2


### PR DESCRIPTION
Into the master because the update contains a workaround required for Dokka, see Kotlin/dokka#3105