### PR TITLE
Fix TaggedDecoder nullable decoding

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/encoding/AbstractDecoder.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/AbstractDecoder.kt
@@ -74,8 +74,7 @@ public abstract class AbstractDecoder : Decoder, CompositeDecoder {
         index: Int,
         deserializer: DeserializationStrategy<T?>,
         previousValue: T?
-    ): T? {
-        val isNullabilitySupported = deserializer.descriptor.isNullable
-        return if (isNullabilitySupported || decodeNotNullMark()) decodeSerializableValue(deserializer, previousValue) else decodeNull()
+    ): T? = decodeIfNullable(deserializer) {
+        decodeSerializableValue(deserializer, previousValue)
     }
 }

--- a/core/commonMain/src/kotlinx/serialization/encoding/Decoding.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/Decoding.kt
@@ -260,10 +260,15 @@ public interface Decoder {
      * Decodes the nullable value of type [T] by delegating the decoding process to the given [deserializer].
      */
     @ExperimentalSerializationApi
-    public fun <T : Any> decodeNullableSerializableValue(deserializer: DeserializationStrategy<T?>): T? {
-        val isNullabilitySupported = deserializer.descriptor.isNullable
-        return if (isNullabilitySupported || decodeNotNullMark()) decodeSerializableValue(deserializer) else decodeNull()
+    public fun <T : Any> decodeNullableSerializableValue(deserializer: DeserializationStrategy<T?>): T? = decodeIfNullable(deserializer) {
+        decodeSerializableValue(deserializer)
     }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+internal inline fun <T : Any> Decoder.decodeIfNullable(deserializer: DeserializationStrategy<T?>, block: () -> T?): T? {
+    val isNullabilitySupported = deserializer.descriptor.isNullable
+    return if (isNullabilitySupported || decodeNotNullMark()) block() else decodeNull()
 }
 
 /**

--- a/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -206,7 +206,6 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder, CompositeDecoder {
     protected open fun <T : Any?> decodeSerializableValue(deserializer: DeserializationStrategy<T>, previousValue: T?): T =
         decodeSerializableValue(deserializer)
 
-
     // ---- Implementation of low-level API ----
 
     override fun decodeInline(descriptor: SerialDescriptor): Decoder =
@@ -284,13 +283,11 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder, CompositeDecoder {
         index: Int,
         deserializer: DeserializationStrategy<T?>,
         previousValue: T?
-    ): T? =
-        tagBlock(descriptor.getTag(index)) {
-            if (decodeNotNullMark() || deserializer.descriptor.isNullable) decodeSerializableValue(
-                deserializer,
-                previousValue
-            ) else decodeNull()
+    ): T? = tagBlock(descriptor.getTag(index)) {
+        decodeIfNullable(deserializer) {
+            decodeSerializableValue(deserializer, previousValue)
         }
+    }
 
     private fun <E> tagBlock(tag: Tag, block: () -> E): E {
         pushTag(tag)

--- a/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Tagged.kt
@@ -286,7 +286,7 @@ public abstract class TaggedDecoder<Tag : Any?> : Decoder, CompositeDecoder {
         previousValue: T?
     ): T? =
         tagBlock(descriptor.getTag(index)) {
-            if (decodeNotNullMark()) decodeSerializableValue(
+            if (decodeNotNullMark() || deserializer.descriptor.isNullable) decodeSerializableValue(
                 deserializer,
                 previousValue
             ) else decodeNull()


### PR DESCRIPTION
The implementation of decodeNullableSerializableElement of TaggedDecoder was inconsistent with AbstractDecoder, which made it impossible to use null-capable serializers as seen in the new tests. This partially fixes #2455 by allowing me to create a nullable version of the JsonElement serializer.