### PR TITLE
Update Gradle Dokka configuration to make sure "source" button is visible in all API docs

### DIFF
--- a/gradle/dokka.gradle
+++ b/gradle/dokka.gradle
@@ -12,6 +12,9 @@ def documentedSubprojects = ["kotlinx-serialization-core",
                              "kotlinx-serialization-properties",
                              "kotlinx-serialization-hocon",
                              "kotlinx-serialization-protobuf"]
+
+def jvmOnlySubprojects = ["kotlinx-serialization-hocon"]
+
 subprojects {
     if (!(name in documentedSubprojects)) return
     apply plugin: 'org.jetbrains.dokka'
@@ -71,6 +74,16 @@ subprojects {
                 perPackageOption {
                     matchingRegex.set("org\\.intellij\\.lang\\.annotations(\$|\\.).*")
                     suppress.set(true)
+                }
+
+                sourceLink {
+                    // sources directory for MPP configured in gradle/configure-source-sets.gradle:61
+                    // in short - kotlin.srcDirs = ["$sourceSet.name/src"]
+                    def sourcesPath = project.name in jvmOnlySubprojects ? "src/main/kotlin" : "$name/src"
+                    def relProjectPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
+                    localDirectory.set(file(sourcesPath))
+                    remoteUrl.set(new URL("https://github.com/Kotlin/kotlinx.serialization/tree/master/$relProjectPath/$sourcesPath"))
+                    remoteLineSuffix.set("#L")
                 }
             }
         }


### PR DESCRIPTION
For context: https://github.com/Kotlin/kotlinx.coroutines/issues/3929 and https://github.com/Kotlin/kotlinx.coroutines/pull/3960