### PR TITLE
Support decoding maps with boolean keys

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/LenientTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/LenientTest.kt
@@ -37,7 +37,7 @@ class LenientTest : JsonTestBase() {
     @Test
     fun testQuotedBoolean() = parametrizedTest {
         val json = """{"i":1, "l":2, "b":"true", "s":"string"}"""
-        assertFailsWithSerial("JsonDecodingException") { default.decodeFromString(Holder.serializer(), json, it) }
+        assertEquals(value, default.decodeFromString(Holder.serializer(), json, it))
         assertEquals(value, lenient.decodeFromString(Holder.serializer(), json, it))
     }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -268,23 +268,14 @@ internal open class StreamingJsonDecoder(
         }
     }
 
-
+    /*
+     * The primitives are allowed to be quoted and unquoted
+     * to simplify map key parsing and integrations with third-party API.
+     */
     override fun decodeBoolean(): Boolean {
-        /*
-         * We prohibit any boolean literal that is not strictly 'true' or 'false' as it is considered way too
-         * error-prone, but allow quoted literal in relaxed mode for booleans.
-         */
-        return if (configuration.isLenient) {
-            lexer.consumeBooleanLenient()
-        } else {
-            lexer.consumeBoolean()
-        }
+        return lexer.consumeBooleanLenient()
     }
 
-    /*
-     * The rest of the primitives are allowed to be quoted and unquoted
-     * to simplify integrations with third-party API.
-     */
     override fun decodeByte(): Byte {
         val value = lexer.consumeNumericLiteral()
         // Check for overflow

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -91,16 +91,7 @@ private sealed class AbstractJsonTreeDecoder(
     override fun decodeTaggedNotNullMark(tag: String): Boolean = currentElement(tag) !== JsonNull
 
     override fun decodeTaggedBoolean(tag: String): Boolean {
-        val value = getPrimitiveValue(tag)
-        if (!json.configuration.isLenient) {
-            val literal = value.asLiteral("boolean")
-            if (literal.isString) throw JsonDecodingException(
-                -1, "Boolean literal for key '$tag' should be unquoted.\n$lenientHint", currentObject().toString()
-            )
-        }
-        return value.primitive("boolean") {
-            booleanOrNull ?: throw IllegalArgumentException() /* Will be handled by 'primitive' */
-        }
+        return getPrimitiveValue(tag).primitive("boolean", JsonPrimitive::booleanOrNull)
     }
 
     override fun decodeTaggedByte(tag: String) = getPrimitiveValue(tag).primitive("byte") {


### PR DESCRIPTION
We ignore quoted/unquoted state when decoding maps with number keys, so it is logical to do the same for boolean maps.

Fixes #2438