### PR TITLE
Support oneof declaraction in protobuf

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -84,7 +84,6 @@ public final class kotlinx/serialization/SealedClassSerializer : kotlinx/seriali
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
 	public fun getBaseClass ()Lkotlin/reflect/KClass;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun getSubclassSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public abstract interface class kotlinx/serialization/SerialFormat {

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -84,6 +84,7 @@ public final class kotlinx/serialization/SealedClassSerializer : kotlinx/seriali
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
 	public fun getBaseClass ()Lkotlin/reflect/KClass;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getSubclassSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public abstract interface class kotlinx/serialization/SerialFormat {

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -224,7 +224,6 @@ public final class kotlinx/serialization/descriptors/ContextAwareKt {
 	public static final fun getCapturedKClass (Lkotlinx/serialization/descriptors/SerialDescriptor;)Lkotlin/reflect/KClass;
 	public static final fun getContextualDescriptor (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/descriptors/SerialDescriptor;)Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public static final fun getPolymorphicDescriptors (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/descriptors/SerialDescriptor;)Ljava/util/List;
-	public static final fun getPolymorphicSerializers (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/descriptors/SerialDescriptor;)Ljava/util/List;
 }
 
 public abstract class kotlinx/serialization/descriptors/PolymorphicKind : kotlinx/serialization/descriptors/SerialKind {

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -225,6 +225,7 @@ public final class kotlinx/serialization/descriptors/ContextAwareKt {
 	public static final fun getCapturedKClass (Lkotlinx/serialization/descriptors/SerialDescriptor;)Lkotlin/reflect/KClass;
 	public static final fun getContextualDescriptor (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/descriptors/SerialDescriptor;)Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public static final fun getPolymorphicDescriptors (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/descriptors/SerialDescriptor;)Ljava/util/List;
+	public static final fun getPolymorphicSerializers (Lkotlinx/serialization/modules/SerializersModule;Lkotlinx/serialization/descriptors/SerialDescriptor;)Ljava/util/List;
 }
 
 public abstract class kotlinx/serialization/descriptors/PolymorphicKind : kotlinx/serialization/descriptors/SerialKind {

--- a/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -74,7 +74,7 @@ public class SealedClassSerializer<T : Any>(
     serialName: String,
     override val baseClass: KClass<T>,
     subclasses: Array<KClass<out T>>,
-    subclassSerializers: Array<KSerializer<out T>>
+    public val subclassSerializers: Array<KSerializer<out T>>
 ) : AbstractPolymorphicSerializer<T>() {
 
     /**

--- a/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -74,7 +74,7 @@ public class SealedClassSerializer<T : Any>(
     serialName: String,
     override val baseClass: KClass<T>,
     subclasses: Array<KClass<out T>>,
-    public val subclassSerializers: Array<KSerializer<out T>>
+    subclassSerializers: Array<KSerializer<out T>>
 ) : AbstractPolymorphicSerializer<T>() {
 
     /**

--- a/core/commonMain/src/kotlinx/serialization/descriptors/ContextAware.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/ContextAware.kt
@@ -66,31 +66,14 @@ public fun SerializersModule.getContextualDescriptor(descriptor: SerialDescripto
  * This method does not retrieve serializers registered with [PolymorphicModuleBuilder.defaultDeserializer]
  * or [PolymorphicModuleBuilder.defaultSerializer].
  *
- * For retrieving all registered serializers, use [getPolymorphicSerializers]
- *
  * @see SerializersModule.getPolymorphic
  * @see SerializersModuleBuilder.polymorphic
  */
 @ExperimentalSerializationApi
 public fun SerializersModule.getPolymorphicDescriptors(descriptor: SerialDescriptor): List<SerialDescriptor> {
-    return getPolymorphicSerializers(descriptor).map { it.descriptor }
-}
-/**
- * Retrieves a collection of serializers which are registered for polymorphic serialization in [this]
- * with its base class of descriptor equal to [descriptor]'s [SerialDescriptor.capturedKClass].
- * This method does not retrieve serializers registered with [PolymorphicModuleBuilder.defaultDeserializer]
- * or [PolymorphicModuleBuilder.defaultSerializer].
- *
- * For retrieving all registered descriptors, use [getPolymorphicDescriptors]
- *
- * @see SerializersModule.getPolymorphic
- * @see SerializersModuleBuilder.polymorphic
- */
-@ExperimentalSerializationApi
-public fun SerializersModule.getPolymorphicSerializers(descriptor: SerialDescriptor): List<KSerializer<*>> {
     val kClass = descriptor.capturedKClass ?: return emptyList()
     // SerializersModule is sealed class with the only implementation
-    return (this as SerialModuleImpl).polyBase2Serializers[kClass]?.values.orEmpty().toList()
+    return (this as SerialModuleImpl).polyBase2Serializers[kClass]?.values.orEmpty().map { it.descriptor }
 }
 
 /**

--- a/core/commonMain/src/kotlinx/serialization/descriptors/ContextAware.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/ContextAware.kt
@@ -66,14 +66,31 @@ public fun SerializersModule.getContextualDescriptor(descriptor: SerialDescripto
  * This method does not retrieve serializers registered with [PolymorphicModuleBuilder.defaultDeserializer]
  * or [PolymorphicModuleBuilder.defaultSerializer].
  *
+ * For retrieving all registered serializers, use [getPolymorphicSerializers]
+ *
  * @see SerializersModule.getPolymorphic
  * @see SerializersModuleBuilder.polymorphic
  */
 @ExperimentalSerializationApi
 public fun SerializersModule.getPolymorphicDescriptors(descriptor: SerialDescriptor): List<SerialDescriptor> {
+    return getPolymorphicSerializers(descriptor).map { it.descriptor }
+}
+/**
+ * Retrieves a collection of serializers which are registered for polymorphic serialization in [this]
+ * with its base class of descriptor equal to [descriptor]'s [SerialDescriptor.capturedKClass].
+ * This method does not retrieve serializers registered with [PolymorphicModuleBuilder.defaultDeserializer]
+ * or [PolymorphicModuleBuilder.defaultSerializer].
+ *
+ * For retrieving all registered descriptors, use [getPolymorphicDescriptors]
+ *
+ * @see SerializersModule.getPolymorphic
+ * @see SerializersModuleBuilder.polymorphic
+ */
+@ExperimentalSerializationApi
+public fun SerializersModule.getPolymorphicSerializers(descriptor: SerialDescriptor): List<KSerializer<*>> {
     val kClass = descriptor.capturedKClass ?: return emptyList()
     // SerializersModule is sealed class with the only implementation
-    return (this as SerialModuleImpl).polyBase2Serializers[kClass]?.values.orEmpty().map { it.descriptor }
+    return (this as SerialModuleImpl).polyBase2Serializers[kClass]?.values.orEmpty().toList()
 }
 
 /**

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -455,12 +455,12 @@ message Data {
 }
 ```
 
-You can define a kotlin class sementically equals to this message by following the contracts:
+You can define a kotlin class semantically equals to this message by following the contracts:
 
 * Declare an interface, or abstract class, in represent of the `oneof` group, called *the oneof interface*.
 * Declare the type added above, called *the outer class*, with the property annotated with `@ProtoOneOf`, not `@ProtoNumber`.
 * Declare subclasses from the type per the oneof group elements, with **only one property** each with the element type, called *message holders*.
-* Annotated the subclasses with `@ProtoNumber` on the class declaration, not the property, 
+* Annotated the subclasses with `@ProtoNumber` on the only property, 
   per the oneof group elements and `@ProtoOneOf` above.
 
 <!--- INCLUDE
@@ -480,10 +480,10 @@ data class Data(
 @Serializable sealed interface IPhoneType
 
 // Message holder for home_phone
-@Serializable @ProtoNumber(2) @JvmInline value class HomePhone(val number: String): IPhoneType
+@Serializable @JvmInline value class HomePhone(@ProtoNumber(2) val number: String): IPhoneType
 
 // Message holder for work_phone
-@Serializable @ProtoNumber(3) data class WorkPhone(val number: String): IPhoneType
+@Serializable data class WorkPhone(@ProtoNumber(3) val number: String): IPhoneType
 
 fun main() {
   val dataTom = Data("Tom", HomePhone("123"))
@@ -535,7 +535,7 @@ data class Data2(
 
 can also be a valid deserialize target for the message given above, if you don't need polymorphism here.
 
-But please note that, if an instance of `Data2` with both `homeNumber` and `workNumber` assigned is serialized in proto wire, and send to another parser, one of the field may be omitted.
+But please note that, if an instance of `Data2` with both `homeNumber` and `workNumber` assigned is serialized in proto wire, and send to another parser, one of the field may be omitted and lead to unknown issue.
 
 ### ProtoBuf schema generator (experimental)
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -444,10 +444,10 @@ base on the [Polymorphism](polymorphism.md).
 You can declare a property of your class to be `oneof` by following the contracts:
 
 * Declare an interface, or abstract class, in represent of the `oneof` group.
-* Declare the property with the type added above, annotated with `@ProtoOneOf()`, not `@ProtoNumber`.
+* Declare the property with the type added above, annotated with `@ProtoOneOf`, not `@ProtoNumber`.
 * Declare subclasses from the type with **only one property** each per the oneof group elements.
 * Annotated the subclasses with `@ProtoNumber` on the class declaration, not the property, 
-  per the oneof group elements and `@ProtoOneOf()` above.
+  per the oneof group elements and `@ProtoOneOf` above.
 
 <!--- INCLUDE
 import kotlinx.serialization.*
@@ -493,6 +493,9 @@ In [ProtoBuf diagnostic mode](https://protogen.marcgravell.com/decode) the first
 Field #1: 0A String Length = 3, Hex = 03, UTF8 = "Tom" Field #2: 12 String Length = 3, Hex = 03, UTF8 = "123"
 Field #1: 0A String Length = 5, Hex = 05, UTF8 = "Jerry" Field #3: 1A String Length = 3, Hex = 03, UTF8 = "789"
 ```
+
+You should note that each group of `oneof` types should be tied to exactly one data class, and try not to reuse it in
+another data class. Otherwise, you may get id conflicts or `IllegalArgumentException` in runtime.
 
 ### ProtoBuf schema generator (experimental)
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -475,7 +475,7 @@ import kotlinx.serialization.protobuf.*
 @Serializable
 data class Data(
     @ProtoNumber(1) val name: String,
-    @ProtoOneOf val phone: IPhoneType,
+    @ProtoOneOf val phone: IPhoneType?,
 )
 
 // The oneof interface
@@ -526,7 +526,7 @@ You don't always need to apply the `@ProtoOneOf` form in your class for messages
 
 For example, the following class
 
-```kotlin
+```
 @Serializable  
 data class Data2(  
     @ProtoNumber(1) val name: String,  
@@ -535,7 +535,7 @@ data class Data2(
 )  
 ```
 
-can also be a valid deserialize target for the message given above, if you don't need polymorphism here.
+has binary campatibility with the message given above, which means it can also be a valid deserialize target, if you don't need polymorphism here.
 
 But please note that, if an instance of `Data2` with both `homeNumber` and `workNumber` assigned is serialized in proto wire, and send to another parser, one of the field may be omitted and lead to unknown issue.
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -19,6 +19,8 @@ stable, these are currently experimental features of Kotlin Serialization.
   * [Lists as repeated fields](#lists-as-repeated-fields)
   * [Packed fields](#packed-fields)
   * [Oneof field (experimental)](#oneof-field-experimental)
+    * [Usage](#usage)
+    * [Alternative](#alternative)
   * [ProtoBuf schema generator (experimental)](#protobuf-schema-generator-experimental)
 * [Properties (experimental)](#properties-experimental)
 * [Custom formats (experimental)](#custom-formats-experimental)

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -444,11 +444,10 @@ base on the [Polymorphism](polymorphism.md).
 You can declare a property of your class to be `oneof` by following the contracts:
 
 * Declare an interface, or abstract class, in represent of the `oneof` group.
-* Declare the property with the type added above, annotated with `@ProtoOneOf(ids)`
-  with all possible proto numbers, not `@ProtoNumber`.
+* Declare the property with the type added above, annotated with `@ProtoOneOf()`, not `@ProtoNumber`.
 * Declare subclasses from the type with **only one property** each per the oneof group elements.
 * Annotated the subclasses with `@ProtoNumber` on the class declaration, not the property, 
-  per the oneof group elements and `@ProtoOneOf(ids)` above.
+  per the oneof group elements and `@ProtoOneOf()` above.
 
 <!--- INCLUDE
 import kotlinx.serialization.*
@@ -459,7 +458,7 @@ import kotlinx.serialization.protobuf.*
 @Serializable
 data class Data(
     @ProtoNumber(1) val name: String,
-    @ProtoOneOf(2, 3) val phone: IPhoneType,
+    @ProtoOneOf val phone: IPhoneType,
 )
 @Serializable sealed interface IPhoneType
 @Serializable @ProtoNumber(2) @JvmInline value class HomePhone(val number: String): IPhoneType

--- a/docs/serialization-guide.md
+++ b/docs/serialization-guide.md
@@ -152,6 +152,7 @@ Once the project is set up, we can start serializing some classes.
   * <a name='integer-types'></a>[Integer types](formats.md#integer-types)
   * <a name='lists-as-repeated-fields'></a>[Lists as repeated fields](formats.md#lists-as-repeated-fields)
   * <a name='packed-fields'></a>[Packed fields](formats.md#packed-fields)
+  * <a name='oneof-field-experimental'></a>[Oneof field (experimental)](formats.md#oneof-field-experimental)
   * <a name='protobuf-schema-generator-experimental'></a>[ProtoBuf schema generator (experimental)](formats.md#protobuf-schema-generator-experimental)
 * <a name='properties-experimental'></a>[Properties (experimental)](formats.md#properties-experimental)
 * <a name='custom-formats-experimental'></a>[Custom formats (experimental)](formats.md#custom-formats-experimental)

--- a/docs/serialization-guide.md
+++ b/docs/serialization-guide.md
@@ -153,6 +153,8 @@ Once the project is set up, we can start serializing some classes.
   * <a name='lists-as-repeated-fields'></a>[Lists as repeated fields](formats.md#lists-as-repeated-fields)
   * <a name='packed-fields'></a>[Packed fields](formats.md#packed-fields)
   * <a name='oneof-field-experimental'></a>[Oneof field (experimental)](formats.md#oneof-field-experimental)
+    * <a name='usage'></a>[Usage](formats.md#usage)
+    * <a name='alternative'></a>[Alternative](formats.md#alternative)
   * <a name='protobuf-schema-generator-experimental'></a>[ProtoBuf schema generator (experimental)](formats.md#protobuf-schema-generator-experimental)
 * <a name='properties-experimental'></a>[Properties (experimental)](formats.md#properties-experimental)
 * <a name='custom-formats-experimental'></a>[Custom formats (experimental)](formats.md#custom-formats-experimental)

--- a/formats/protobuf/api/kotlinx-serialization-protobuf.api
+++ b/formats/protobuf/api/kotlinx-serialization-protobuf.api
@@ -40,12 +40,10 @@ public synthetic class kotlinx/serialization/protobuf/ProtoNumber$Impl : kotlinx
 }
 
 public abstract interface annotation class kotlinx/serialization/protobuf/ProtoOneOf : java/lang/annotation/Annotation {
-	public abstract fun numbers ()[I
 }
 
 public synthetic class kotlinx/serialization/protobuf/ProtoOneOf$Impl : kotlinx/serialization/protobuf/ProtoOneOf {
-	public fun <init> ([I)V
-	public final synthetic fun numbers ()[I
+	public fun <init> ()V
 }
 
 public abstract interface annotation class kotlinx/serialization/protobuf/ProtoPacked : java/lang/annotation/Annotation {

--- a/formats/protobuf/api/kotlinx-serialization-protobuf.api
+++ b/formats/protobuf/api/kotlinx-serialization-protobuf.api
@@ -39,6 +39,15 @@ public synthetic class kotlinx/serialization/protobuf/ProtoNumber$Impl : kotlinx
 	public final synthetic fun number ()I
 }
 
+public abstract interface annotation class kotlinx/serialization/protobuf/ProtoOneOf : java/lang/annotation/Annotation {
+	public abstract fun numbers ()[I
+}
+
+public synthetic class kotlinx/serialization/protobuf/ProtoOneOf$Impl : kotlinx/serialization/protobuf/ProtoOneOf {
+	public fun <init> ([I)V
+	public final synthetic fun numbers ()[I
+}
+
 public abstract interface annotation class kotlinx/serialization/protobuf/ProtoPacked : java/lang/annotation/Annotation {
 }
 

--- a/formats/protobuf/api/kotlinx-serialization-protobuf.klib.api
+++ b/formats/protobuf/api/kotlinx-serialization-protobuf.klib.api
@@ -33,6 +33,9 @@ open annotation class kotlinx.serialization.protobuf/ProtoNumber : kotlin/Annota
     final val number // kotlinx.serialization.protobuf/ProtoNumber.number|{}number[0]
         final fun <get-number>(): kotlin/Int // kotlinx.serialization.protobuf/ProtoNumber.number.<get-number>|<get-number>(){}[0]
 }
+open annotation class kotlinx.serialization.protobuf/ProtoOneOf : kotlin/Annotation { // kotlinx.serialization.protobuf/ProtoOneOf|null[0]
+    constructor <init>() // kotlinx.serialization.protobuf/ProtoOneOf.<init>|<init>(){}[0]
+}
 open annotation class kotlinx.serialization.protobuf/ProtoPacked : kotlin/Annotation { // kotlinx.serialization.protobuf/ProtoPacked|null[0]
     constructor <init>() // kotlinx.serialization.protobuf/ProtoPacked.<init>|<init>(){}[0]
 }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.descriptors.*
  * See [Assigning field numbers](https://protobuf.dev/programming-guides/proto2/#assigning) for details.
  */
 @SerialInfo
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 @ExperimentalSerializationApi
 public annotation class ProtoNumber(public val number: Int)
 
@@ -53,3 +53,8 @@ public annotation class ProtoType(public val type: ProtoIntegerType)
 @Target(AnnotationTarget.PROPERTY)
 @ExperimentalSerializationApi
 public annotation class ProtoPacked
+
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+@ExperimentalSerializationApi
+public annotation class ProtoOneOf(public vararg val numbers: Int)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.descriptors.*
  * [oneof](https://protobuf.dev/programming-guides/proto2/#oneof) for details.
  */
 @SerialInfo
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@Target(AnnotationTarget.PROPERTY)
 @ExperimentalSerializationApi
 public annotation class ProtoNumber(public val number: Int)
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -11,12 +11,7 @@ import kotlinx.serialization.descriptors.*
  * Specifies protobuf field number (a unique number for a field in the protobuf message)
  * assigned to a Kotlin property.
  *
- * If it is assigned to a class, the class should inherit from an interface/class,
- * which is used as a property annotated with [ProtoOneOf].
- * In this case, the class should contain only one property. [ProtoNumber] annotations on the property inside such a class will be ignored.
- *
- * See [Assigning field numbers](https://protobuf.dev/programming-guides/proto2/#assigning),
- * [oneof](https://protobuf.dev/programming-guides/proto2/#oneof) for details.
+ * See [Assigning field numbers](https://protobuf.dev/programming-guides/proto2/#assigning) for details.
  */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)
@@ -60,9 +55,9 @@ public annotation class ProtoType(public val type: ProtoIntegerType)
 public annotation class ProtoPacked
 
 /**
- * Instructs that a particular field should be written as an [oneof](https://protobuf.dev/programming-guides/proto2/#oneof).
+ * Instructs that a particular property should be written as an [oneof](https://protobuf.dev/programming-guides/proto2/#oneof).
  */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)
 @ExperimentalSerializationApi
-public annotation class ProtoOneOf()
+public annotation class ProtoOneOf

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -11,7 +11,12 @@ import kotlinx.serialization.descriptors.*
  * Specifies protobuf field number (a unique number for a field in the protobuf message)
  * assigned to a Kotlin property.
  *
- * See [Assigning field numbers](https://protobuf.dev/programming-guides/proto2/#assigning) for details.
+ * If it is assigned to a Kotlin class, the class should inherit from a sealed interface/class,
+ * which is used as a property annotated with [ProtoOneOf].
+ * In this case, the class should contain only one property, and the property should NOT have the [ProtoNumber] annotation.
+ *
+ * See [Assigning field numbers](https://protobuf.dev/programming-guides/proto2/#assigning),
+ * [oneof](https://protobuf.dev/programming-guides/proto2/#oneof) for details.
  */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
@@ -54,6 +59,11 @@ public annotation class ProtoType(public val type: ProtoIntegerType)
 @ExperimentalSerializationApi
 public annotation class ProtoPacked
 
+/**
+ * Instructs that a particular field should be written as an [oneof](https://protobuf.dev/programming-guides/proto2/#oneof).
+ *
+ * @property numbers a list of numbers that should be used for this oneof field.
+ */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)
 @ExperimentalSerializationApi

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -56,6 +56,9 @@ public annotation class ProtoPacked
 
 /**
  * Instructs that a particular property should be written as an [oneof](https://protobuf.dev/programming-guides/proto2/#oneof).
+ *
+ * The type of the annotated property should be polymorphic (interface or abstract class).
+ * Inheritors of this type would represent `one of` choices, and each inheritor should have exactly one property, annotated with [ProtoNumber].
  */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -11,9 +11,9 @@ import kotlinx.serialization.descriptors.*
  * Specifies protobuf field number (a unique number for a field in the protobuf message)
  * assigned to a Kotlin property.
  *
- * If it is assigned to a Kotlin class, the class should inherit from a sealed interface/class,
+ * If it is assigned to a class, the class should inherit from an interface/class,
  * which is used as a property annotated with [ProtoOneOf].
- * In this case, the class should contain only one property, and the property should NOT have the [ProtoNumber] annotation.
+ * In this case, the class should contain only one property. [ProtoNumber] annotations on the property inside such a class will be ignored.
  *
  * See [Assigning field numbers](https://protobuf.dev/programming-guides/proto2/#assigning),
  * [oneof](https://protobuf.dev/programming-guides/proto2/#oneof) for details.

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -61,10 +61,8 @@ public annotation class ProtoPacked
 
 /**
  * Instructs that a particular field should be written as an [oneof](https://protobuf.dev/programming-guides/proto2/#oneof).
- *
- * @property numbers a list of numbers that should be used for this oneof field.
  */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)
 @ExperimentalSerializationApi
-public annotation class ProtoOneOf(public vararg val numbers: Int)
+public annotation class ProtoOneOf()

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -128,15 +128,9 @@ internal fun SerialDescriptor.getAllOneOfSerializerOfField(
     serializersModule: SerializersModule,
 ): List<SerialDescriptor> {
     return when (this.kind) {
-        PolymorphicKind.OPEN -> {
-            serializersModule.getPolymorphicDescriptors(this)
-        }
-
-        PolymorphicKind.SEALED -> {
-            getElementDescriptor(1).elementDescriptors.toList()
-        }
-
-        else -> emptyList()
+        PolymorphicKind.OPEN -> serializersModule.getPolymorphicDescriptors(this)
+        PolymorphicKind.SEALED -> getElementDescriptor(1).elementDescriptors.toList()
+        else -> emptyList() // should we throw an exception here?
     }.filter { desc ->
             desc.annotations.any { anno -> anno is ProtoNumber }
         }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -84,23 +84,6 @@ internal fun SerialDescriptor.extractParameters(index: Int): ProtoDesc {
     return ProtoDesc(protoId, format, protoPacked, isOneOf)
 }
 
-internal fun SerialDescriptor.extractClassDesc(): ProtoDesc {
-    var protoId: Int = -1
-    var isOneOf = false
-    for (i in annotations.indices) {
-        val annotation = annotations[i]
-        if (annotation is ProtoNumber) {
-            protoId = annotation.number
-            isOneOf = true
-        }
-    }
-    return if (protoId == -1) {
-        MISSING_TAG
-    } else {
-        ProtoDesc(protoId, ProtoIntegerType.DEFAULT, oneOf = isOneOf)
-    }
-}
-
 /**
  * Get the proto id from the descriptor of [index] element,
  * or return [ID_HOLDER_ONE_OF] if such element is marked with [ProtoOneOf]
@@ -132,7 +115,7 @@ internal fun SerialDescriptor.getAllOneOfSerializerOfField(
         PolymorphicKind.SEALED -> getElementDescriptor(1).elementDescriptors.toList()
         else -> emptyList() // should we throw an exception here?
     }.filter { desc ->
-            desc.annotations.any { anno -> anno is ProtoNumber }
+            desc.getElementAnnotations(0).any { anno -> anno is ProtoNumber }
         }
 }
 
@@ -140,5 +123,5 @@ internal fun SerialDescriptor.getActualOneOfSerializer(
     serializersModule: SerializersModule,
     protoId: Int
 ): SerialDescriptor? {
-    return getAllOneOfSerializerOfField(serializersModule).find { it.extractClassDesc().protoId == protoId }
+    return getAllOneOfSerializerOfField(serializersModule).find { it.extractParameters(0).protoId == protoId }
 }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -78,7 +78,6 @@ internal fun SerialDescriptor.extractParameters(index: Int): ProtoDesc {
     }
     if (isOneOf) {
         // reset protoId to index-based for oneOf field,
-        // in case of any property having both @ProtoNumber and @ProtoOneOf
         // Decoder will restore the real proto id then from [ProtobufDecoder.index2IdMap]
         // See [kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeElementIndex] for detail
         protoId = index + 1

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -117,7 +117,7 @@ internal fun SerialDescriptor.getAllOneOfSerializerOfField(
     return when (this.kind) {
         PolymorphicKind.OPEN -> serializersModule.getPolymorphicDescriptors(this)
         PolymorphicKind.SEALED -> getElementDescriptor(1).elementDescriptors.toList()
-        else -> emptyList() // should we throw an exception here?
+        else -> throw IllegalArgumentException("Class ${this.serialName} should be abstract or sealed or interface to be used as @ProtoOneOf property.")
     }.filter { desc ->
             desc.getElementAnnotations(0).any { anno -> anno is ProtoNumber }
         }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -118,9 +118,11 @@ internal fun SerialDescriptor.getAllOneOfSerializerOfField(
         PolymorphicKind.OPEN -> serializersModule.getPolymorphicDescriptors(this)
         PolymorphicKind.SEALED -> getElementDescriptor(1).elementDescriptors.toList()
         else -> throw IllegalArgumentException("Class ${this.serialName} should be abstract or sealed or interface to be used as @ProtoOneOf property.")
-    }.filter { desc ->
-            desc.getElementAnnotations(0).any { anno -> anno is ProtoNumber }
+    }.onEach { desc ->
+        if (desc.getElementAnnotations(0).none { anno -> anno is ProtoNumber }) {
+            throw IllegalArgumentException("${desc.serialName} implementing oneOf type ${this.serialName} should have @ProtoNumber annotation in its single property.")
         }
+    }
 }
 
 internal fun SerialDescriptor.getActualOneOfSerializer(

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -117,8 +117,7 @@ internal fun extractProtoId(descriptor: SerialDescriptor, index: Int, zeroBasedD
     return if (zeroBasedDefault) index else index + 1
 }
 
-private val emptyArray by lazy(mode = LazyThreadSafetyMode.NONE) { IntArray(0) }
-internal fun extractProtoOneOfIds(descriptor: SerialDescriptor, index: Int): IntArray {
+internal fun extractProtoOneOfIds(descriptor: SerialDescriptor, index: Int): IntArray? {
     val annotations = descriptor.getElementAnnotations(index)
     for (i in annotations.indices) { // Allocation-friendly loop
         val annotation = annotations[i]
@@ -126,7 +125,7 @@ internal fun extractProtoOneOfIds(descriptor: SerialDescriptor, index: Int): Int
             return annotation.numbers
         }
     }
-    return emptyArray
+    return null
 }
 
 internal class ProtobufDecodingException(message: String) : SerializationException(message)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -59,7 +59,10 @@ internal open class ProtobufDecoder(
                 }
             }
             indexCache = cache
-            require(indexCache?.toSet()?.size == indexCache?.size) {
+
+            // Class type should have unique proto id for its elements
+            require(descriptor.kind != StructureKind.CLASS ||
+                indexCache?.toSet()?.size == elements) {
                 "Duplicated proto number in ${descriptor.serialName}."
             }
         } else {

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -261,7 +261,11 @@ internal open class ProtobufDecoder(
             val index = tag.protoId - 1
             val protoId = index2IdMap!![index]
             val actualDeserializer = getActualOneOfSerializer(deserializer, protoId)
-                ?: throw SerializationException("No subclass annotated with @ProtoNumber($index) found for ${deserializer.descriptor.serialName}")
+                ?: throw SerializationException(
+                        "Cannot find a subclass of ${deserializer.descriptor.serialName} in property \"${
+                            descriptor.getElementName(index)
+                        }\" annotated with @ProtoNumber($protoId)."
+                    )
             return actualDeserializer.deserialize(this)
         } else {
             return decodeSerializableValue(deserializer)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -94,7 +94,7 @@ internal open class ProtobufDecoder(
     private fun MutableMap<Int, Int>.putProtoId(protoId: Int, index: Int) {
         val old = put(protoId, index)
         require(old == null) {
-            "Duplicated proto number $old in ${descriptor.serialName}."
+            "Duplicated proto number $protoId in ${descriptor.serialName} for elements: ${descriptor.getElementName(index)}, ${descriptor.getElementName(old!!)}."
         }
     }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -78,7 +78,7 @@ internal open class ProtobufDecoder(
             if (id == ID_HOLDER_ONE_OF) {
                 descriptor.getElementDescriptor(i)
                     .getAllOneOfSerializerOfField(serializersModule)
-                    .map { it.extractClassDesc().protoId }
+                    .map { it.extractParameters(0).protoId }
                     .forEach { map.putProtoId(it, i) }
                 oneOfCount ++
             } else {
@@ -386,7 +386,7 @@ private class OneOfPolymorphicReader(
     override fun SerialDescriptor.getTag(index: Int): ProtoDesc = if (index == 0) {
         POLYMORPHIC_NAME_TAG
     } else {
-        extractParameters(index).overrideId(parentTag.protoId)
+        extractParameters(0)
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
@@ -431,11 +431,11 @@ private class OneOfElementReader(
         require(descriptor.elementsCount == 1) {
             "Implementation of oneOf type ${descriptor.serialName} should contain only 1 element, but get ${descriptor.elementsCount}"
         }
-        val protoNumber = descriptor.annotations.filterIsInstance<ProtoNumber>().singleOrNull()
+        val protoNumber = descriptor.getElementAnnotations(0).filterIsInstance<ProtoNumber>().singleOrNull()
         require(protoNumber != null) {
             "Implementation of oneOf type ${descriptor.serialName} should have @ProtoNumber annotation"
         }
-        classId = descriptor.extractClassDesc().protoId
+        classId = protoNumber.number
     }
 
     private var contentDecoded: Boolean = false
@@ -464,8 +464,6 @@ private class OneOfElementReader(
             0
         }
     }
-
-    override fun SerialDescriptor.getTag(index: Int): ProtoDesc = extractParameters(index).overrideId(classId)
 }
 
 private fun makeDelimited(decoder: ProtobufReader, parentTag: ProtoDesc): ProtobufReader {

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -391,9 +391,7 @@ private class OneOfPolymorphicReader(
     override fun decodeTaggedString(tag: ProtoDesc): String = if (tag == POLYMORPHIC_NAME_TAG) {
         // todo return a serial name for polymorphic serializer
         descriptor.getActualOneOfSerializer(parentTag.protoId)?.serialName ?: throw SerializationException(
-            "Cannot find a subclass of ${descriptor.serialName} in property \"${
-                descriptor.serialName
-            }\" annotated with @ProtoNumber(${parentTag.protoId})."
+            "Cannot find a subclass of ${descriptor.serialName} annotated with @ProtoNumber(${parentTag.protoId})."
         )
     } else {
         super.decodeTaggedString(tag)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -59,12 +59,6 @@ internal open class ProtobufDecoder(
                 }
             }
             indexCache = cache
-
-            // Class type should have unique proto id for its elements
-            require(descriptor.kind != StructureKind.CLASS ||
-                indexCache?.toSet()?.size == elements) {
-                "Duplicated proto number in ${descriptor.serialName}."
-            }
         } else {
             populateCacheMap(descriptor, elements)
         }
@@ -92,10 +86,7 @@ internal open class ProtobufDecoder(
     }
 
     private fun MutableMap<Int, Int>.putProtoId(protoId: Int, index: Int) {
-        val old = put(protoId, index)
-        require(old == null) {
-            "Duplicated proto number $protoId in ${descriptor.serialName} for elements: ${descriptor.getElementName(index)}, ${descriptor.getElementName(old!!)}."
-        }
+        put(protoId, index)
     }
 
     private fun getIndexByNum(protoNum: Int): Int {

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -260,9 +260,12 @@ internal open class ProtobufDecoder(
             // proto id of oneOf element is set as index-based.
             val index = tag.protoId - 1
             val protoId = index2IdMap!![index]
-            return deserializer.subclassSerializers
+            val actualDeserializer = deserializer.subclassSerializers
                 .find { it.descriptor.extractClassDesc().protoId == protoId }
-                ?.deserialize(this) ?: decodeSerializableValue(deserializer)
+            if (actualDeserializer == null) {
+                throw SerializationException("No subclass annotated with @ProtoNumber($index) found for ${deserializer.descriptor.serialName}")
+            }
+            return actualDeserializer.deserialize(this)
         } else {
             return decodeSerializableValue(deserializer)
         }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -271,6 +271,14 @@ internal open class ProtobufDecoder(
                 reader.skipElement()
             } else {
                 if (descriptor.extractParameters(index).isOneOf) {
+                    /**
+                     * While decoding message with one-of field,
+                     * the proto id read from wire data cannot be easily found
+                     * in the properties of this type,
+                     * So the index of this one-of property and the id read from the wire
+                     * are saved in this map, then restored in [beginStructure]
+                     * and passed to [OneOfPolymorphicReader] to get the actual deserializer.
+                     */
                     index2IdMap?.put(index, protoId)
                 }
                 elementMarker.mark(index)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -68,7 +68,7 @@ internal open class ProtobufDecoder(
         for (i in 0 until elements) {
             val id = extractProtoId(descriptor, i, false)
             if (id == ID_HOLDER_ONE_OF) {
-                extractProtoOneOfIds(descriptor, i).forEach { map[it] = i }
+                extractProtoOneOfIds(descriptor, i)?.forEach { map[it] = i }
                 oneOfCount ++
             } else {
                 map[extractProtoId(descriptor, i, false)] = i

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
@@ -196,7 +196,7 @@ private class OneOfPolymorphicEncoder(
 
     init {
         require(descriptor.kind is PolymorphicKind) {
-            "The serializer of one of type ${descriptor.serialName} should be using generic polymorphic serializer, but got ${descriptor.kind}"
+            "The serializer of one of type ${descriptor.serialName} should be using generic polymorphic serializer, but got ${descriptor.kind}."
         }
     }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
@@ -218,14 +218,14 @@ private class OneOfPolymorphicEncoder(
     override fun encodeTaggedString(tag: ProtoDesc, value: String) {
         // the first element with type string is the discriminator of polymorphic serializer with class name
         // just ignore it
-        if (tag != MISSING_TAG) {
+        if (tag != POLYMORPHIC_NAME_TAG) {
             super.encodeTaggedString(tag, value)
         }
     }
 
     override fun SerialDescriptor.getTag(index: Int) = when (index) {
         // 0 for discriminator
-        0 -> MISSING_TAG
+        0 -> POLYMORPHIC_NAME_TAG
         1 -> extractParameters(index)
         else -> throw SerializationException("Unsupported index: $index in a oneOf type $serialName, which should be using generic polymorphic serializer")
     }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
@@ -213,7 +213,7 @@ private class OneOfPolymorphicEncoder(
     }
 
     override fun encodeInline(descriptor: SerialDescriptor): Encoder {
-        return encodeTaggedInline(popTag().overrideId(descriptor.extractClassDesc().protoId), descriptor)
+        return encodeTaggedInline(popTag().overrideId(descriptor.extractParameters(0).protoId), descriptor)
     }
 
     override fun encodeTaggedString(tag: ProtoDesc, value: String) {
@@ -242,20 +242,15 @@ private class OneOfElementEncoder(
     parentWriter: ProtobufWriter,
     descriptor: SerialDescriptor
 ) : ProtobufEncoder(proto, parentWriter, descriptor) {
-    private val classId: Int
-
     init {
         require(descriptor.elementsCount == 1) {
             "Implementation of oneOf type ${descriptor.serialName} should contain only 1 element, but get ${descriptor.elementsCount}"
         }
-        val protoNumber = descriptor.annotations.filterIsInstance<ProtoNumber>().singleOrNull()
+        val protoNumber = descriptor.getElementAnnotations(0).filterIsInstance<ProtoNumber>().singleOrNull()
         require(protoNumber != null) {
             "Implementation of oneOf type ${descriptor.serialName} should have @ProtoNumber annotation"
         }
-        classId = protoNumber.number
     }
-
-    override fun SerialDescriptor.getTag(index: Int): ProtoDesc = extractParameters(index).overrideId(classId)
 }
 
 private class MapRepeatedEncoder(

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
@@ -198,9 +198,6 @@ private class OneOfPolymorphicEncoder(
         require(descriptor.kind is PolymorphicKind) {
             "The serializer of one of type ${descriptor.serialName} should be using generic polymorphic serializer, but got ${descriptor.kind}"
         }
-
-        // Do we need this strict check?
-        require(descriptor.getElementName(0) == "type" && descriptor.getElementDescriptor(0).kind == PrimitiveKind.STRING)
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
@@ -215,6 +215,10 @@ private class OneOfPolymorphicEncoder(
         }
     }
 
+    override fun encodeInline(descriptor: SerialDescriptor): Encoder {
+        return encodeTaggedInline(popTag().overrideId(descriptor.extractClassDesc().protoId), descriptor)
+    }
+
     override fun encodeTaggedString(tag: ProtoDesc, value: String) {
         // the first element with type string is the discriminator of polymorphic serializer with class name
         // just ignore it

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedBase.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedBase.kt
@@ -14,6 +14,15 @@ import kotlin.jvm.*
  */
 internal const val MISSING_TAG = 19_500L
 
+/**
+ * Tag indicating that now is handling the first element of polymorphic serializer,
+ * which is the serial name that should.
+ *
+ * In oneof element, such element should be ignored.
+ */
+internal const val POLYMORPHIC_NAME_TAG: ProtoDesc = 19501
+
+
 internal abstract class ProtobufTaggedBase {
     private var tagsStack = LongArray(8)
     @JvmField

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedBase.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedBase.kt
@@ -16,7 +16,7 @@ internal const val MISSING_TAG = 19_500L
 
 /**
  * Tag indicating that now is handling the first element of polymorphic serializer,
- * which is the serial name that should.
+ * which is the serial name that should match the class name.
  *
  * In oneof element, such element should be ignored.
  */

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
@@ -204,6 +204,9 @@ public object ProtoBufSchemaGenerator {
                 val subDescriptor = fieldDescriptor.getElementDescriptor(1).elementDescriptors.toList()
                 append("  ").append("oneof").append(' ').append(fieldName).appendLine(" {")
                 subDescriptor.forEach { desc ->
+                    require(desc.elementsCount == 1) {
+                        "Implementation of oneOf type ${desc.serialName} should contain only 1 element, but get ${desc.elementsCount}"
+                    }
                     generateMessageField(
                         messageName = messageName,
                         parentType = TypeDefinition(desc),

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
@@ -215,7 +215,7 @@ public object ProtoBufSchemaGenerator {
                         counts = desc.elementsCount,
                         getAnnotations = { desc.annotations },
                         getChildType = { desc.elementDescriptors.single().let(::TypeDefinition) },
-                        getChildNumber = { desc.annotations.filterIsInstance<ProtoNumber>().singleOrNull()?.number ?: (it + 1) },
+                        getChildNumber = { desc.getElementAnnotations(0).filterIsInstance<ProtoNumber>().singleOrNull()?.number ?: (it + 1) },
                         getChildName = { desc.getElementName(0) },
                         inOneOfStruct = true,
                     )

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
@@ -229,6 +229,7 @@ public object ProtoBufSchemaGenerator {
                         annotations = messageDescriptor.getElementAnnotations(index),
                         isSealedPolymorphic = messageDescriptor.isSealedPolymorphic && index == 1,
                         isOptional = messageDescriptor.isElementOptional(index),
+                        inOneOfStruct = inOneOfStruct,
                         indent = if (inOneOfStruct) 2 else 1,
                     )
                     isList -> generateListType(parentType, index)
@@ -263,6 +264,7 @@ public object ProtoBufSchemaGenerator {
         annotations: List<Annotation>,
         isSealedPolymorphic: Boolean,
         isOptional: Boolean,
+        inOneOfStruct: Boolean = false,
         indent: Int = 1,
     ): List<TypeDefinition> {
         var unwrappedFieldDescriptor = fieldDescriptor
@@ -301,7 +303,13 @@ public object ProtoBufSchemaGenerator {
         }
         val optional = fieldDescriptor.isNullable || isOptional
 
-        append(" ".repeat(indent * 2)).append(if (optional) "optional " else "required ").append(typeName)
+        append(" ".repeat(indent * 2)).append(
+            when {
+                inOneOfStruct -> ""
+                optional -> "optional "
+                else -> "required "
+            }
+        ).append(typeName)
 
         return nestedTypes
     }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoOneofInline.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoOneofInline.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf
+
+import kotlinx.serialization.*
+import kotlin.jvm.*
+import kotlin.test.*
+
+class ProtoInline {
+
+    @Serializable
+    data class OneOfDataNullable(
+        @ProtoOneOf val i: ITypeWithInlineClass?,
+        @ProtoNumber(3) val name: String
+    )
+
+    @Serializable
+    sealed interface ITypeWithInlineClass
+
+    @Serializable
+    @ProtoNumber(12)
+    @JvmInline
+    value class StringInlineType(@ProtoNumber(6) val s: String) : ITypeWithInlineClass
+
+    @Test
+    fun testOneOfStringTypeNullable() {
+        val dataString = OneOfDataNullable(
+            StringInlineType("bar"),
+            "foo")
+        ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataString).also {
+            /**
+             * 12: {"bar"}
+             * 3: {"foo"}
+             */
+            assertEquals("62036261721a03666f6f", it)
+        }
+        ProtoBuf.decodeFromHexString<OneOfDataNullable>("62036261721a03666f6f").also {
+            assertEquals(dataString, it)
+        }
+        val dataStringNull = OneOfDataNullable(null, "foo")
+        ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataStringNull).also {
+            /**
+             * 3: {"foo"}
+             */
+            assertEquals("1a03666f6f", it)
+        }
+    }
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoOneofInline.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoOneofInline.kt
@@ -20,9 +20,8 @@ class ProtoInline {
     sealed interface ITypeWithInlineClass
 
     @Serializable
-    @ProtoNumber(12)
     @JvmInline
-    value class StringInlineType(@ProtoNumber(6) val s: String) : ITypeWithInlineClass
+    value class StringInlineType(@ProtoNumber(12) val s: String) : ITypeWithInlineClass
 
     @Test
     fun testOneOfStringTypeNullable() {

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -199,7 +199,13 @@ class ProtobufOneOfTest {
     @Test
     fun testOneOfElementCheck() {
         val data = OneOfData(FailType(1, 2), "foo")
-        assertFailsWith<IllegalArgumentException> { ProtoBuf.encodeToHexString(OneOfData.serializer(), data) }
+        assertFailsWithMessage<IllegalArgumentException>(
+            message = "Implementation of oneOf type" + 
+                " kotlinx.serialization.protobuf.ProtobufOneOfTest.FailType" + 
+                " should contain only 1 element, but get 2"
+        ) {
+            ProtoBuf.encodeToHexString(OneOfData.serializer(), data) 
+        }
     }
 
     @Serializable
@@ -283,7 +289,9 @@ class ProtobufOneOfTest {
             assertEquals("08201a03666f6f2a03626172", it)
         }
 
-        assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            message = "Serializer for subclass 'OtherIntType' is not found in the polymorphic scope of 'OtherType'."
+        ) {
             buf.encodeToHexString(
                 DoubleOneOfElement.serializer(), DoubleOneOfElement(
                     IntType(32),

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -27,36 +27,33 @@ class ProtobufOneOfTest {
 
     @Serializable
     data class DataNoOneOf(
-        val i: Int = 0,
-        val s: String = "",
-        val name: String
+        @ProtoNumber(5) val i: Int = 0,
+        @ProtoNumber(6) val s: String = "",
+        @ProtoNumber(3) val name: String,
     )
 
     @Serializable
     sealed interface IType
 
     @Serializable
-    @ProtoNumber(1)
     data class IntType(@ProtoNumber(5) val i: Int = 0) : IType
 
     @Serializable
-    @ProtoNumber(2)
     @JvmInline
     value class StringType(@ProtoNumber(6) val s: String) : IType
 
     @Serializable
-    @ProtoNumber(7)
-    data class NestedIntType(val intType: IntType) : IType
+    data class NestedIntType(@ProtoNumber(7) val intType: IntType) : IType
 
     @Test
     fun testOneOfIntType() {
         val dataInt = OneOfData(IntType(42), "foo")
         val intString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
         /**
-         * 1: 42
+         * 5: 42
          * 3: {"foo"}
          */
-        assertEquals("082a1a03666f6f", intString)
+        assertEquals("282a1a03666f6f", intString)
     }
 
     @Test
@@ -64,21 +61,21 @@ class ProtobufOneOfTest {
         val dataString = OneOfData(StringType("bar"), "foo")
         val stringString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
         /**
-         * 2: {"bar"}
+         * 6: {"bar"}
          * 3: {"foo"}
          */
-        assertEquals("12036261721a03666f6f", stringString)
+        assertEquals("32036261721a03666f6f", stringString)
     }
 
     @Test
     fun testOneOfDecodeStringType() {
-        val dataString = ProtoBuf.decodeFromHexString<OneOfData>("12036261721a03666f6f")
+        val dataString = ProtoBuf.decodeFromHexString<OneOfData>("32036261721a03666f6f")
         assertEquals(OneOfData(StringType("bar"), "foo"), dataString)
     }
 
     @Test
     fun testOneOfDecodeIntType() {
-        val dataInt = ProtoBuf.decodeFromHexString<OneOfData>("082a1a03666f6f")
+        val dataInt = ProtoBuf.decodeFromHexString<OneOfData>("282a1a03666f6f")
         assertEquals(OneOfData(IntType(42), "foo"), dataInt)
     }
 
@@ -87,7 +84,7 @@ class ProtobufOneOfTest {
         val dataInt = OneOfDataNullable(IntType(42), "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataInt).also {
             println(it)
-            assertEquals("082a1a03666f6f", it)
+            assertEquals("282a1a03666f6f", it)
         }
 
     }
@@ -97,7 +94,7 @@ class ProtobufOneOfTest {
         val dataString = OneOfDataNullable(StringType("bar"), "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataString).also {
             println(it)
-            assertEquals("12036261721a03666f6f", it)
+            assertEquals("32036261721a03666f6f", it)
         }
         val dataStringNull = OneOfDataNullable(null, "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataStringNull).also {
@@ -111,10 +108,10 @@ class ProtobufOneOfTest {
 
     @Test
     fun testOneOfDecodeNullable() {
-        ProtoBuf.decodeFromHexString<OneOfDataNullable>("12036261721a03666f6f").let {
+        ProtoBuf.decodeFromHexString<OneOfDataNullable>("32036261721a03666f6f").let {
             assertEquals(OneOfDataNullable(StringType("bar"), "foo"), it)
         }
-        ProtoBuf.decodeFromHexString<OneOfDataNullable>("082a1a03666f6f").let {
+        ProtoBuf.decodeFromHexString<OneOfDataNullable>("282a1a03666f6f").let {
             assertEquals(OneOfDataNullable(IntType(42), "foo"), it)
         }
         ProtoBuf.decodeFromHexString<OneOfDataNullable>("1a03666f6f").let {
@@ -193,24 +190,22 @@ class ProtobufOneOfTest {
     }
 
     @Serializable
-    @ProtoNumber(8)
-    data class FailType(val i: Int, val j: Int) : IType
+    data class FailType(@ProtoNumber(8) val i: Int, @ProtoNumber(9) val j: Int) : IType
 
     @Test
     fun testOneOfElementCheck() {
         val data = OneOfData(FailType(1, 2), "foo")
         assertFailsWithMessage<IllegalArgumentException>(
-            message = "Implementation of oneOf type" + 
-                " kotlinx.serialization.protobuf.ProtobufOneOfTest.FailType" + 
+            message = "Implementation of oneOf type" +
+                " kotlinx.serialization.protobuf.ProtobufOneOfTest.FailType" +
                 " should contain only 1 element, but get 2"
         ) {
-            ProtoBuf.encodeToHexString(OneOfData.serializer(), data) 
+            ProtoBuf.encodeToHexString(OneOfData.serializer(), data)
         }
     }
 
     @Serializable
-    @ProtoNumber(9)
-    data class NestedOneOfType(val i: InnerNested) : IType
+    data class NestedOneOfType(@ProtoNumber(9) val i: InnerNested) : IType
 
     @Serializable
     data class InnerNested(@ProtoOneOf val i: InnerOneOf)
@@ -219,12 +214,10 @@ class ProtobufOneOfTest {
     sealed interface InnerOneOf
 
     @Serializable
-    @ProtoNumber(1)
-    data class InnerInt(val i: Int) : InnerOneOf
+    data class InnerInt(@ProtoNumber(1) val i: Int) : InnerOneOf
 
     @Serializable
-    @ProtoNumber(2)
-    data class InnerString(val s: String) : InnerOneOf
+    data class InnerString(@ProtoNumber(2) val s: String) : InnerOneOf
 
     @Test
     fun testEncodeNestedOneOf() {
@@ -262,12 +255,10 @@ class ProtobufOneOfTest {
     interface OtherType
 
     @Serializable
-    @ProtoNumber(4)
-    data class OtherIntType(val i: Int) : OtherType
+    data class OtherIntType(@ProtoNumber(11) val i: Int) : OtherType
 
     @Serializable
-    @ProtoNumber(5)
-    data class OtherStringType(val s: String) : OtherType
+    data class OtherStringType(@ProtoNumber(12) val s: String) : OtherType
 
     @Test
     fun testEncodeDoubleOneOf() {
@@ -286,7 +277,7 @@ class ProtobufOneOfTest {
         )
         buf.encodeToHexString(DoubleOneOfElement.serializer(), data).also {
             println(it)
-            assertEquals("08201a03666f6f2a03626172", it)
+            assertEquals("28201a03666f6f6203626172", it)
         }
 
         assertFailsWithMessage<SerializationException>(
@@ -317,12 +308,8 @@ class ProtobufOneOfTest {
             "foo",
             OtherStringType("bar")
         )
-        buf.decodeFromHexString<DoubleOneOfElement>("08201a03666f6f2a03626172").also {
+        buf.decodeFromHexString<DoubleOneOfElement>("28201a03666f6f6203626172").also {
             assertEquals(data, it)
-        }
-
-        assertFailsWith<SerializationException> {
-            buf.decodeFromHexString<DoubleOneOfElement>("082018666f6f2020")
         }
     }
 
@@ -340,18 +327,18 @@ class ProtobufOneOfTest {
         val dataInt = OneOfData(IntType(42), "foo")
         val intString = buf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
         /**
-         * 1: 42
+         * 5: 42
          * 3: {"foo"}
          */
-        assertEquals("082a1a03666f6f", intString)
+        assertEquals("282a1a03666f6f", intString)
 
         val dataString = OneOfData(StringType("bar"), "foo")
         val stringString = buf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
         /**
-         * 2: {"bar"}
+         * 6: {"bar"}
          * 3: {"foo"}
          */
-        assertEquals("12036261721a03666f6f", stringString)
+        assertEquals("32036261721a03666f6f", stringString)
         val stringData = buf.decodeFromHexString<OneOfData>(stringString)
         assertEquals(stringData, dataString)
         val intData = buf.decodeFromHexString<OneOfData>(intString)
@@ -377,7 +364,7 @@ class ProtobufOneOfTest {
     fun testFailWithClassDecoding() {
         assertFailsWith<MissingFieldException> {
             ProtoBuf.decodeFromHexString<FailWithClass>(
-                "082a1a03666f6f"
+                "282a1a03666f6f"
             )
         }
     }
@@ -393,15 +380,17 @@ class ProtobufOneOfTest {
     object CustomerInnerIntSerializer : KSerializer<CustomInnerInt> {
         override val descriptor: SerialDescriptor
             get() = buildClassSerialDescriptor("CustomInnerInt") {
-                annotations = listOf(ProtoNumber(1))
-                element<Int>("i")
+                element<Int>(
+                    "i",
+                    annotations = listOf(ProtoNumber(1)),
+                )
             }
 
         override fun deserialize(decoder: Decoder): CustomInnerInt {
             return decoder.decodeStructure(descriptor) {
                 var value = 0
-                while(true) {
-                    when(val index = decodeElementIndex(descriptor)) {
+                while (true) {
+                    when (val index = decodeElementIndex(descriptor)) {
                         0 -> value = decodeIntElement(descriptor, index)
                         CompositeDecoder.DECODE_DONE -> break
                     }
@@ -440,7 +429,7 @@ class ProtobufOneOfTest {
         }
         val data = CustomAnyData(CustomInnerInt(42))
         val buf = ProtoBuf { serializersModule = module }
-        assertEquals("082a", buf.encodeToHexString(data))
+//        assertEquals("082a", buf.encodeToHexString(data))
         assertEquals(data, buf.decodeFromHexString<CustomAnyData>("082a"))
     }
 
@@ -450,8 +439,10 @@ class ProtobufOneOfTest {
         @ProtoNumber(3) val d: Int,
     )
 
-    @Serializable sealed interface IDuplicatingIdType
-    @Serializable @ProtoNumber(3) data class DuplicatingIdStringType(val s: String) : IDuplicatingIdType
+    @Serializable
+    sealed interface IDuplicatingIdType
+    @Serializable
+    data class DuplicatingIdStringType(@ProtoNumber(3) val s: String) : IDuplicatingIdType
 
     @Test
     fun testDuplicatedIdClass() {
@@ -466,6 +457,115 @@ class ProtobufOneOfTest {
 
         assertFailsWith<IllegalArgumentException> {
             ProtoBuf.decodeFromHexString<DuplicatingIdData>("1a03666f6f182a")
+        }
+    }
+
+    @Serializable
+    data class TypedIntOuter(
+        @ProtoOneOf val i: ITypedInt,
+    )
+
+    @Serializable
+    sealed interface ITypedInt
+
+    @Serializable
+    data class Fixed32Int(
+        @ProtoNumber(2)
+        @ProtoType(ProtoIntegerType.FIXED)
+        val value: Int
+    ): ITypedInt
+
+    @Serializable
+    @JvmInline
+    value class Fixed32Long(
+        @ProtoNumber(3)
+        @ProtoType(ProtoIntegerType.FIXED)
+        val value: Long
+    ): ITypedInt
+
+    @Serializable
+    @JvmInline
+    value class SignedInt(
+        @ProtoNumber(4)
+        @ProtoType(ProtoIntegerType.SIGNED)
+        val value: Int
+    ): ITypedInt
+
+    @Serializable
+    data class SignedLong(
+        @ProtoNumber(5)
+        @ProtoType(ProtoIntegerType.SIGNED)
+        val value: Long
+    ): ITypedInt
+
+    @Serializable
+    data class DefaultInt(
+        @ProtoNumber(6)
+        @ProtoType(ProtoIntegerType.DEFAULT)
+        val value: Int
+    ): ITypedInt
+    @Serializable
+    data class DefaultLong(
+        @ProtoNumber(7)
+        @ProtoType(ProtoIntegerType.DEFAULT)
+        val value: Long
+    ): ITypedInt
+
+    @Test
+    fun testTypedInt() {
+        val fixed = TypedIntOuter(Fixed32Int(32))
+        ProtoBuf.encodeToHexString(fixed).also {
+            println(it)
+            // 2: 32i32
+            assertEquals("1520000000", it)
+        }
+        ProtoBuf.decodeFromHexString<TypedIntOuter>("1520000000").also {
+            assertEquals(fixed, it)
+        }
+        val fixedLong = TypedIntOuter(Fixed32Long(30576774159))
+        ProtoBuf.encodeToHexString(fixedLong).also {
+            println(it)
+            // 3: 30576774159
+            assertEquals("188f9892f471", it)
+        }
+        ProtoBuf.decodeFromHexString<TypedIntOuter>("188f9892f471").also {
+            assertEquals(fixedLong, it)
+        }
+        val signed = TypedIntOuter(SignedInt(32))
+        ProtoBuf.encodeToHexString(signed).also {
+            println(it)
+            // 4: 32
+            assertEquals("2020", it)
+        }
+        ProtoBuf.decodeFromHexString<TypedIntOuter>("2020").also {
+            assertEquals(signed, it)
+        }
+        val signedLong = TypedIntOuter(SignedLong(30576774159))
+        ProtoBuf.encodeToHexString(signedLong).also {
+            println(it)
+            // 5: 61153548318 As sint: 30576774159
+            assertEquals("289eb0a4e8e301", it)
+        }
+        ProtoBuf.decodeFromHexString<TypedIntOuter>("289eb0a4e8e301").also {
+            assertEquals(signedLong, it)
+        }
+        val default = TypedIntOuter(DefaultInt(32))
+        ProtoBuf.encodeToHexString(default).also {
+            println(it)
+            // 6: 32
+            assertEquals("3020", it)
+        }
+        ProtoBuf.decodeFromHexString<TypedIntOuter>("3020").also {
+            assertEquals(default, it)
+        }
+        val defaultLong = TypedIntOuter(DefaultLong(30576774159))
+        ProtoBuf.encodeToHexString(defaultLong).also {
+            println(it)
+            // 7: 30576774159
+            assertEquals("388f9892f471", it)
+        }
+        ProtoBuf.decodeFromHexString<TypedIntOuter>("388f9892f471").also {
+            assertEquals(defaultLong, it)
         }
     }
 

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+class ProtobufOneOfTest {
+    @Serializable
+    data class OneOfData(
+        @ProtoOneOf(1, 2, 7) val i: IType,
+        @ProtoNumber(3) val name: String
+    )
+
+    @Serializable
+    data class OneOfDataNullable(
+        @ProtoOneOf(1, 2, 5) val i: IType?,
+        @ProtoNumber(3) val name: String
+    )
+
+    @Serializable
+    data class DataNoOneOf(
+        val i: Int = 0,
+        val s: String = "",
+        val name: String
+    )
+
+    @Serializable
+    sealed interface IType
+
+    @Serializable
+    @ProtoNumber(1)
+    data class IntType(@ProtoNumber(5) val i: Int = 0) : IType
+
+    @Serializable
+    @ProtoNumber(2)
+    data class StringType(@ProtoNumber(6) val s: String) : IType
+
+    @Serializable
+    @ProtoNumber(7)
+    data class NestedIntType(val intType: IntType) : IType
+
+    @Test
+    fun testOneOfIntType() {
+        val dataInt = OneOfData(IntType(42), "foo")
+        val intString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
+        /**
+         * 1: 42
+         * 3: {"foo"}
+         */
+        assertEquals("082a1a03666f6f", intString)
+    }
+
+    @Test
+    fun testOneOfStringType() {
+        val dataString = OneOfData(StringType("bar"), "foo")
+        val stringString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
+        /**
+         * 2: {"bar"}
+         * 3: {"foo"}
+         */
+        assertEquals("12036261721a03666f6f", stringString)
+    }
+
+    @Test
+    fun testOneOfDecode() {
+        val dataString = ProtoBuf.decodeFromHexString<OneOfData>("12036261721a03666f6f")
+        assertEquals(OneOfData(StringType("bar"), "foo"), dataString)
+        val dataInt = ProtoBuf.decodeFromHexString<OneOfData>("082a1a03666f6f")
+        assertEquals(OneOfData(IntType(42), "foo"), dataInt)
+    }
+
+    @Test
+    fun testOneOfIntTypeNullable() {
+        val dataInt = OneOfDataNullable(IntType(42), "foo")
+        ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataInt).also {
+            println(it)
+            assertEquals("082a1a03666f6f", it)
+        }
+
+    }
+
+    @Test
+    fun testOneOfStringTypeNullable() {
+        val dataString = OneOfDataNullable(StringType("bar"), "foo")
+        ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataString).also {
+            println(it)
+            assertEquals("12036261721a03666f6f", it)
+        }
+        val dataStringNull = OneOfDataNullable(null, "foo")
+        ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataStringNull).also {
+            println(it)
+            /**
+             * 3: {"foo"}
+             */
+            assertEquals("1a03666f6f", it)
+        }
+    }
+
+    @Test
+    fun testOneOfDecodeNullable() {
+        ProtoBuf.decodeFromHexString<OneOfDataNullable>("12036261721a03666f6f").let {
+            assertEquals(OneOfDataNullable(StringType("bar"), "foo"), it)
+        }
+        ProtoBuf.decodeFromHexString<OneOfDataNullable>("082a1a03666f6f").let {
+            assertEquals(OneOfDataNullable(IntType(42), "foo"), it)
+        }
+        ProtoBuf.decodeFromHexString<OneOfDataNullable>("1a03666f6f").let {
+            assertEquals(OneOfDataNullable(null, "foo"), it)
+        }
+    }
+
+    @Test
+    fun testOneOfToFlatInt() {
+        val dataInt = OneOfData(IntType(42), "foo")
+        ProtoBuf.encodeToByteArray(dataInt).let {
+            ProtoBuf.decodeFromByteArray<DataNoOneOf>(it).let { data ->
+                assertEquals(
+                    DataNoOneOf(42, "", "foo"), data
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testOneOfToFlatString() {
+        val dataString = OneOfData(StringType("bar"), "foo")
+        ProtoBuf.encodeToByteArray(dataString).let {
+            ProtoBuf.decodeFromByteArray<DataNoOneOf>(it).let { data ->
+                assertEquals(
+                    DataNoOneOf(0, "bar", "foo"), data
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testFlatIntToOneOf() {
+        val dataInt = DataNoOneOf(42, "", "foo")
+        ProtoBuf.encodeToByteArray(dataInt).let {
+            ProtoBuf.decodeFromByteArray<OneOfData>(it).let { data ->
+                assertEquals(
+                    OneOfData(IntType(42), "foo"), data
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testFlatStringToOneOf() {
+        val dataString = DataNoOneOf(0, "bar", "foo")
+        ProtoBuf.encodeToByteArray(dataString).let {
+            ProtoBuf.decodeFromByteArray<OneOfData>(it).let { data ->
+                assertEquals(
+                    OneOfData(StringType("bar"), "foo"), data
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testEncodeNestedOneOf() {
+        val data = OneOfData(NestedIntType(IntType(32)), "foo")
+        ProtoBuf.encodeToHexString(OneOfData.serializer(), data).also {
+            println(it)
+            /**
+             * 7: {5: 32}
+             * 3: {"foo"}
+             */
+            assertEquals("3a0228201a03666f6f", it)
+        }
+    }
+
+    @Test
+    fun testDecodeNestedOneOf() {
+        val data = OneOfData(NestedIntType(IntType(32)), "foo")
+        ProtoBuf.decodeFromHexString<OneOfData>("3a0228201a03666f6f").also {
+            println(it)
+            assertEquals(data, it)
+        }
+    }
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -15,13 +15,13 @@ import kotlin.test.*
 class ProtobufOneOfTest {
     @Serializable
     data class OneOfData(
-        @ProtoOneOf(1, 2, 7, 8, 9) val i: IType,
+        @ProtoOneOf val i: IType,
         @ProtoNumber(3) val name: String
     )
 
     @Serializable
     data class OneOfDataNullable(
-        @ProtoOneOf(1, 2, 5) val i: IType?,
+        @ProtoOneOf val i: IType?,
         @ProtoNumber(3) val name: String
     )
 
@@ -207,7 +207,7 @@ class ProtobufOneOfTest {
     data class NestedOneOfType(val i: InnerNested) : IType
 
     @Serializable
-    data class InnerNested(@ProtoOneOf(1, 2) val i: InnerOneOf)
+    data class InnerNested(@ProtoOneOf val i: InnerOneOf)
 
     @Serializable
     sealed interface InnerOneOf
@@ -248,9 +248,9 @@ class ProtobufOneOfTest {
 
     @Serializable
     data class DoubleOneOfElement(
-        @ProtoOneOf(1, 2) val one: IType,
+        @ProtoOneOf val one: IType,
         @ProtoNumber(3) val name: String,
-        @ProtoOneOf(4, 5) val two: OtherType
+        @ProtoOneOf val two: OtherType
     )
 
     interface OtherType
@@ -351,7 +351,7 @@ class ProtobufOneOfTest {
     }
 
     @Serializable
-    data class FailWithClass(@ProtoOneOf(1) val i: IFailType, @ProtoNumber(3) val name: String)
+    data class FailWithClass(@ProtoOneOf val i: IFailType, @ProtoNumber(3) val name: String)
 
     @Serializable
     sealed interface IFailType
@@ -375,7 +375,7 @@ class ProtobufOneOfTest {
     }
 
     @Serializable
-    data class CustomOuter(@ProtoOneOf(1, 2) val inner: CustomInner)
+    data class CustomOuter(@ProtoOneOf val inner: CustomInner)
 
     @Serializable
     abstract class CustomInner
@@ -421,7 +421,7 @@ class ProtobufOneOfTest {
     }
 
     @Serializable
-    data class CustomAnyData(@ProtoOneOf(1, 2) @Polymorphic val inner: Any)
+    data class CustomAnyData(@ProtoOneOf @Polymorphic val inner: Any)
 
     @Test
     fun testCustomAny() {

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -49,7 +49,7 @@ class ProtobufOneOfTest {
     @Test
     fun testOneOfIntType() {
         val dataInt = OneOfData(IntType(42), "foo")
-        val intString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
+        val intString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataInt)
         /**
          * 5:VARINT 42
          * 3:LEN {"foo"}
@@ -60,7 +60,7 @@ class ProtobufOneOfTest {
     @Test
     fun testOneOfStringType() {
         val dataString = OneOfData(StringType("bar"), "foo")
-        val stringString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
+        val stringString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataString)
         /**
          * 6:LEN {"bar"}
          * 3:LEN {"foo"}
@@ -92,7 +92,6 @@ class ProtobufOneOfTest {
     fun testOneOfIntTypeNullable() {
         val dataInt = OneOfDataNullable(IntType(42), "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataInt).also {
-            println(it)
             /**
              * 5:VARINT 42
              * 3:LEN {"foo"}
@@ -106,7 +105,6 @@ class ProtobufOneOfTest {
     fun testOneOfStringTypeNullable() {
         val dataString = OneOfDataNullable(StringType("bar"), "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataString).also {
-            println(it)
             /**
              * 6:LEN {"bar"}
              * 3:LEN {"foo"}
@@ -115,7 +113,6 @@ class ProtobufOneOfTest {
         }
         val dataStringNull = OneOfDataNullable(null, "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataStringNull).also {
-            println(it)
             /**
              * 3:LEN {"foo"}
              */
@@ -199,7 +196,6 @@ class ProtobufOneOfTest {
     fun testEncodeNestedStruct() {
         val data = OneOfData(NestedIntType(IntType(32)), "foo")
         ProtoBuf.encodeToHexString(OneOfData.serializer(), data).also {
-            println(it)
             /**
              * 7:LEN {5:VARINT 32}
              * 3:LEN {"foo"}
@@ -216,7 +212,6 @@ class ProtobufOneOfTest {
          * 3:LEN {"foo"}
          */
         ProtoBuf.decodeFromHexString<OneOfData>("3a0228201a03666f6f").also {
-            println(it)
             assertEquals(data, it)
         }
     }
@@ -255,7 +250,6 @@ class ProtobufOneOfTest {
     fun testEncodeNestedOneOf() {
         val data = OneOfData(NestedOneOfType(i = InnerNested(InnerInt(32))), "foo")
         ProtoBuf.encodeToHexString(OneOfData.serializer(), data).also {
-            println(it)
             /**
              * 9:LEN {1:VARINT 32}
              * 3:LEN {"foo"}
@@ -272,7 +266,6 @@ class ProtobufOneOfTest {
          * 3:LEN {"foo"}
          */
         ProtoBuf.decodeFromHexString<OneOfData>("4a0208201a03666f6f").also {
-            println(it)
             /**
              * 9: {1: 32}
              * 3: {"foo"}
@@ -312,7 +305,6 @@ class ProtobufOneOfTest {
             OtherStringType("bar")
         )
         buf.encodeToHexString(DoubleOneOfElement.serializer(), data).also {
-            println(it)
             /**
              * 5:VARINT 32
              * 3:LEN {"foo"}
@@ -371,7 +363,7 @@ class ProtobufOneOfTest {
         val buf = ProtoBuf { serializersModule = module }
 
         val dataInt = OneOfData(IntType(42), "foo")
-        val intString = buf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
+        val intString = buf.encodeToHexString(OneOfData.serializer(), dataInt)
         /**
          * 5:VARINT 42
          * 3:LEN {"foo"}
@@ -379,7 +371,7 @@ class ProtobufOneOfTest {
         assertEquals("282a1a03666f6f", intString)
 
         val dataString = OneOfData(StringType("bar"), "foo")
-        val stringString = buf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
+        val stringString = buf.encodeToHexString(OneOfData.serializer(), dataString)
         /**
          * 6:LEN {"bar"}
          * 3:LEN {"foo"}
@@ -403,12 +395,16 @@ class ProtobufOneOfTest {
     @Test
     fun testFailWithClassEncoding() {
         val data = FailWithClass(FailIntType(42), "foo")
-        assertFailsWith<IllegalArgumentException> { ProtoBuf.encodeToHexString(FailWithClass.serializer(), data) }
+        assertFailsWithMessage<IllegalArgumentException>(
+            "Implementation of oneOf type kotlinx.serialization.protobuf.ProtobufOneOfTest.FailIntType should have @ProtoNumber annotation"
+        ) { ProtoBuf.encodeToHexString(FailWithClass.serializer(), data) }
     }
 
     @Test
     fun testFailWithClassDecoding() {
-        assertFailsWith<MissingFieldException> {
+        assertFailsWithMessage<IllegalArgumentException>(
+            "kotlinx.serialization.protobuf.ProtobufOneOfTest.FailIntType implementing oneOf type kotlinx.serialization.protobuf.ProtobufOneOfTest.IFailType should have @ProtoNumber annotation in its single property."
+        ) {
             ProtoBuf.decodeFromHexString<FailWithClass>(
                 /**
                  * 5:VARINT 42
@@ -511,7 +507,9 @@ class ProtobufOneOfTest {
             assertEquals("1a03666f6f182a", it)
         }
 
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWithMessage<IllegalArgumentException>(
+            "Duplicated proto number 3 in kotlinx.serialization.protobuf.ProtobufOneOfTest.DuplicatingIdData for elements: d, bad."
+        ) {
             /**
              * 3:LEN {"foo"}
              * 3:VARINT 42
@@ -576,7 +574,6 @@ class ProtobufOneOfTest {
     fun testTypedInt() {
         val fixed = TypedIntOuter(Fixed32Int(32))
         ProtoBuf.encodeToHexString(fixed).also {
-            println(it)
             /**
              * 2:I32 32i32
              */
@@ -590,7 +587,6 @@ class ProtobufOneOfTest {
         }
         val fixedLong = TypedIntOuter(Fixed32Long(30576774159))
         ProtoBuf.encodeToHexString(fixedLong).also {
-            println(it)
             /**
              * 3:VARINT 30576774159
              */
@@ -604,7 +600,6 @@ class ProtobufOneOfTest {
         }
         val signed = TypedIntOuter(SignedInt(32))
         ProtoBuf.encodeToHexString(signed).also {
-            println(it)
             /**
              * 4:VARINT 32
              */
@@ -618,7 +613,6 @@ class ProtobufOneOfTest {
         }
         val signedLong = TypedIntOuter(SignedLong(30576774159))
         ProtoBuf.encodeToHexString(signedLong).also {
-            println(it)
             /**
              * 5:VARINT 61153548318
              */
@@ -632,7 +626,6 @@ class ProtobufOneOfTest {
         }
         val default = TypedIntOuter(DefaultInt(32))
         ProtoBuf.encodeToHexString(default).also {
-            println(it)
             /**
              * 6:VARINT 32
              */
@@ -646,7 +639,6 @@ class ProtobufOneOfTest {
         }
         val defaultLong = TypedIntOuter(DefaultLong(30576774159))
         ProtoBuf.encodeToHexString(defaultLong).also {
-            println(it)
             /**
              * 7:VARINT 30576774159
              */

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -436,4 +436,29 @@ class ProtobufOneOfTest {
         assertEquals(data, buf.decodeFromHexString<CustomAnyData>("082a"))
     }
 
+    @Serializable
+    data class DuplicatingIdData(
+        @ProtoOneOf val bad: IDuplicatingIdType,
+        @ProtoNumber(3) val d: Int,
+    )
+
+    @Serializable sealed interface IDuplicatingIdType
+    @Serializable @ProtoNumber(3) data class DuplicatingIdStringType(val s: String) : IDuplicatingIdType
+
+    @Test
+    fun testDuplicatedIdClass() {
+        val duplicated = DuplicatingIdData(DuplicatingIdStringType("foo"), 42)
+        ProtoBuf.encodeToHexString(duplicated).also {
+            /**
+             * 3: {"foo"}
+             * 3: 42
+             */
+            assertEquals("1a03666f6f182a", it)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            ProtoBuf.decodeFromHexString<DuplicatingIdData>("1a03666f6f182a")
+        }
+    }
+
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -367,7 +367,7 @@ class ProtobufOneOfTest {
 
     @Test
     fun testFailWithClassDecoding() {
-        assertFailsWith<SerializationException> {
+        assertFailsWith<MissingFieldException> {
             ProtoBuf.decodeFromHexString<FailWithClass>(
                 "082a1a03666f6f"
             )

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 class ProtobufOneOfTest {
     @Serializable
     data class OneOfData(
-        @ProtoOneOf(1, 2, 7) val i: IType,
+        @ProtoOneOf(1, 2, 7, 8) val i: IType,
         @ProtoNumber(3) val name: String
     )
 
@@ -161,7 +161,7 @@ class ProtobufOneOfTest {
     }
 
     @Test
-    fun testEncodeNestedOneOf() {
+    fun testEncodeNestedStruct() {
         val data = OneOfData(NestedIntType(IntType(32)), "foo")
         ProtoBuf.encodeToHexString(OneOfData.serializer(), data).also {
             println(it)
@@ -174,11 +174,21 @@ class ProtobufOneOfTest {
     }
 
     @Test
-    fun testDecodeNestedOneOf() {
+    fun testDecodeNestedStruct() {
         val data = OneOfData(NestedIntType(IntType(32)), "foo")
         ProtoBuf.decodeFromHexString<OneOfData>("3a0228201a03666f6f").also {
             println(it)
             assertEquals(data, it)
         }
+    }
+
+    @Serializable
+    @ProtoNumber(8)
+    data class FailType(val i: Int, val j: Int) : IType
+
+    @Test
+    fun testOneOfElementCheck() {
+        val data = OneOfData(FailType(1, 2), "foo")
+        assertFailsWith<IllegalArgumentException> { ProtoBuf.encodeToHexString(OneOfData.serializer(), data) }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -50,8 +50,8 @@ class ProtobufOneOfTest {
         val dataInt = OneOfData(IntType(42), "foo")
         val intString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
         /**
-         * 5: 42
-         * 3: {"foo"}
+         * 5:VARINT 42
+         * 3:LEN {"foo"}
          */
         assertEquals("282a1a03666f6f", intString)
     }
@@ -61,20 +61,28 @@ class ProtobufOneOfTest {
         val dataString = OneOfData(StringType("bar"), "foo")
         val stringString = ProtoBuf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
         /**
-         * 6: {"bar"}
-         * 3: {"foo"}
+         * 6:LEN {"bar"}
+         * 3:LEN {"foo"}
          */
         assertEquals("32036261721a03666f6f", stringString)
     }
 
     @Test
     fun testOneOfDecodeStringType() {
+        /**
+         * 6:LEN {"bar"}
+         * 3:LEN {"foo"}
+         */
         val dataString = ProtoBuf.decodeFromHexString<OneOfData>("32036261721a03666f6f")
         assertEquals(OneOfData(StringType("bar"), "foo"), dataString)
     }
 
     @Test
     fun testOneOfDecodeIntType() {
+        /**
+         * 5:VARINT 42
+         * 3:LEN {"foo"}
+         */
         val dataInt = ProtoBuf.decodeFromHexString<OneOfData>("282a1a03666f6f")
         assertEquals(OneOfData(IntType(42), "foo"), dataInt)
     }
@@ -84,6 +92,10 @@ class ProtobufOneOfTest {
         val dataInt = OneOfDataNullable(IntType(42), "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataInt).also {
             println(it)
+            /**
+             * 5:VARINT 42
+             * 3:LEN {"foo"}
+             */
             assertEquals("282a1a03666f6f", it)
         }
 
@@ -94,13 +106,17 @@ class ProtobufOneOfTest {
         val dataString = OneOfDataNullable(StringType("bar"), "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataString).also {
             println(it)
+            /**
+             * 6:LEN {"bar"}
+             * 3:LEN {"foo"}
+             */
             assertEquals("32036261721a03666f6f", it)
         }
         val dataStringNull = OneOfDataNullable(null, "foo")
         ProtoBuf.encodeToHexString(OneOfDataNullable.serializer(), dataStringNull).also {
             println(it)
             /**
-             * 3: {"foo"}
+             * 3:LEN {"foo"}
              */
             assertEquals("1a03666f6f", it)
         }
@@ -108,12 +124,23 @@ class ProtobufOneOfTest {
 
     @Test
     fun testOneOfDecodeNullable() {
+        /**
+         * 6:LEN {"bar"}
+         * 3:LEN {"foo"}
+         */
         ProtoBuf.decodeFromHexString<OneOfDataNullable>("32036261721a03666f6f").let {
             assertEquals(OneOfDataNullable(StringType("bar"), "foo"), it)
         }
+        /**
+         * 5:VARINT 42
+         * 3:LEN {"foo"}
+         */
         ProtoBuf.decodeFromHexString<OneOfDataNullable>("282a1a03666f6f").let {
             assertEquals(OneOfDataNullable(IntType(42), "foo"), it)
         }
+        /**
+         * 3:LEN {"foo"}
+         */
         ProtoBuf.decodeFromHexString<OneOfDataNullable>("1a03666f6f").let {
             assertEquals(OneOfDataNullable(null, "foo"), it)
         }
@@ -173,8 +200,8 @@ class ProtobufOneOfTest {
         ProtoBuf.encodeToHexString(OneOfData.serializer(), data).also {
             println(it)
             /**
-             * 7: {5: 32}
-             * 3: {"foo"}
+             * 7:LEN {5:VARINT 32}
+             * 3:LEN {"foo"}
              */
             assertEquals("3a0228201a03666f6f", it)
         }
@@ -183,6 +210,10 @@ class ProtobufOneOfTest {
     @Test
     fun testDecodeNestedStruct() {
         val data = OneOfData(NestedIntType(IntType(32)), "foo")
+        /**
+         * 7:LEN {5:VARINT 32}
+         * 3:LEN {"foo"}
+         */
         ProtoBuf.decodeFromHexString<OneOfData>("3a0228201a03666f6f").also {
             println(it)
             assertEquals(data, it)
@@ -225,8 +256,8 @@ class ProtobufOneOfTest {
         ProtoBuf.encodeToHexString(OneOfData.serializer(), data).also {
             println(it)
             /**
-             * 9: {1: 32}
-             * 3: {"foo"}
+             * 9:LEN {1:VARINT 32}
+             * 3:LEN {"foo"}
              */
             assertEquals("4a0208201a03666f6f", it)
         }
@@ -235,6 +266,10 @@ class ProtobufOneOfTest {
     @Test
     fun testDecodeNestedOneOf() {
         val data = OneOfData(NestedOneOfType(i = InnerNested(InnerInt(32))), "foo")
+        /**
+         * 9:LEN {1:VARINT 32}
+         * 3:LEN {"foo"}
+         */
         ProtoBuf.decodeFromHexString<OneOfData>("4a0208201a03666f6f").also {
             println(it)
             /**
@@ -277,6 +312,11 @@ class ProtobufOneOfTest {
         )
         buf.encodeToHexString(DoubleOneOfElement.serializer(), data).also {
             println(it)
+            /**
+             * 5:VARINT 32
+             * 3:LEN {"foo"}
+             * 12:LEN {"bar"}
+             */
             assertEquals("28201a03666f6f6203626172", it)
         }
 
@@ -308,6 +348,11 @@ class ProtobufOneOfTest {
             "foo",
             OtherStringType("bar")
         )
+        /**
+         * 5:VARINT 32
+         * 3:LEN {"foo"}
+         * 12:LEN {"bar"}
+         */
         buf.decodeFromHexString<DoubleOneOfElement>("28201a03666f6f6203626172").also {
             assertEquals(data, it)
         }
@@ -327,16 +372,16 @@ class ProtobufOneOfTest {
         val dataInt = OneOfData(IntType(42), "foo")
         val intString = buf.encodeToHexString(OneOfData.serializer(), dataInt).also { println(it) }
         /**
-         * 5: 42
-         * 3: {"foo"}
+         * 5:VARINT 42
+         * 3:LEN {"foo"}
          */
         assertEquals("282a1a03666f6f", intString)
 
         val dataString = OneOfData(StringType("bar"), "foo")
         val stringString = buf.encodeToHexString(OneOfData.serializer(), dataString).also { println(it) }
         /**
-         * 6: {"bar"}
-         * 3: {"foo"}
+         * 6:LEN {"bar"}
+         * 3:LEN {"foo"}
          */
         assertEquals("32036261721a03666f6f", stringString)
         val stringData = buf.decodeFromHexString<OneOfData>(stringString)
@@ -364,6 +409,10 @@ class ProtobufOneOfTest {
     fun testFailWithClassDecoding() {
         assertFailsWith<MissingFieldException> {
             ProtoBuf.decodeFromHexString<FailWithClass>(
+                /**
+                 * 5:VARINT 42
+                 * 3:LEN {"foo"}
+                 */
                 "282a1a03666f6f"
             )
         }
@@ -414,6 +463,9 @@ class ProtobufOneOfTest {
         }
         val data = CustomOuter(CustomInnerInt(42))
         val buf = ProtoBuf { serializersModule = module }
+        /**
+         * 1:VARINT 42
+         */
         assertEquals("082a", buf.encodeToHexString(CustomOuter.serializer(), data))
     }
 
@@ -429,7 +481,9 @@ class ProtobufOneOfTest {
         }
         val data = CustomAnyData(CustomInnerInt(42))
         val buf = ProtoBuf { serializersModule = module }
-//        assertEquals("082a", buf.encodeToHexString(data))
+        /**
+         * 1:VARINT 42
+         */
         assertEquals(data, buf.decodeFromHexString<CustomAnyData>("082a"))
     }
 
@@ -449,13 +503,17 @@ class ProtobufOneOfTest {
         val duplicated = DuplicatingIdData(DuplicatingIdStringType("foo"), 42)
         ProtoBuf.encodeToHexString(duplicated).also {
             /**
-             * 3: {"foo"}
-             * 3: 42
+             * 3:LEN {"foo"}
+             * 3:VARINT 42
              */
             assertEquals("1a03666f6f182a", it)
         }
 
         assertFailsWith<IllegalArgumentException> {
+            /**
+             * 3:LEN {"foo"}
+             * 3:VARINT 42
+             */
             ProtoBuf.decodeFromHexString<DuplicatingIdData>("1a03666f6f182a")
         }
     }
@@ -516,57 +574,86 @@ class ProtobufOneOfTest {
         val fixed = TypedIntOuter(Fixed32Int(32))
         ProtoBuf.encodeToHexString(fixed).also {
             println(it)
-            // 2: 32i32
+            /**
+             * 2:I32 32i32
+             */
             assertEquals("1520000000", it)
         }
+        /**
+         * 2:I32 32i32
+         */
         ProtoBuf.decodeFromHexString<TypedIntOuter>("1520000000").also {
             assertEquals(fixed, it)
         }
         val fixedLong = TypedIntOuter(Fixed32Long(30576774159))
         ProtoBuf.encodeToHexString(fixedLong).also {
             println(it)
-            // 3: 30576774159
+            /**
+             * 3:VARINT 30576774159
+             */
             assertEquals("188f9892f471", it)
         }
+        /**
+         * 3:VARINT 30576774159
+         */
         ProtoBuf.decodeFromHexString<TypedIntOuter>("188f9892f471").also {
             assertEquals(fixedLong, it)
         }
         val signed = TypedIntOuter(SignedInt(32))
         ProtoBuf.encodeToHexString(signed).also {
             println(it)
-            // 4: 32
+            /**
+             * 4:VARINT 32
+             */
             assertEquals("2020", it)
         }
+        /**
+         * 4:VARINT 32
+         */
         ProtoBuf.decodeFromHexString<TypedIntOuter>("2020").also {
             assertEquals(signed, it)
         }
         val signedLong = TypedIntOuter(SignedLong(30576774159))
         ProtoBuf.encodeToHexString(signedLong).also {
             println(it)
-            // 5: 61153548318 As sint: 30576774159
+            /**
+             * 5:VARINT 61153548318
+             */
             assertEquals("289eb0a4e8e301", it)
         }
+        /**
+         * 5:VARINT 61153548318
+         */
         ProtoBuf.decodeFromHexString<TypedIntOuter>("289eb0a4e8e301").also {
             assertEquals(signedLong, it)
         }
         val default = TypedIntOuter(DefaultInt(32))
         ProtoBuf.encodeToHexString(default).also {
             println(it)
-            // 6: 32
+            /**
+             * 6:VARINT 32
+             */
             assertEquals("3020", it)
         }
+        /**
+         * 6:VARINT 32
+         */
         ProtoBuf.decodeFromHexString<TypedIntOuter>("3020").also {
             assertEquals(default, it)
         }
         val defaultLong = TypedIntOuter(DefaultLong(30576774159))
         ProtoBuf.encodeToHexString(defaultLong).also {
             println(it)
-            // 7: 30576774159
+            /**
+             * 7:VARINT 30576774159
+             */
             assertEquals("388f9892f471", it)
         }
+        /**
+         * 7:VARINT 30576774159
+         */
         ProtoBuf.decodeFromHexString<TypedIntOuter>("388f9892f471").also {
             assertEquals(defaultLong, it)
         }
     }
-
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -71,9 +71,13 @@ class ProtobufOneOfTest {
     }
 
     @Test
-    fun testOneOfDecode() {
+    fun testOneOfDecodeStringType() {
         val dataString = ProtoBuf.decodeFromHexString<OneOfData>("12036261721a03666f6f")
         assertEquals(OneOfData(StringType("bar"), "foo"), dataString)
+    }
+
+    @Test
+    fun testOneOfDecodeIntType() {
         val dataInt = ProtoBuf.decodeFromHexString<OneOfData>("082a1a03666f6f")
         assertEquals(OneOfData(IntType(42), "foo"), dataInt)
     }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.protobuf
 
 import kotlinx.serialization.*
+import kotlin.jvm.*
 import kotlin.test.*
 
 class ProtobufOneOfTest {
@@ -36,7 +37,8 @@ class ProtobufOneOfTest {
 
     @Serializable
     @ProtoNumber(2)
-    data class StringType(@ProtoNumber(6) val s: String) : IType
+    @JvmInline
+    value class StringType(@ProtoNumber(6) val s: String) : IType
 
     @Serializable
     @ProtoNumber(7)

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -308,4 +308,24 @@ class ProtobufOneOfTest {
         val intData = buf.decodeFromHexString<OneOfData>(intString)
         assertEquals(intData, dataInt)
     }
+
+    @Serializable
+    data class FailWithClass(@ProtoOneOf(1) val i: IFailType, @ProtoNumber(3) val name: String)
+
+    @Serializable
+    sealed interface IFailType
+
+    @Serializable data class FailIntType(val i: Int): IFailType
+
+    @Test
+    fun testFailWithClassEncoding() {
+        val data = FailWithClass(FailIntType(42), "foo")
+        assertFailsWith<IllegalArgumentException> { ProtoBuf.encodeToHexString(FailWithClass.serializer(), data) }
+    }
+
+    @Test
+    fun testFailWithClassDecoding() {
+        assertFailsWith<SerializationException> { ProtoBuf.decodeFromHexString<FailWithClass>("082a1a03666f6f") }
+    }
+
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -367,9 +367,7 @@ class ProtobufOneOfTest {
 
     @Test
     fun testFailWithClassDecoding() {
-        assertFailsWith<SerializationException>(
-            "Cannot find a subclass of kotlinx.serialization.protobuf.ProtobufOneOfTest.IFailType in property \"i\" annotated with @ProtoNumber(1)."
-        ) {
+        assertFailsWith<SerializationException> {
             ProtoBuf.decodeFromHexString<FailWithClass>(
                 "082a1a03666f6f"
             )

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -656,4 +656,27 @@ class ProtobufOneOfTest {
             assertEquals(defaultLong, it)
         }
     }
+
+    // @ProtoNumber(777) here should be ignored
+    @Serializable
+    data class Dummy(@ProtoNumber(777) @ProtoOneOf val i: DummyInterface)
+    @Serializable
+    sealed interface DummyInterface
+    @Serializable data class DummyInt(@ProtoNumber(1) val i: Int): DummyInterface
+    @Test
+    fun testDummyAnnotation() {
+        val data = Dummy(DummyInt(42))
+        ProtoBuf.encodeToHexString(data).also {
+            /**
+             * 1:VARINT 42
+             */
+            assertEquals("082a", it)
+        }
+        /**
+         * 1:VARINT 42
+         */
+        ProtoBuf.decodeFromHexString<Dummy>("082a").also {
+            assertEquals(data, it)
+        }
+    }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -418,4 +418,20 @@ class ProtobufOneOfTest {
         assertEquals("082a", buf.encodeToHexString(CustomOuter.serializer(), data))
     }
 
+    @Serializable
+    data class CustomAnyData(@ProtoOneOf(1, 2) @Polymorphic val inner: Any)
+
+    @Test
+    fun testCustomAny() {
+        val module = SerializersModule {
+            polymorphic(Any::class) {
+                subclass(CustomInnerInt::class, CustomerInnerIntSerializer)
+            }
+        }
+        val data = CustomAnyData(CustomInnerInt(42))
+        val buf = ProtoBuf { serializersModule = module }
+        assertEquals("082a", buf.encodeToHexString(data))
+        assertEquals(data, buf.decodeFromHexString<CustomAnyData>("082a"))
+    }
+
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -363,7 +363,13 @@ class ProtobufOneOfTest {
 
     @Test
     fun testFailWithClassDecoding() {
-        assertFailsWith<SerializationException> { ProtoBuf.decodeFromHexString<FailWithClass>("082a1a03666f6f") }
+        assertFailsWith<SerializationException>(
+            "Cannot find a subclass of kotlinx.serialization.protobuf.ProtobufOneOfTest.IFailType in property \"i\" annotated with @ProtoNumber(1)."
+        ) {
+            ProtoBuf.decodeFromHexString<FailWithClass>(
+                "082a1a03666f6f"
+            )
+        }
     }
 
     @Serializable

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -546,6 +546,7 @@ class ProtobufOneOfTest {
     @Test
     fun testDuplicatedIdClass() {
         val duplicated = DuplicatingIdData(DuplicatingIdStringType("foo"), 42)
+        // Fine to encode duplicated proto number properties in wire data
         ProtoBuf.encodeToHexString(duplicated).also {
             /**
              * 3:LEN {"foo"}
@@ -554,8 +555,11 @@ class ProtobufOneOfTest {
             assertEquals("1a03666f6f182a", it)
         }
 
+        // Without checking duplication of proto numbers,
+        // ProtoBuf just throw exception about wrong wire type
         assertFailsWithMessage<IllegalArgumentException>(
-            "Duplicated proto number 3 in kotlinx.serialization.protobuf.ProtobufOneOfTest.DuplicatingIdData for elements: d, bad."
+//            "Duplicated proto number 3 in kotlinx.serialization.protobuf.ProtobufOneOfTest.DuplicatingIdData for elements: d, bad."
+            "Expected wire type 0, but found 2"
         ) {
             /**
              * 3:LEN {"foo"}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctions.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctions.kt
@@ -18,3 +18,15 @@ inline fun <reified T> testConversion(data: T, expectedHexString: String) {
     assertEquals(expectedHexString, string)
     assertEquals(data, ProtoBuf.decodeFromHexString(string))
 }
+
+inline fun <reified T : Throwable> assertFailsWithMessage(
+    message: String,
+    assertionMessage: String? = null,
+    block: () -> Unit
+) {
+    val exception = assertFailsWith(T::class, assertionMessage, block)
+    assertTrue(
+        exception.message!!.contains(message),
+        "expected:<$message> but was:<${exception.message}>"
+    )
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -175,7 +175,7 @@ class SchemaValidationsTest {
         assertFailsWithMessage<IllegalArgumentException>(
             message = "Implementation of oneOf type kotlinx.serialization.protobuf.ProtobufOneOfTest.FailType should contain only 1 element, but get 2"
         ) {
-            ProtoBufSchemaGenerator.generateSchemaText(ProtobufOneOfTest.OneOfDataNullable.serializer().descriptor)
+            ProtoBufSchemaGenerator.generateSchemaText(ProtobufOneOfTest.FailOuter.serializer().descriptor)
         }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -143,7 +143,7 @@ class SchemaValidationsTest {
     @Serializable
     data class OneOfData(
         @ProtoNumber(1) val name: String,
-        @ProtoOneOf(2, 3, 4) val i: IType
+        @ProtoOneOf val i: IType
     )
 
     @Serializable

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -149,17 +149,14 @@ class SchemaValidationsTest {
     sealed interface IType
 
     @Serializable
-    @ProtoNumber(2)
-    data class IntType(@ProtoNumber(4) val intValue: Int): IType
+    data class IntType(@ProtoNumber(2) val intValue: Int): IType
 
     @Serializable
-    @ProtoNumber(3)
     @JvmInline
-    value class StringType(@ProtoNumber(5) val strValue: String): IType
+    value class StringType(@ProtoNumber(3) val strValue: String): IType
 
     @Serializable
-    @ProtoNumber(4)
-    data class WrapType(val content: InnerType): IType
+    data class WrapType(@ProtoNumber(4) val content: InnerType): IType
 
     @Serializable
     data class InnerType(val innerContent: String)
@@ -168,6 +165,7 @@ class SchemaValidationsTest {
     fun testOneOfGenerate() {
         val descriptors = listOf(OneOfData.serializer().descriptor)
         ProtoBufSchemaGenerator.generateSchemaText(descriptors).also {
+            println(it)
             assertContains(it, "oneof i")
             assertContains(it, "message InnerType")
             // oneof fields need no required keyword

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -2,6 +2,7 @@ package kotlinx.serialization.protobuf.schema
 
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
+import kotlin.jvm.*
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -137,5 +138,38 @@ class SchemaValidationsTest {
     fun testFieldNumberDuplicates() {
         assertFailsWith(IllegalArgumentException::class) { ProtoBufSchemaGenerator.generateSchemaText(listOf(FieldNumberDuplicates.serializer().descriptor)) }
         assertFailsWith(IllegalArgumentException::class) { ProtoBufSchemaGenerator.generateSchemaText(listOf(FieldNumberImplicitlyDuplicates.serializer().descriptor)) }
+    }
+
+    @Serializable
+    data class OneOfData(
+        @ProtoNumber(1) val name: String,
+        @ProtoOneOf(2, 3, 4) val i: IType
+    )
+
+    @Serializable
+    sealed interface IType
+
+    @Serializable
+    @ProtoNumber(2)
+    data class IntType(@ProtoNumber(4) val intValue: Int): IType
+
+    @Serializable
+    @ProtoNumber(3)
+    @JvmInline
+    value class StringType(@ProtoNumber(5) val strValue: String): IType
+
+    @Serializable
+    @ProtoNumber(4)
+    data class WrapType(val content: InnerType): IType
+
+    @Serializable
+    data class InnerType(val innerContent: String)
+
+    @Test
+    fun testOneOfGenerate() {
+        val descriptors = listOf(OneOfData.serializer().descriptor)
+        ProtoBufSchemaGenerator.generateSchemaText(descriptors).also {
+            println(it)
+        }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -173,5 +173,11 @@ class SchemaValidationsTest {
             // oneof fields need no required keyword
             assertTrue(it.contains("required int32").not())
         }
+
+        assertFailsWithMessage<IllegalArgumentException>(
+            message = "Implementation of oneOf type kotlinx.serialization.protobuf.ProtobufOneOfTest.FailType should contain only 1 element, but get 2"
+        ) {
+            ProtoBufSchemaGenerator.generateSchemaText(ProtobufOneOfTest.OneOfDataNullable.serializer().descriptor)
+        }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -3,8 +3,7 @@ package kotlinx.serialization.protobuf.schema
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
 import kotlin.jvm.*
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.*
 
 class SchemaValidationsTest {
     @Serializable
@@ -169,7 +168,8 @@ class SchemaValidationsTest {
     fun testOneOfGenerate() {
         val descriptors = listOf(OneOfData.serializer().descriptor)
         ProtoBufSchemaGenerator.generateSchemaText(descriptors).also {
-            println(it)
+            assertContains(it, "oneof i")
+            assertContains(it, "message InnerType")
         }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -170,6 +170,8 @@ class SchemaValidationsTest {
         ProtoBufSchemaGenerator.generateSchemaText(descriptors).also {
             assertContains(it, "oneof i")
             assertContains(it, "message InnerType")
+            // oneof fields need no required keyword
+            assertTrue(it.contains("required int32").not())
         }
     }
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -169,7 +169,7 @@ class SchemaValidationsTest {
             assertContains(it, "oneof i")
             assertContains(it, "message InnerType")
             // oneof fields need no required keyword
-            assertTrue(it.contains("required int32").not())
+            assertFalse(it.contains("required int32"))
         }
 
         assertFailsWithMessage<IllegalArgumentException>(

--- a/guide/example/example-formats-08.kt
+++ b/guide/example/example-formats-08.kt
@@ -4,14 +4,21 @@ package example.exampleFormats08
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
 
+// The outer class
 @Serializable
 data class Data(
     @ProtoNumber(1) val name: String,
     @ProtoOneOf val phone: IPhoneType,
 )
+
+// The oneof interface
 @Serializable sealed interface IPhoneType
-@Serializable @ProtoNumber(2) @JvmInline value class HomePhone(val number: String): IPhoneType
-@Serializable @ProtoNumber(3) data class WorkPhone(val number: String): IPhoneType
+
+// Message holder for home_phone
+@Serializable @JvmInline value class HomePhone(@ProtoNumber(2) val number: String): IPhoneType
+
+// Message holder for work_phone
+@Serializable data class WorkPhone(@ProtoNumber(3) val number: String): IPhoneType
 
 fun main() {
   val dataTom = Data("Tom", HomePhone("123"))

--- a/guide/example/example-formats-08.kt
+++ b/guide/example/example-formats-08.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.protobuf.*
 @Serializable
 data class Data(
     @ProtoNumber(1) val name: String,
-    @ProtoOneOf val phone: IPhoneType,
+    @ProtoOneOf val phone: IPhoneType?,
 )
 
 // The oneof interface

--- a/guide/example/example-formats-08.kt
+++ b/guide/example/example-formats-08.kt
@@ -17,7 +17,7 @@ data class Data(
 // Message holder for home_phone
 @Serializable @JvmInline value class HomePhone(@ProtoNumber(2) val number: String): IPhoneType
 
-// Message holder for work_phone
+// Message holder for work_phone. Can also be a value class, but we leave it as `data` to demonstrate that both variants can be used.
 @Serializable data class WorkPhone(@ProtoNumber(3) val number: String): IPhoneType
 
 fun main() {

--- a/guide/example/example-formats-08.kt
+++ b/guide/example/example-formats-08.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.protobuf.*
 @Serializable
 data class Data(
     @ProtoNumber(1) val name: String,
-    @ProtoOneOf(2, 3) val phone: IPhoneType,
+    @ProtoOneOf val phone: IPhoneType,
 )
 @Serializable sealed interface IPhoneType
 @Serializable @ProtoNumber(2) @JvmInline value class HomePhone(val number: String): IPhoneType

--- a/guide/example/example-formats-08.kt
+++ b/guide/example/example-formats-08.kt
@@ -3,16 +3,23 @@ package example.exampleFormats08
 
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
-import kotlinx.serialization.protobuf.schema.ProtoBufSchemaGenerator
 
 @Serializable
-data class SampleData(
-    val amount: Long,
-    val description: String?,
-    val department: String = "QA"
+data class Data(
+    @ProtoNumber(1) val name: String,
+    @ProtoOneOf(2, 3) val phone: IPhoneType,
 )
+@Serializable sealed interface IPhoneType
+@Serializable @ProtoNumber(2) @JvmInline value class HomePhone(val number: String): IPhoneType
+@Serializable @ProtoNumber(3) data class WorkPhone(val number: String): IPhoneType
+
 fun main() {
-  val descriptors = listOf(SampleData.serializer().descriptor)
-  val schemas = ProtoBufSchemaGenerator.generateSchemaText(descriptors)
-  println(schemas)
+  val dataTom = Data("Tom", HomePhone("123"))
+  val stringTom = ProtoBuf.encodeToHexString(dataTom)
+  val dataJerry = Data("Jerry", WorkPhone("789"))
+  val stringJerry = ProtoBuf.encodeToHexString(dataJerry)
+  println(stringTom)
+  println(stringJerry)
+  println(ProtoBuf.decodeFromHexString<Data>(stringTom))
+  println(ProtoBuf.decodeFromHexString<Data>(stringJerry))
 }

--- a/guide/example/example-formats-09.kt
+++ b/guide/example/example-formats-09.kt
@@ -1,6 +1,12 @@
 // This file was automatically generated from formats.md by Knit tool. Do not edit.
 package example.exampleFormats09
 
+@Serializable  
+data class Data2(  
+    @ProtoNumber(1) val name: String,  
+    @ProtoNumber(2) val homeNumber: String? = null,  
+    @ProtoNumber(3) val workNumber: String? = null,  
+)  
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
 import kotlinx.serialization.protobuf.schema.ProtoBufSchemaGenerator

--- a/guide/example/example-formats-09.kt
+++ b/guide/example/example-formats-09.kt
@@ -2,17 +2,17 @@
 package example.exampleFormats09
 
 import kotlinx.serialization.*
-import kotlinx.serialization.properties.Properties // todo: remove when no longer needed
-import kotlinx.serialization.properties.*
+import kotlinx.serialization.protobuf.*
+import kotlinx.serialization.protobuf.schema.ProtoBufSchemaGenerator
 
 @Serializable
-class Project(val name: String, val owner: User)
-
-@Serializable
-class User(val name: String)
-
+data class SampleData(
+    val amount: Long,
+    val description: String?,
+    val department: String = "QA"
+)
 fun main() {
-    val data = Project("kotlinx.serialization",  User("kotlin"))
-    val map = Properties.encodeToMap(data)
-    map.forEach { (k, v) -> println("$k = $v") }
+  val descriptors = listOf(SampleData.serializer().descriptor)
+  val schemas = ProtoBufSchemaGenerator.generateSchemaText(descriptors)
+  println(schemas)
 }

--- a/guide/example/example-formats-09.kt
+++ b/guide/example/example-formats-09.kt
@@ -1,12 +1,6 @@
 // This file was automatically generated from formats.md by Knit tool. Do not edit.
 package example.exampleFormats09
 
-@Serializable  
-data class Data2(  
-    @ProtoNumber(1) val name: String,  
-    @ProtoNumber(2) val homeNumber: String? = null,  
-    @ProtoNumber(3) val workNumber: String? = null,  
-)  
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
 import kotlinx.serialization.protobuf.schema.ProtoBufSchemaGenerator

--- a/guide/example/example-formats-10.kt
+++ b/guide/example/example-formats-10.kt
@@ -2,35 +2,17 @@
 package example.exampleFormats10
 
 import kotlinx.serialization.*
-import kotlinx.serialization.descriptors.*
-import kotlinx.serialization.encoding.*
-import kotlinx.serialization.modules.*
-
-class ListEncoder : AbstractEncoder() {
-    val list = mutableListOf<Any>()
-
-    override val serializersModule: SerializersModule = EmptySerializersModule()
-
-    override fun encodeValue(value: Any) {
-        list.add(value)
-    }
-}
-
-fun <T> encodeToList(serializer: SerializationStrategy<T>, value: T): List<Any> {
-    val encoder = ListEncoder()
-    encoder.encodeSerializableValue(serializer, value)
-    return encoder.list
-}
-
-inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value)
+import kotlinx.serialization.properties.Properties // todo: remove when no longer needed
+import kotlinx.serialization.properties.*
 
 @Serializable
-data class Project(val name: String, val owner: User, val votes: Int)
+class Project(val name: String, val owner: User)
 
 @Serializable
-data class User(val name: String)
+class User(val name: String)
 
 fun main() {
-    val data = Project("kotlinx.serialization",  User("kotlin"), 9000)
-    println(encodeToList(data))
+    val data = Project("kotlinx.serialization",  User("kotlin"))
+    val map = Properties.encodeToMap(data)
+    map.forEach { (k, v) -> println("$k = $v") }
 }

--- a/guide/example/example-formats-11.kt
+++ b/guide/example/example-formats-11.kt
@@ -24,29 +24,6 @@ fun <T> encodeToList(serializer: SerializationStrategy<T>, value: T): List<Any> 
 
 inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value)
 
-class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
-    private var elementIndex = 0
-
-    override val serializersModule: SerializersModule = EmptySerializersModule()
-
-    override fun decodeValue(): Any = list.removeFirst()
-    
-    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
-        if (elementIndex == descriptor.elementsCount) return CompositeDecoder.DECODE_DONE
-        return elementIndex++
-    }
-
-    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
-        ListDecoder(list)
-}
-
-fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>): T {
-    val decoder = ListDecoder(ArrayDeque(list))
-    return decoder.decodeSerializableValue(deserializer)
-}
-
-inline fun <reified T> decodeFromList(list: List<Any>): T = decodeFromList(list, serializer())
-
 @Serializable
 data class Project(val name: String, val owner: User, val votes: Int)
 
@@ -55,8 +32,5 @@ data class User(val name: String)
 
 fun main() {
     val data = Project("kotlinx.serialization",  User("kotlin"), 9000)
-    val list = encodeToList(data)
-    println(list)
-    val obj = decodeFromList<Project>(list)
-    println(obj)
+    println(encodeToList(data))
 }

--- a/guide/example/example-formats-12.kt
+++ b/guide/example/example-formats-12.kt
@@ -37,10 +37,8 @@ class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
-        ListDecoder(list) 
-
-    override fun decodeSequentially(): Boolean = true
-}        
+        ListDecoder(list)
+}
 
 fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>): T {
     val decoder = ListDecoder(ArrayDeque(list))

--- a/guide/example/example-formats-13.kt
+++ b/guide/example/example-formats-13.kt
@@ -13,12 +13,7 @@ class ListEncoder : AbstractEncoder() {
 
     override fun encodeValue(value: Any) {
         list.add(value)
-    }                               
-
-    override fun beginCollection(descriptor: SerialDescriptor, collectionSize: Int): CompositeEncoder {
-        encodeInt(collectionSize)
-        return this
-    }                                                
+    }
 }
 
 fun <T> encodeToList(serializer: SerializationStrategy<T>, value: T): List<Any> {
@@ -29,26 +24,23 @@ fun <T> encodeToList(serializer: SerializationStrategy<T>, value: T): List<Any> 
 
 inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value)
 
-class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
+class ListDecoder(val list: ArrayDeque<Any>) : AbstractDecoder() {
     private var elementIndex = 0
 
     override val serializersModule: SerializersModule = EmptySerializersModule()
 
     override fun decodeValue(): Any = list.removeFirst()
-
+    
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
-        if (elementIndex == elementsCount) return CompositeDecoder.DECODE_DONE
+        if (elementIndex == descriptor.elementsCount) return CompositeDecoder.DECODE_DONE
         return elementIndex++
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
-        ListDecoder(list, descriptor.elementsCount)
+        ListDecoder(list) 
 
     override fun decodeSequentially(): Boolean = true
-
-    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int =
-        decodeInt().also { elementsCount = it }
-}
+}        
 
 fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>): T {
     val decoder = ListDecoder(ArrayDeque(list))
@@ -58,13 +50,13 @@ fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>
 inline fun <reified T> decodeFromList(list: List<Any>): T = decodeFromList(list, serializer())
 
 @Serializable
-data class Project(val name: String, val owners: List<User>, val votes: Int)
+data class Project(val name: String, val owner: User, val votes: Int)
 
 @Serializable
 data class User(val name: String)
 
 fun main() {
-    val data = Project("kotlinx.serialization",  listOf(User("kotlin"), User("jetbrains")), 9000)
+    val data = Project("kotlinx.serialization",  User("kotlin"), 9000)
     val list = encodeToList(data)
     println(list)
     val obj = decodeFromList<Project>(list)

--- a/guide/example/example-formats-14.kt
+++ b/guide/example/example-formats-14.kt
@@ -19,9 +19,6 @@ class ListEncoder : AbstractEncoder() {
         encodeInt(collectionSize)
         return this
     }                                                
-
-    override fun encodeNull() = encodeValue("NULL")
-    override fun encodeNotNullMark() = encodeValue("!!")
 }
 
 fun <T> encodeToList(serializer: SerializationStrategy<T>, value: T): List<Any> {
@@ -34,7 +31,7 @@ inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value
 
 class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
-    
+
     override val serializersModule: SerializersModule = EmptySerializersModule()
 
     override fun decodeValue(): Any = list.removeFirst()
@@ -51,8 +48,6 @@ class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : Abstr
 
     override fun decodeCollectionSize(descriptor: SerialDescriptor): Int =
         decodeInt().also { elementsCount = it }
-
-    override fun decodeNotNullMark(): Boolean = decodeString() != "NULL"
 }
 
 fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>): T {
@@ -63,16 +58,15 @@ fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>
 inline fun <reified T> decodeFromList(list: List<Any>): T = decodeFromList(list, serializer())
 
 @Serializable
-data class Project(val name: String, val owner: User?, val votes: Int?)
+data class Project(val name: String, val owners: List<User>, val votes: Int)
 
 @Serializable
 data class User(val name: String)
 
 fun main() {
-    val data = Project("kotlinx.serialization",  User("kotlin") , null)
+    val data = Project("kotlinx.serialization",  listOf(User("kotlin"), User("jetbrains")), 9000)
     val list = encodeToList(data)
     println(list)
     val obj = decodeFromList<Project>(list)
     println(obj)
 }
-

--- a/guide/example/example-formats-15.kt
+++ b/guide/example/example-formats-15.kt
@@ -2,54 +2,42 @@
 package example.exampleFormats15
 
 import kotlinx.serialization.*
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.modules.*
-import java.io.*
 
-class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
+class ListEncoder : AbstractEncoder() {
+    val list = mutableListOf<Any>()
+
     override val serializersModule: SerializersModule = EmptySerializersModule()
-    override fun encodeBoolean(value: Boolean) = output.writeByte(if (value) 1 else 0)
-    override fun encodeByte(value: Byte) = output.writeByte(value.toInt())
-    override fun encodeShort(value: Short) = output.writeShort(value.toInt())
-    override fun encodeInt(value: Int) = output.writeInt(value)
-    override fun encodeLong(value: Long) = output.writeLong(value)
-    override fun encodeFloat(value: Float) = output.writeFloat(value)
-    override fun encodeDouble(value: Double) = output.writeDouble(value)
-    override fun encodeChar(value: Char) = output.writeChar(value.code)
-    override fun encodeString(value: String) = output.writeUTF(value)
-    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = output.writeInt(index)
+
+    override fun encodeValue(value: Any) {
+        list.add(value)
+    }                               
 
     override fun beginCollection(descriptor: SerialDescriptor, collectionSize: Int): CompositeEncoder {
         encodeInt(collectionSize)
         return this
-    }
+    }                                                
 
-    override fun encodeNull() = encodeBoolean(false)
-    override fun encodeNotNullMark() = encodeBoolean(true)
+    override fun encodeNull() = encodeValue("NULL")
+    override fun encodeNotNullMark() = encodeValue("!!")
 }
 
-fun <T> encodeTo(output: DataOutput, serializer: SerializationStrategy<T>, value: T) {
-    val encoder = DataOutputEncoder(output)
+fun <T> encodeToList(serializer: SerializationStrategy<T>, value: T): List<Any> {
+    val encoder = ListEncoder()
     encoder.encodeSerializableValue(serializer, value)
+    return encoder.list
 }
 
-inline fun <reified T> encodeTo(output: DataOutput, value: T) = encodeTo(output, serializer(), value)
+inline fun <reified T> encodeToList(value: T) = encodeToList(serializer(), value)
 
-class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : AbstractDecoder() {
+class ListDecoder(val list: ArrayDeque<Any>, var elementsCount: Int = 0) : AbstractDecoder() {
     private var elementIndex = 0
+    
     override val serializersModule: SerializersModule = EmptySerializersModule()
-    override fun decodeBoolean(): Boolean = input.readByte().toInt() != 0
-    override fun decodeByte(): Byte = input.readByte()
-    override fun decodeShort(): Short = input.readShort()
-    override fun decodeInt(): Int = input.readInt()
-    override fun decodeLong(): Long = input.readLong()
-    override fun decodeFloat(): Float = input.readFloat()
-    override fun decodeDouble(): Double = input.readDouble()
-    override fun decodeChar(): Char = input.readChar()
-    override fun decodeString(): String = input.readUTF()
-    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = input.readInt()
+
+    override fun decodeValue(): Any = list.removeFirst()
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         if (elementIndex == elementsCount) return CompositeDecoder.DECODE_DONE
@@ -57,38 +45,34 @@ class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : Abstr
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder =
-        DataInputDecoder(input, descriptor.elementsCount)
+        ListDecoder(list, descriptor.elementsCount)
 
     override fun decodeSequentially(): Boolean = true
 
     override fun decodeCollectionSize(descriptor: SerialDescriptor): Int =
         decodeInt().also { elementsCount = it }
 
-    override fun decodeNotNullMark(): Boolean = decodeBoolean()
+    override fun decodeNotNullMark(): Boolean = decodeString() != "NULL"
 }
 
-fun <T> decodeFrom(input: DataInput, deserializer: DeserializationStrategy<T>): T {
-    val decoder = DataInputDecoder(input)
+fun <T> decodeFromList(list: List<Any>, deserializer: DeserializationStrategy<T>): T {
+    val decoder = ListDecoder(ArrayDeque(list))
     return decoder.decodeSerializableValue(deserializer)
 }
 
-inline fun <reified T> decodeFrom(input: DataInput): T = decodeFrom(input, serializer())
-
-fun ByteArray.toAsciiHexString() = joinToString("") {
-    if (it in 32..127) it.toInt().toChar().toString() else
-        "{${it.toUByte().toString(16).padStart(2, '0').uppercase()}}"
-}
+inline fun <reified T> decodeFromList(list: List<Any>): T = decodeFromList(list, serializer())
 
 @Serializable
-data class Project(val name: String, val language: String)
+data class Project(val name: String, val owner: User?, val votes: Int?)
+
+@Serializable
+data class User(val name: String)
 
 fun main() {
-    val data = Project("kotlinx.serialization", "Kotlin")
-    val output = ByteArrayOutputStream()
-    encodeTo(DataOutputStream(output), data)
-    val bytes = output.toByteArray()
-    println(bytes.toAsciiHexString())
-    val input = ByteArrayInputStream(bytes)
-    val obj = decodeFrom<Project>(DataInputStream(input))
+    val data = Project("kotlinx.serialization",  User("kotlin") , null)
+    val list = encodeToList(data)
+    println(list)
+    val obj = decodeFromList<Project>(list)
     println(obj)
 }
+

--- a/guide/example/example-formats-17.kt
+++ b/guide/example/example-formats-17.kt
@@ -1,13 +1,14 @@
 // This file was automatically generated from formats.md by Knit tool. Do not edit.
-package example.exampleFormats16
+package example.exampleFormats17
 
 import kotlinx.serialization.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
-import kotlinx.serialization.encoding.*
 import kotlinx.serialization.modules.*
+import kotlinx.serialization.encoding.*
 import java.io.*
 
+private val byteArraySerializer = serializer<ByteArray>()
 class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
     override val serializersModule: SerializersModule = EmptySerializersModule()
     override fun encodeBoolean(value: Boolean) = output.writeByte(if (value) 1 else 0)
@@ -28,6 +29,27 @@ class DataOutputEncoder(val output: DataOutput) : AbstractEncoder() {
 
     override fun encodeNull() = encodeBoolean(false)
     override fun encodeNotNullMark() = encodeBoolean(true)
+
+    override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+        if (serializer.descriptor == byteArraySerializer.descriptor)
+            encodeByteArray(value as ByteArray)
+        else
+            super.encodeSerializableValue(serializer, value)
+    }
+
+    private fun encodeByteArray(bytes: ByteArray) {
+        encodeCompactSize(bytes.size)
+        output.write(bytes)
+    }
+    
+    private fun encodeCompactSize(value: Int) {
+        if (value < 0xff) {
+            output.writeByte(value)
+        } else {
+            output.writeByte(0xff)
+            output.writeInt(value)
+        }
+    }            
 }
 
 fun <T> encodeTo(output: DataOutput, serializer: SerializationStrategy<T>, value: T) {
@@ -65,6 +87,25 @@ class DataInputDecoder(val input: DataInput, var elementsCount: Int = 0) : Abstr
         decodeInt().also { elementsCount = it }
 
     override fun decodeNotNullMark(): Boolean = decodeBoolean()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>, previousValue: T?): T =
+        if (deserializer.descriptor == byteArraySerializer.descriptor)
+            decodeByteArray() as T
+        else
+            super.decodeSerializableValue(deserializer, previousValue)
+
+    private fun decodeByteArray(): ByteArray {
+        val bytes = ByteArray(decodeCompactSize())
+        input.readFully(bytes)
+        return bytes
+    }
+
+    private fun decodeCompactSize(): Int {
+        val byte = input.readByte().toInt() and 0xff
+        if (byte < 0xff) return byte
+        return input.readInt()
+    }
 }
 
 fun <T> decodeFrom(input: DataInput, deserializer: DeserializationStrategy<T>): T {
@@ -80,10 +121,10 @@ fun ByteArray.toAsciiHexString() = joinToString("") {
 }
 
 @Serializable
-data class Project(val name: String, val language: String)
+data class Project(val name: String, val attachment: ByteArray)
 
 fun main() {
-    val data = Project("kotlinx.serialization", "Kotlin")
+    val data = Project("kotlinx.serialization", byteArrayOf(0x0A, 0x0B, 0x0C, 0x0D))
     val output = ByteArrayOutputStream()
     encodeTo(DataOutputStream(output), data)
     val bytes = output.toByteArray()

--- a/guide/test/FormatsTest.kt
+++ b/guide/test/FormatsTest.kt
@@ -62,10 +62,20 @@ class FormatsTest {
     @Test
     fun testExampleFormats08() {
         captureOutput("ExampleFormats08") { example.exampleFormats08.main() }.verifyOutputLines(
+            "0a03546f6d1203313233",
+            "0a054a657272791a03373839",
+            "Data(name=Tom, phone=HomePhone(number=123))",
+            "Data(name=Jerry, phone=WorkPhone(number=789))"
+        )
+    }
+
+    @Test
+    fun testExampleFormats09() {
+        captureOutput("ExampleFormats09") { example.exampleFormats09.main() }.verifyOutputLines(
             "syntax = \"proto2\";",
             "",
             "",
-            "// serial name 'example.exampleFormats08.SampleData'",
+            "// serial name 'example.exampleFormats09.SampleData'",
             "message SampleData {",
             "  required int64 amount = 1;",
             "  optional string description = 2;",
@@ -77,25 +87,17 @@ class FormatsTest {
     }
 
     @Test
-    fun testExampleFormats09() {
-        captureOutput("ExampleFormats09") { example.exampleFormats09.main() }.verifyOutputLines(
+    fun testExampleFormats10() {
+        captureOutput("ExampleFormats10") { example.exampleFormats10.main() }.verifyOutputLines(
             "name = kotlinx.serialization",
             "owner.name = kotlin"
         )
     }
 
     @Test
-    fun testExampleFormats10() {
-        captureOutput("ExampleFormats10") { example.exampleFormats10.main() }.verifyOutputLines(
-            "[kotlinx.serialization, kotlin, 9000]"
-        )
-    }
-
-    @Test
     fun testExampleFormats11() {
         captureOutput("ExampleFormats11") { example.exampleFormats11.main() }.verifyOutputLines(
-            "[kotlinx.serialization, kotlin, 9000]",
-            "Project(name=kotlinx.serialization, owner=User(name=kotlin), votes=9000)"
+            "[kotlinx.serialization, kotlin, 9000]"
         )
     }
 
@@ -110,30 +112,38 @@ class FormatsTest {
     @Test
     fun testExampleFormats13() {
         captureOutput("ExampleFormats13") { example.exampleFormats13.main() }.verifyOutputLines(
-            "[kotlinx.serialization, 2, kotlin, jetbrains, 9000]",
-            "Project(name=kotlinx.serialization, owners=[User(name=kotlin), User(name=jetbrains)], votes=9000)"
+            "[kotlinx.serialization, kotlin, 9000]",
+            "Project(name=kotlinx.serialization, owner=User(name=kotlin), votes=9000)"
         )
     }
 
     @Test
     fun testExampleFormats14() {
         captureOutput("ExampleFormats14") { example.exampleFormats14.main() }.verifyOutputLines(
-            "[kotlinx.serialization, !!, kotlin, NULL]",
-            "Project(name=kotlinx.serialization, owner=User(name=kotlin), votes=null)"
+            "[kotlinx.serialization, 2, kotlin, jetbrains, 9000]",
+            "Project(name=kotlinx.serialization, owners=[User(name=kotlin), User(name=jetbrains)], votes=9000)"
         )
     }
 
     @Test
     fun testExampleFormats15() {
         captureOutput("ExampleFormats15") { example.exampleFormats15.main() }.verifyOutputLines(
-            "{00}{15}kotlinx.serialization{00}{06}Kotlin",
-            "Project(name=kotlinx.serialization, language=Kotlin)"
+            "[kotlinx.serialization, !!, kotlin, NULL]",
+            "Project(name=kotlinx.serialization, owner=User(name=kotlin), votes=null)"
         )
     }
 
     @Test
     fun testExampleFormats16() {
         captureOutput("ExampleFormats16") { example.exampleFormats16.main() }.verifyOutputLines(
+            "{00}{15}kotlinx.serialization{00}{06}Kotlin",
+            "Project(name=kotlinx.serialization, language=Kotlin)"
+        )
+    }
+
+    @Test
+    fun testExampleFormats17() {
+        captureOutput("ExampleFormats17") { example.exampleFormats17.main() }.verifyOutputLines(
             "{00}{15}kotlinx.serialization{04}{0A}{0B}{0C}{0D}",
             "Project(name=kotlinx.serialization, attachment=[10, 11, 12, 13])"
         )


### PR DESCRIPTION
It is an implementation of #2538 , to support `oneof` declaraction in protobuf.

Some major changes:

1. Introduce a new annotation `ProtoOneOf` to mark a property of class should be decoded and encoded in the oneof way.
2. `ProtoNumber` now can be attached to a class, to mark the proto id if such class is an implementation of oneof field.
3. `SealedClassSerializer.subclassSerializers` now is a public property, because when decoding message with oneof mark, I need to find the related serializer of concrete class with `ProtoNumber` annotation, assisted by change 2.

For change 3, there may be some other implementation to achieve it. For example, binding the proto id with specific serializer in `ProtoOneOf` annotation like

```kotlin
public annotation class ProtoOneOf(public vararg val numbers: ProtoOneOfPair)

public annotation class ProtoOneOfPair(public val number: Int, public val serializer: KClass<KSerializer<*>>)
```

But it may be tedious for user to write some super heavy tag for a property in data class, and hard to know that **the protoNumber annotated in oneof field has priority to number in inner proerty**. so current implementation became my choise.

If everything in this PR is OK, I will continue to update comments of code and docs.