### PR TITLE
Added annotation to keep generated serializer when a custom one is specified

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -44,6 +44,9 @@ public abstract interface class kotlinx/serialization/KSerializer : kotlinx/seri
 	public abstract fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 }
 
+public abstract interface annotation class kotlinx/serialization/KeepGeneratedSerializer : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class kotlinx/serialization/MetaSerializable : java/lang/annotation/Annotation {
 }
 

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -325,6 +325,23 @@ public annotation class UseSerializers(vararg val serializerClasses: KClass<out 
 public annotation class Polymorphic
 
 /**
+ * Instructs the serialization plugin to generate serializer automatically generate implementation of [KSerializer]
+ * for the current class if a custom serializer is specified at the same time `@Serializable(with=SomeSerializer::class)`.
+ *
+ * Automatically generated serializer is available via `generatedSerializer()` function in companion object of serializable class.
+ *
+ * Generated serializers allow to use custom serializers on classes from which other serializable classes are inherited.
+ *
+ * Used only with the [Serializable] annotation.
+ *
+ * A compiler version `2.0.0` and higher is required.
+ */
+@InternalSerializationApi
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class KeepGeneratedSerializer
+
+/**
  * Marks declarations that are still **experimental** in kotlinx.serialization, which means that the design of the
  * corresponding declarations has open issues which may (or may not) lead to their changes in the future.
  * Roughly speaking, there is a chance that those declarations will be deprecated in the near future or

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -325,7 +325,7 @@ public annotation class UseSerializers(vararg val serializerClasses: KClass<out 
 public annotation class Polymorphic
 
 /**
- * Instructs the serialization plugin to generate serializer automatically generate implementation of [KSerializer]
+ * Instructs the serialization plugin to keep automatically generated implementation of [KSerializer]
  * for the current class if a custom serializer is specified at the same time `@Serializable(with=SomeSerializer::class)`.
  *
  * Automatically generated serializer is available via `generatedSerializer()` function in companion object of serializable class.


### PR DESCRIPTION
If the @KeepGeneratedSerializer annotation is specified on the class, and a custom serializer is specified, then keep to generate a plugin serializer.

Resolves #1169