### PR TITLE
Reorder and filter mavenLocal() for more reproducible builds

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -5,9 +5,13 @@ buildscript {
     ext.serialization_version = mainLibVersion
 
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+        mavenLocal() {
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
     }
 }
 
@@ -19,9 +23,13 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+    mavenLocal() {
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
 }
 
 group 'com.example'
@@ -64,7 +72,7 @@ kotlin {
 
         commonMain {
             dependencies {
-                implementation kotlin('stdlib-common')
+                implementation kotlin('stdlib')
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-protobuf:$serialization_version"


### PR DESCRIPTION
The mavenLocal() repository has been moved down below and filtered to ensure that it is checked last and only for kotlinx-serialization:1.x.y-SNAPSHOT.

Also replace outdated `stdlib-common` artifact name.