### PR TITLE
Change priority for PolymorphicSerializer inside serializer() function

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -123,6 +123,8 @@ public abstract interface annotation class kotlinx/serialization/Serializer : ja
 }
 
 public final class kotlinx/serialization/SerializersKt {
+	public static final fun moduleThenPolymorphic (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
+	public static final fun moduleThenPolymorphic (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 	public static final fun noCompiledSerializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
 	public static final fun noCompiledSerializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;)Lkotlinx/serialization/KSerializer;
 	public static final fun noCompiledSerializer (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;

--- a/core/commonMain/src/kotlinx/serialization/SerializersCache.kt
+++ b/core/commonMain/src/kotlinx/serialization/SerializersCache.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.internal.*
 import kotlinx.serialization.internal.cast
 import kotlinx.serialization.internal.createCache
 import kotlinx.serialization.internal.createParametrizedCache
@@ -18,13 +19,13 @@ import kotlin.reflect.KType
  * Cache for non-null non-parametrized and non-contextual serializers.
  */
 @ThreadLocal
-private val SERIALIZERS_CACHE = createCache { it.serializerOrNull() }
+private val SERIALIZERS_CACHE = createCache { it.serializerOrNull() ?: it.polymorphicIfInterface() }
 
 /**
  * Cache for nullable non-parametrized and non-contextual serializers.
  */
 @ThreadLocal
-private val SERIALIZERS_CACHE_NULLABLE = createCache<Any?> { it.serializerOrNull()?.nullable?.cast() }
+private val SERIALIZERS_CACHE_NULLABLE = createCache<Any?> { (it.serializerOrNull() ?: it.polymorphicIfInterface())?.nullable?.cast() }
 
 /**
  * Cache for non-null parametrized and non-contextual serializers.
@@ -72,3 +73,6 @@ internal fun findParametrizedCachedSerializer(
         PARAMETRIZED_SERIALIZERS_CACHE_NULLABLE.get(clazz, types)
     }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun KClass<*>.polymorphicIfInterface() = if (this.isInterface()) PolymorphicSerializer(this) else null

--- a/core/commonMain/src/kotlinx/serialization/internal/Platform.common.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Platform.common.kt
@@ -141,6 +141,8 @@ internal expect fun BooleanArray.getChecked(index: Int): Boolean
 
 internal expect fun <T : Any> KClass<T>.compiledSerializerImpl(): KSerializer<T>?
 
+internal expect fun <T: Any> KClass<T>.isInterface(): Boolean
+
 /**
  * Create serializers cache for non-parametrized and non-contextual serializers.
  * The activity and type of cache is determined for a specific platform and a specific environment.

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -67,6 +67,9 @@ public sealed class SerializersModule {
      */
     @ExperimentalSerializationApi
     public abstract fun dumpTo(collector: SerializersModuleCollector)
+
+    @InternalSerializationApi
+    internal abstract val hasInterfaceContextualSerializers: Boolean
 }
 
 /**
@@ -76,7 +79,14 @@ public sealed class SerializersModule {
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("EmptySerializersModule()"))
 @JsName("EmptySerializersModuleLegacyJs") // Compatibility with JS
-public val EmptySerializersModule: SerializersModule = SerialModuleImpl(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap())
+public val EmptySerializersModule: SerializersModule = SerialModuleImpl(
+    emptyMap(),
+    emptyMap(),
+    emptyMap(),
+    emptyMap(),
+    emptyMap(),
+    false
+)
 
 /**
  * Returns a combination of two serial modules
@@ -147,7 +157,8 @@ internal class SerialModuleImpl(
     @JvmField val polyBase2Serializers: Map<KClass<*>, Map<KClass<*>, KSerializer<*>>>,
     private val polyBase2DefaultSerializerProvider: Map<KClass<*>, PolymorphicSerializerProvider<*>>,
     private val polyBase2NamedSerializers: Map<KClass<*>, Map<String, KSerializer<*>>>,
-    private val polyBase2DefaultDeserializerProvider: Map<KClass<*>, PolymorphicDeserializerProvider<*>>
+    private val polyBase2DefaultDeserializerProvider: Map<KClass<*>, PolymorphicDeserializerProvider<*>>,
+    internal override val hasInterfaceContextualSerializers: Boolean
 ) : SerializersModule() {
 
     override fun <T : Any> getPolymorphic(baseClass: KClass<in T>, value: T): SerializationStrategy<T>? {

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -49,6 +49,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
     private val polyBase2DefaultSerializerProvider: MutableMap<KClass<*>, PolymorphicSerializerProvider<*>> = hashMapOf()
     private val polyBase2NamedSerializers: MutableMap<KClass<*>, MutableMap<String, KSerializer<*>>> = hashMapOf()
     private val polyBase2DefaultDeserializerProvider: MutableMap<KClass<*>, PolymorphicDeserializerProvider<*>> = hashMapOf()
+    private var hasInterfaceContextualSerializers: Boolean = false
 
     /**
      * Adds [serializer] associated with given [kClass] for contextual serialization.
@@ -155,6 +156,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
             }
         }
         class2ContextualProvider[forClass] = provider
+        if (forClass.isInterface()) hasInterfaceContextualSerializers = true
     }
 
     @JvmName("registerDefaultPolymorphicSerializer") // Don't mangle method name for prettier stack traces
@@ -229,7 +231,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
 
     @PublishedApi
     internal fun build(): SerializersModule =
-        SerialModuleImpl(class2ContextualProvider, polyBase2Serializers, polyBase2DefaultSerializerProvider, polyBase2NamedSerializers, polyBase2DefaultDeserializerProvider)
+        SerialModuleImpl(class2ContextualProvider, polyBase2Serializers, polyBase2DefaultSerializerProvider, polyBase2NamedSerializers, polyBase2DefaultDeserializerProvider, hasInterfaceContextualSerializers)
 }
 
 /**

--- a/core/commonTest/src/kotlinx/serialization/InterfaceContextualSerializerTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/InterfaceContextualSerializerTest.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2017-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+import kotlinx.serialization.test.*
+import kotlin.reflect.*
+import kotlin.test.*
+
+// Imagine this is a 3rd party interface
+interface IApiError {
+    val code: Int
+}
+
+@Serializable(CustomSer::class)
+interface HasCustom
+
+
+object CustomSer: KSerializer<HasCustom> {
+    override val descriptor: SerialDescriptor
+        get() = TODO("Not yet implemented")
+
+    override fun serialize(encoder: Encoder, value: HasCustom) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deserialize(decoder: Decoder): HasCustom {
+        TODO("Not yet implemented")
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+class InterfaceContextualSerializerTest {
+
+    @Serializable
+    data class Box<T>(val boxed: T)
+
+    object MyApiErrorSerializer : KSerializer<IApiError> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("IApiError", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: IApiError) {
+            encoder.encodeInt(value.code)
+        }
+
+        override fun deserialize(decoder: Decoder): IApiError {
+            val code = decoder.decodeInt()
+            return object : IApiError {
+                override val code: Int = code
+            }
+        }
+    }
+
+    private inline fun <reified T> SerializersModule.doTest(block: (KSerializer<T>) -> Unit) {
+        block(this.serializer<T>())
+        block(this.serializer(typeOf<T>()) as KSerializer<T>)
+    }
+
+    // Native, WASM - can't retrieve serializer (no .isInterface)
+    @Test
+    fun testDefault() {
+        if (isNative() || isWasm()) return
+        assertEquals(PolymorphicKind.OPEN, serializer<IApiError>().descriptor.kind)
+        assertEquals(PolymorphicKind.OPEN, serializer(typeOf<IApiError>()).descriptor.kind)
+    }
+
+    @Test
+    fun testCustom() {
+        assertSame(CustomSer, serializer<HasCustom>())
+        assertSame(CustomSer, serializer(typeOf<HasCustom>()) as KSerializer<HasCustom>)
+    }
+
+    // JVM - intrinsics kick in
+    @Test
+    fun testContextual() {
+        val module = serializersModuleOf(IApiError::class, MyApiErrorSerializer)
+        assertSame(MyApiErrorSerializer, module.serializer(typeOf<IApiError>()) as KSerializer<IApiError>)
+        shouldFail<AssertionError>(beforeKotlin = "2.0.0", onJvm = true, onWasm = false, onNative = false, onJs = false ) {
+            assertSame(MyApiErrorSerializer, module.serializer<IApiError>())
+        }
+    }
+
+    // JVM - intrinsics kick in
+    @Test
+    fun testInsideList() {
+        val module = serializersModuleOf(IApiError::class, MyApiErrorSerializer)
+        assertEquals(MyApiErrorSerializer.descriptor, module.serializer(typeOf<List<IApiError>>()).descriptor.elementDescriptors.first())
+        shouldFail<AssertionError>(beforeKotlin = "2.0.0", onWasm = false, onNative = false, onJs = false ) {
+            assertEquals(
+                MyApiErrorSerializer.descriptor,
+                module.serializer<List<IApiError>>().descriptor.elementDescriptors.first()
+            )
+        }
+    }
+
+    @Test
+    fun testInsideBox() {
+        val module = serializersModuleOf(IApiError::class, MyApiErrorSerializer)
+        assertEquals(MyApiErrorSerializer.descriptor, module.serializer(typeOf<Box<IApiError>>()).descriptor.elementDescriptors.first())
+        shouldFail<AssertionError>(beforeKotlin = "2.0.0", onWasm = false, onNative = false, onJs = false ) {
+            assertEquals(
+                MyApiErrorSerializer.descriptor,
+                module.serializer<Box<IApiError>>().descriptor.elementDescriptors.first()
+            )
+        }
+    }
+
+    @Test
+    fun testWithNullability() {
+        val module = serializersModuleOf(IApiError::class, MyApiErrorSerializer)
+        assertEquals(MyApiErrorSerializer.nullable.descriptor, module.serializer(typeOf<IApiError?>()).descriptor)
+        shouldFail<AssertionError>(beforeKotlin = "2.0.0", onWasm = false, onNative = false, onJs = false ) {
+            assertEquals(MyApiErrorSerializer.nullable.descriptor, module.serializer<IApiError?>().descriptor)
+        }
+    }
+
+    @Test
+    fun testWithNullabilityInsideList() {
+        val module = serializersModuleOf(IApiError::class, MyApiErrorSerializer)
+        assertEquals(MyApiErrorSerializer.nullable.descriptor, module.serializer(typeOf<List<IApiError?>>()).descriptor.elementDescriptors.first())
+        shouldFail<AssertionError>(beforeKotlin = "2.0.0", onWasm = false, onNative = false, onJs = false ) {
+            assertEquals(
+                MyApiErrorSerializer.nullable.descriptor,
+                module.serializer<List<IApiError?>>().descriptor.elementDescriptors.first()
+            )
+        }
+    }
+
+    class Unrelated
+
+    object UnrelatedSerializer: KSerializer<Unrelated> {
+        override val descriptor: SerialDescriptor
+            get() = TODO("Not yet implemented")
+
+        override fun serialize(encoder: Encoder, value: Unrelated) {
+            TODO("Not yet implemented")
+        }
+
+        override fun deserialize(decoder: Decoder): Unrelated {
+            TODO("Not yet implemented")
+        }
+    }
+
+    @Test
+    fun interfaceSerializersAreCachedInsideIfModuleIsNotFilledWithInterface() = jvmOnly {
+        // Caches are implemented on JVM
+        val module = serializersModuleOf(Unrelated::class, UnrelatedSerializer)
+        val p1 = module.serializer(typeOf<List<IApiError>>())
+        assertEquals(PolymorphicKind.OPEN, p1.descriptor.elementDescriptors.first().kind)
+        val p2 = module.serializer(typeOf<List<IApiError>>())
+        assertSame(p1, p2)
+    }
+
+    @Test
+    fun interfaceSerializersAreCachedTopLevelIfModuleIsNotFilledWithInterface() = jvmOnly {
+        val module = serializersModuleOf(Unrelated::class, UnrelatedSerializer)
+        val p1 = module.serializer(typeOf<IApiError>())
+        assertEquals(PolymorphicKind.OPEN, p1.descriptor.kind)
+        val p2 = module.serializer(typeOf<IApiError>())
+        assertSame(p1, p2)
+    }
+
+    interface Parametrized<T> {
+        val param: List<T>
+    }
+
+    class PSer<T>(val tSer: KSerializer<T>): KSerializer<Parametrized<T>> {
+        override val descriptor: SerialDescriptor
+            get() = buildClassSerialDescriptor("PSer<${tSer.descriptor.serialName}>")
+
+        override fun serialize(encoder: Encoder, value: Parametrized<T>) {
+            TODO("Not yet implemented")
+        }
+
+        override fun deserialize(decoder: Decoder): Parametrized<T> {
+            TODO("Not yet implemented")
+        }
+    }
+
+    @Test
+    fun testParametrizedInterface() {
+        if (!isNative() && !isWasm()) {
+            assertEquals(PolymorphicKind.OPEN, serializer(typeOf<Parametrized<String>>()).descriptor.kind)
+        }
+        val md = SerializersModule {
+            contextual(Parametrized::class) { PSer(it[0]) }
+        }
+        assertEquals("PSer<kotlin.String>", md.serializer(typeOf<Parametrized<String>>()).descriptor.serialName)
+        shouldFail<AssertionError>(beforeKotlin = "2.0.0", onWasm = false, onNative = false, onJs = false ) {
+            assertEquals("PSer<kotlin.String>", md.serializer<Parametrized<String>>().descriptor.serialName)
+        }
+    }
+
+    @Serializable
+    sealed interface SealedI
+
+    @Test
+    fun sealedInterfacesAreNotAffected() {
+        val module = serializersModuleOf(IApiError::class, MyApiErrorSerializer)
+        module.doTest<SealedI> {
+            assertEquals(PolymorphicKind.SEALED, it.descriptor.kind)
+        }
+        module.doTest<List<SealedI>> {
+            assertEquals(PolymorphicKind.SEALED, it.descriptor.elementDescriptors.first().kind)
+        }
+        module.doTest<Box<SealedI>> {
+            assertEquals(PolymorphicKind.SEALED, it.descriptor.elementDescriptors.first().kind)
+        }
+    }
+
+    object SealedSer: KSerializer<SealedI> {
+        override val descriptor: SerialDescriptor
+            get() = PrimitiveSerialDescriptor("SealedSer", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: SealedI) {
+            TODO("Not yet implemented")
+        }
+
+        override fun deserialize(decoder: Decoder): SealedI {
+            TODO("Not yet implemented")
+        }
+    }
+
+    @Test
+    fun sealedInterfacesAreNotOverriden() {
+        val module = serializersModuleOf(SealedI::class, SealedSer)
+        module.doTest<SealedI> {
+            assertEquals(PolymorphicKind.SEALED, it.descriptor.kind)
+        }
+        module.doTest<List<SealedI>> {
+            assertEquals(PolymorphicKind.SEALED, it.descriptor.elementDescriptors.first().kind)
+        }
+        module.doTest<Box<SealedI>> {
+            assertEquals(PolymorphicKind.SEALED, it.descriptor.elementDescriptors.first().kind)
+        }
+    }
+}

--- a/core/commonTest/src/kotlinx/serialization/SerializersLookupNamedCompanionTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerializersLookupNamedCompanionTest.kt
@@ -88,12 +88,6 @@ class SerializersLookupNamedCompanionTest {
                 serializer(typeOf<SealedInterface>()).descriptor.toString()
             )
         }
-
-        // should fail because annotation @NamedCompanion will be placed again by the compilation plugin
-        // and they both will be placed into @Container annotation - thus they will be invisible to the runtime
-        shouldFail<SerializationException>(sinceKotlin = "1.9.20", onJs = false, onNative = false, onWasm = false) {
-            serializer(typeOf<SealedInterfaceWithExplicitAnnotation>())
-        }
     }
 
 

--- a/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
@@ -23,6 +23,8 @@ internal actual fun <T : Any> KClass<T>.compiledSerializerImpl(): KSerializer<T>
         else this.js.asDynamic().Companion?.serializer()
         ) as? KSerializer<T>
 
+internal actual fun <T: Any> KClass<T>.isInterface(): Boolean = isInterface
+
 internal actual fun <T> createCache(factory: (KClass<*>) -> KSerializer<T>?): SerializerCache<T> {
     return object: SerializerCache<T> {
         override fun get(key: KClass<Any>): KSerializer<T>? {
@@ -56,7 +58,6 @@ internal actual fun <T : Any> KClass<T>.constructSerializerForGivenTypeArgs(vara
         when {
             assocObject is KSerializer<*> -> assocObject as KSerializer<T>
             assocObject is SerializerFactory -> assocObject.serializer(*args) as KSerializer<T>
-            this.isInterface -> PolymorphicSerializer(this)
             else -> null
         }
     } catch (e: dynamic) {

--- a/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
@@ -19,7 +19,7 @@ internal actual fun BooleanArray.getChecked(index: Int): Boolean {
 
 internal actual fun <T : Any> KClass<T>.compiledSerializerImpl(): KSerializer<T>? =
     this.constructSerializerForGivenTypeArgs() ?: (
-        if (this === Nothing::class) NothingSerializer // Workaround for KT-51333
+        if (this === Nothing::class) NothingSerializer // .js throws an exception for Nothing
         else this.js.asDynamic().Companion?.serializer()
         ) as? KSerializer<T>
 
@@ -71,5 +71,9 @@ internal actual fun isReferenceArray(rootClass: KClass<Any>): Boolean = rootClas
  *
  * Should be eventually replaced with compiler intrinsics
  */
-private val KClass<*>.isInterface
-    get(): Boolean = js.asDynamic().`$metadata$`?.kind == "interface"
+private val KClass<*>.isInterface: Boolean
+    get(): Boolean {
+        // .js throws an exception for Nothing
+        if (this === Nothing::class) return false
+        return js.asDynamic().`$metadata$`?.kind == "interface"
+    }

--- a/core/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
+++ b/core/jvmMain/src/kotlinx/serialization/SerializersJvm.kt
@@ -168,7 +168,7 @@ private fun <T : Any> SerializersModule.reflectiveOrContextual(
 ): KSerializer<T>? {
     jClass.constructSerializerForGivenTypeArgs(*typeArgumentsSerializers.toTypedArray())?.let { return it }
     val kClass = jClass.kotlin
-    return kClass.builtinSerializerOrNull() ?: getContextual(kClass, typeArgumentsSerializers)
+    return kClass.builtinSerializerOrNull() ?: getContextual(kClass, typeArgumentsSerializers) ?: if (jClass.isInterface) PolymorphicSerializer(jClass.kotlin) else null
 }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/core/jvmTest/src/kotlinx/serialization/InterfaceContextualSerializerTestJvm.kt
+++ b/core/jvmTest/src/kotlinx/serialization/InterfaceContextualSerializerTestJvm.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+import kotlinx.serialization.test.*
+import kotlinx.serialization.test.shouldFail
+import org.junit.Test
+import kotlin.reflect.*
+import kotlin.test.*
+
+interface JApiError {
+    val code: Int
+}
+
+class InterfaceContextualSerializerTestJvm {
+    object MyApiErrorSerializer : KSerializer<JApiError> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JApiError", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: JApiError) {
+            encoder.encodeInt(value.code)
+        }
+
+        override fun deserialize(decoder: Decoder): JApiError {
+            val code = decoder.decodeInt()
+            return object : JApiError {
+                override val code: Int = code
+            }
+        }
+    }
+
+    @Test
+    fun testDefault() {
+        assertEquals(PolymorphicKind.OPEN, serializer(typeTokenOf<JApiError>()).descriptor.kind)
+    }
+
+    @Test
+    fun testContextual() {
+        val module = serializersModuleOf(JApiError::class, MyApiErrorSerializer)
+        assertSame(MyApiErrorSerializer, module.serializer(typeTokenOf<JApiError>()) as KSerializer<JApiError>)
+    }
+
+    @Test
+    fun testInsideList() {
+        val module = serializersModuleOf(JApiError::class, MyApiErrorSerializer)
+        assertSame(MyApiErrorSerializer.descriptor, module.serializer(typeTokenOf<List<JApiError>>()).descriptor.elementDescriptors.first())
+    }
+
+    interface Parametrized<T> {
+        val param: List<T>
+    }
+
+    class PSer<T>(val tSer: KSerializer<T>): KSerializer<Parametrized<T>> {
+        override val descriptor: SerialDescriptor
+            get() = buildClassSerialDescriptor("PSer<${tSer.descriptor.serialName}>")
+
+        override fun serialize(encoder: Encoder, value: Parametrized<T>) {
+            TODO("Not yet implemented")
+        }
+
+        override fun deserialize(decoder: Decoder): Parametrized<T> {
+            TODO("Not yet implemented")
+        }
+    }
+
+    @Test
+    fun testParametrizedInterface() {
+        assertEquals(PolymorphicKind.OPEN, serializer(typeTokenOf<Parametrized<String>>()).descriptor.kind)
+        val md = SerializersModule {
+            contextual(Parametrized::class) { PSer(it[0]) }
+        }
+        assertEquals("PSer<kotlin.String>", md.serializer(typeTokenOf<Parametrized<String>>()).descriptor.serialName)
+    }
+}

