### PR TITLE
Kotlin community variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ buildscript {
     ]
     ext.koverEnabled = property('kover.enabled') ?: true
 
+    def noTeamcityInteractionFlag = rootProject.hasProperty("no_teamcity_interaction")
+    def buildSnapshotUPFlag = rootProject.hasProperty("build_snapshot_up")
+    ext.teamcityInteractionDisabled = noTeamcityInteractionFlag || buildSnapshotUPFlag
+
     /*
     * This property group is used to build kotlinx.serialization against Kotlin compiler snapshot.
     * When build_snapshot_train is set to true, kotlin_version property is overridden with kotlin_snapshot_version.

--- a/gradle/teamcity.gradle
+++ b/gradle/teamcity.gradle
@@ -3,7 +3,7 @@
  */
 
 def teamcitySuffix = project.findProperty("teamcitySuffix")?.toString()
-if (project.hasProperty("teamcity") && !(build_snapshot_train || rootProject.properties['build_snapshot_up'])) {
+if (!teamcityInteractionDisabled && project.hasProperty("teamcity") && !(build_snapshot_train || rootProject.properties['build_snapshot_up'])) {
     // Tell teamcity about version number
     def postfix = (teamcitySuffix == null) ? "" : " ($teamcitySuffix)"
     println("##teamcity[buildNumber '${project.version}${postfix}']")


### PR DESCRIPTION
Transfer commits regarding TC setup from `kotlin-community/k2/dev` branch.

After landing these commits in `dev`, branch should be identical to `kotlin-community/k2/dev`, so there will be no need for community branches — K2 Aggregate build will be able to use `dev` directly. Current aggregate build should also use `dev` instead of `kotlin-community/dev` now.