### PR TITLE
Align Kotlin Native targets with Kotlin documentation

### DIFF
--- a/gradle/native-targets.gradle
+++ b/gradle/native-targets.gradle
@@ -11,13 +11,14 @@ kotlin {
 
         // According to https://kotlinlang.org/docs/native-target-support.html
         // Tier 1
-        linuxX64()
         macosX64()
         macosArm64()
         iosSimulatorArm64()
         iosX64()
 
         // Tier 2
+        linuxX64()
+        linuxArm64()
         watchosSimulatorArm64()
         watchosX64()
         watchosArm32()
@@ -26,7 +27,6 @@ kotlin {
         tvosX64()
         tvosArm64()
         iosArm64()
-        linuxArm64()
 
         // Tier 3
         mingwX64()


### PR DESCRIPTION
This request aligns the Kotlin Native targets with the [Kotlin Native target support﻿](https://kotlinlang.org/docs/native-target-support.html) documentation by moving the `linuxX64` target to the tier 2 and by reordering targets of this tier.