--- a/core/nativeMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/nativeMain/src/kotlinx/serialization/internal/Platform.kt
@@ -41,6 +41,7 @@ internal actual fun <T : Any> KClass<T>.constructSerializerForGivenTypeArgs(vara
 internal actual fun <T : Any> KClass<T>.compiledSerializerImpl(): KSerializer<T>? =
     this.constructSerializerForGivenTypeArgs()
 
+internal actual fun <T: Any> KClass<T>.isInterface(): Boolean = false // we do not know, but also PolymorphicSerializer is never returned on Native for interfaces
 
 internal actual fun <T> createCache(factory: (KClass<*>) -> KSerializer<T>?): SerializerCache<T> {
     return object: SerializerCache<T> {

--- a/core/wasmMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/wasmMain/src/kotlinx/serialization/internal/Platform.kt
@@ -40,6 +40,7 @@ internal actual fun <T : Any> KClass<T>.constructSerializerForGivenTypeArgs(vara
 internal actual fun <T : Any> KClass<T>.compiledSerializerImpl(): KSerializer<T>? =
     this.constructSerializerForGivenTypeArgs()
 
+internal actual fun <T: Any> KClass<T>.isInterface(): Boolean = false // we do not know, but also PolymorphicSerializer is never returned on WASM for interfaces
 
 internal actual fun <T> createCache(factory: (KClass<*>) -> KSerializer<T>?): SerializerCache<T> {
     return object: SerializerCache<T> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 #
 
 group=org.jetbrains.kotlinx
-version=1.6.4-SNAPSHOT
+version=1.7.0-SNAPSHOT
 
 kotlin.version=1.9.22
 

--- a/integration-test/gradle.properties
+++ b/integration-test/gradle.properties
@@ -3,7 +3,7 @@
 #
 
 mainKotlinVersion=1.9.22
-mainLibVersion=1.6.4-SNAPSHOT
+mainLibVersion=1.7.0-SNAPSHOT
 
 kotlin.code.style=official
 kotlin.js.compiler=ir


### PR DESCRIPTION
Now, we look up serializers for non-sealed interfaces in SerializersModule first, and only then unconditionally return PolymorphicSerializer. This is done because with old behavior, it was impossible to override interface serializer with context, as interfaces were treated as always having PolymorphicSerializer.

This is a behavioral change, although impact should be minimal, as for most usecases (without modules), serializer will be the same and special workarounds are performed so cache would also work as expected.

Note that KClass.serializer() function will no longer return PolymorphicSerializer for interfaces at all and return null instead. It is OK, because this function is marked with @InternalSerializationApi, and we can change its behavior.

Intrinsics in plugin with changed functionality are expected to be merged in 2.0.0-RC.

Fixes #2060