### PR TITLE
Update Dokka to 1.9.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,10 +13,10 @@ kotlin.version.snapshot=1.9.255-SNAPSHOT
 
 junit_version=4.12
 jackson_version=2.10.0.pr1
-dokka_version=1.8.10
+dokka_version=1.9.10
 native.deploy=
 validator_version=0.13.2
-knit_version=0.5.0-Beta
+knit_version=0.5.0
 # Only for tests
 coroutines_version=1.6.4
 kover_version=0.4.2


### PR DESCRIPTION
Depends on knit release: https://github.com/Kotlin/kotlinx-knit/pull/59

`dokka`/`knit`/`knitCheck` tasks works fine locally with fixed `knit` published to `mavenLocal`

I've also done some minimal manual QA of produced result - haven't spotted any issues, only some style changes