### PR TITLE
Fix AbstractKotlinCompile.ownModuleName usage

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -126,13 +126,14 @@ object Java9Modularity {
             source(sourceFile)
             destinationDirectory.set(temporaryDir)
             multiPlatformEnabled.set(compileTask.multiPlatformEnabled)
-            kotlinOptions {
-                moduleName = compileTask.kotlinOptions.moduleName
-                jvmTarget = "9"
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_9)
                 // To support LV override when set in aggregate builds
-                languageVersion = compileTask.kotlinOptions.languageVersion
-                freeCompilerArgs += listOf("-Xjdk-release=9",  "-Xsuppress-version-warnings", "-Xexpect-actual-classes")
-                options.optIn.addAll(compileTask.kotlinOptions.options.optIn)
+                languageVersion.set(compileTask.compilerOptions.languageVersion)
+                freeCompilerArgs.addAll(
+                    listOf("-Xjdk-release=9",  "-Xsuppress-version-warnings", "-Xexpect-actual-classes")
+                )
+                optIn.addAll(compileTask.kotlinOptions.options.optIn)
             }
             // work-around for https://youtrack.jetbrains.com/issue/KT-60583
             inputs.files(

--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -112,8 +112,8 @@ object Java9Modularity {
         val verifyModuleTaskName = "verify${compileTask.name.removePrefix("compile").capitalize()}Module"
         // work-around for https://youtrack.jetbrains.com/issue/KT-60542
         val verifyModuleTask = plugins
-            .findPlugin(KotlinBaseApiPlugin::class)!!
-            .registerKotlinJvmCompileTask(verifyModuleTaskName)
+            .getPlugin(KotlinBaseApiPlugin::class)
+            .registerKotlinJvmCompileTask(verifyModuleTaskName, compileTask.compilerOptions.moduleName.get())
         verifyModuleTask {
             group = VERIFICATION_GROUP
             description = "Verify Kotlin sources for JPMS problems"


### PR DESCRIPTION
This task input is going to be removed via [KT-64504](https://youtrack.jetbrains.com/issue/KT-64504/Remove-ownModuleName-from-AbstractKotlinCompile)