### PR TITLE
Better approach to configuring common sources for KotlinJvmCompile task

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -161,12 +161,15 @@ object Java9Modularity {
                     .find { it.name == "ownModuleName" }
                     ?.get(this) as? Property<String>
                 ownModuleNameProp?.set(compileTask.kotlinOptions.moduleName)
+            }
+
+            val taskKotlinLanguageVersion = compilerOptions.languageVersion.orElse(KotlinVersion.DEFAULT)
+            @OptIn(InternalKotlinGradlePluginApi::class)
+            if (taskKotlinLanguageVersion.get() < KotlinVersion.KOTLIN_2_0) {
                 // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
                 @Suppress("INVISIBLE_MEMBER")
                 commonSourceSet.from(compileTask.commonSourceSet)
-            }
-            @OptIn(InternalKotlinGradlePluginApi::class)
-            apply {
+            } else {
                 multiplatformStructure.refinesEdges.set(compileTask.multiplatformStructure.refinesEdges)
                 multiplatformStructure.fragments.set(compileTask.multiplatformStructure.fragments)
             }


### PR DESCRIPTION
Kotlin's language version 2.0 has a new model to compile common/shared sources which requires more fine-grained task configuration. For language versions lower than 2.0, task configuration is different and all common sources should be set as input.

This change should fix the following error:
```
Declaration annotated with '@OptionalExpectation' can only be used in common module sources
```