### PR TITLE
Mute "expect/actual classes are experimental" warning

### DIFF
--- a/gradle/configure-source-sets.gradle
+++ b/gradle/configure-source-sets.gradle
@@ -112,6 +112,7 @@ kotlin {
                     languageVersion = rootProject.ext.kotlin_lv_override
                     freeCompilerArgs += "-Xsuppress-version-warnings"
                 }
+                freeCompilerArgs += "-Xexpect-actual-classes"
             }
         }
         compilations.main {


### PR DESCRIPTION
This warning is introduced in Kotlin 1.9. KT-61573 If I don't mute this warning then the build fails because of `-Werror`