### PR TITLE
Enable error loglevel for partial linkage messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,13 @@ allprojects {
         mavenLocal()
 
     }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile).configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    }
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile).configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    }
 }
 
 def unpublishedProjects = ["benchmark", "guide", "kotlinx-serialization-json-tests"] as Set


### PR DESCRIPTION
The change is related to building kotlinx-serialization as a Kotlin user project.
See [QA-1115](https://youtrack.jetbrains.com/issue/QA-1115) for more details.