### PR TITLE
Fix JPMS verification task for K2

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -12,6 +12,7 @@ import org.gradle.jvm.toolchain.*
 import org.gradle.kotlin.dsl.*
 import org.gradle.language.base.plugins.LifecycleBasePlugin.*
 import org.gradle.process.*
+import org.jetbrains.kotlin.gradle.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
@@ -150,6 +151,11 @@ object Java9Modularity {
             // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
             @Suppress("INVISIBLE_MEMBER")
             commonSourceSet.from(compileTask.commonSourceSet)
+            @OptIn(InternalKotlinGradlePluginApi::class)
+            apply {
+                multiplatformStructure.refinesEdges.set(compileTask.multiplatformStructure.refinesEdges)
+                multiplatformStructure.fragments.set(compileTask.multiplatformStructure.fragments)
+            }
             // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
             // and work-around for https://youtrack.jetbrains.com/issue/KT-60582
             incremental = false


### PR DESCRIPTION
The task for verification of Kotlin sources for JPMS problems tries to replicate the setup of the default Kotlin/JVM compilation task. The change here introduces copying of `K2MultiplatformCompilationTask.multiplatformStructure` to set up compilation arguments properly within K2.

Fixes [KT-61952](https://youtrack.jetbrains.com/issue/KT-61952)