### PR TITLE
Use JavaCompile.destinationDirectory instead of the whole task

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -82,7 +82,7 @@ object Java9Modularity {
                         )
 
                         // add the resulting module descriptor to this target's artifact
-                        artifactTask.from(compileModuleTask) {
+                        artifactTask.from(compileModuleTask.map { it.destinationDirectory }) {
                             if (multiRelease) {
                                 into("META-INF/versions/9/")
                             }


### PR DESCRIPTION
as a source directory for copying module-info.class to the multi-release jar.

This ensures that no additional files except java compiler output get into jar.

Fixes #2398