### PR TITLE
Minor, move decodeDuration logic to a function reference

### DIFF
--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -109,11 +109,13 @@ public sealed class Hocon(
 
         private fun getTaggedNumber(tag: T) = validateAndCast<Number>(tag)
 
+        @Suppress("UNCHECKED_CAST")
+        protected fun <E> decodeDuration(tag: T): E =
+            getValueFromTaggedConfig(tag, ::decodeDurationImpl) as E
+
         @SuppressAnimalSniffer
-        protected fun <E> decodeDuration(tag: T): E {
-            @Suppress("UNCHECKED_CAST")
-            return getValueFromTaggedConfig(tag) { conf, path -> conf.decodeJavaDuration(path).toKotlinDuration() } as E
-        }
+        private fun decodeDurationImpl(conf: Config, path: String): Duration =
+            conf.decodeJavaDuration(path).toKotlinDuration()
 
         override fun decodeTaggedString(tag: T) = validateAndCast<String>(tag)
 


### PR DESCRIPTION
This is needed because once we enable indy lambdas by default (KT-45375), `@SuppressAnimalSniffer` annotation stops working, and the `animalsnifferMain` task reports several errors about `java.time.Duration` being used.

There are multiple ways to workaround this issue, for example we could annotate the lambda with `@JvmSerializableLambda` or compile the whole module with `-Xlambdas=class`, but I chose to use a simple function reference instead, since we don't generate those via invokedynamic yet (KT-45658), and it doesn't make the code any more difficult.