### PR TITLE
Actualize lenient mode documentation

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -95,7 +95,7 @@ It gives the following nice result:
 ### Lenient parsing
 
 By default, [Json] parser enforces various JSON restrictions to be as specification-compliant as possible
-(see [RFC-4627]). Particularly, keys must be quoted, while literals must be unquoted. Those restrictions can be relaxed with
+(see [RFC-4627]). Particularly, keys and string literals must be quoted. Those restrictions can be relaxed with
 the [isLenient][JsonBuilder.isLenient] property. With `isLenient = true`, you can parse quite freely-formatted data:
 
 ```kotlin

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -254,11 +254,10 @@ public class JsonBuilder internal constructor(json: Json) {
 
     /**
      * Removes JSON specification restriction (RFC-4627) and makes parser
-     * more liberal to the malformed input. In lenient mode quoted boolean literals,
-     * and unquoted string literals are allowed.
+     * more liberal to the malformed input. In lenient mode, unquoted JSON keys and string values are allowed.
      *
      * Its relaxations can be expanded in the future, so that lenient parser becomes even more
-     * permissive to invalid value in the input, replacing them with defaults.
+     * permissive to invalid values in the input.
      *
      * `false` by default.
      */


### PR DESCRIPTION
Because after #2440 quoted boolean values are allowed by default, and quoted numbers were allowed even before that.