### PR TITLE
Support using an integer as the class/case discriminator in polymorphic serialization

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -69,6 +69,7 @@ public final class kotlinx/serialization/PolymorphicSerializer : kotlinx/seriali
 public final class kotlinx/serialization/PolymorphicSerializerKt {
 	public static final fun findPolymorphicSerializer (Lkotlinx/serialization/internal/AbstractPolymorphicSerializer;Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
 	public static final fun findPolymorphicSerializer (Lkotlinx/serialization/internal/AbstractPolymorphicSerializer;Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
+	public static final fun findPolymorphicSerializerWithNumber (Lkotlinx/serialization/internal/AbstractPolymorphicSerializer;Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/Integer;)Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public abstract interface annotation class kotlinx/serialization/Required : java/lang/annotation/Annotation {
@@ -79,6 +80,7 @@ public final class kotlinx/serialization/SealedClassSerializer : kotlinx/seriali
 	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;[Ljava/lang/annotation/Annotation;)V
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
+	public fun findPolymorphicSerializerWithNumberOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/Integer;)Lkotlinx/serialization/DeserializationStrategy;
 	public fun getBaseClass ()Lkotlin/reflect/KClass;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 }
@@ -97,6 +99,21 @@ public abstract interface annotation class kotlinx/serialization/SerialInfo : ja
 
 public abstract interface annotation class kotlinx/serialization/SerialName : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract interface annotation class kotlinx/serialization/SerialPolymorphicNumber : java/lang/annotation/Annotation {
+	public abstract fun baseClass ()Ljava/lang/Class;
+	public abstract fun number ()I
+}
+
+public abstract interface annotation class kotlinx/serialization/SerialPolymorphicNumber$Container : java/lang/annotation/Annotation {
+	public abstract fun value ()[Lkotlinx/serialization/SerialPolymorphicNumber;
+}
+
+public synthetic class kotlinx/serialization/SerialPolymorphicNumber$Impl : kotlinx/serialization/SerialPolymorphicNumber {
+	public fun <init> (Lkotlin/reflect/KClass;I)V
+	public final synthetic fun baseClass ()Ljava/lang/Class;
+	public final synthetic fun number ()I
 }
 
 public abstract interface annotation class kotlinx/serialization/Serializable : java/lang/annotation/Annotation {
@@ -151,6 +168,13 @@ public final class kotlinx/serialization/UnknownFieldException : kotlinx/seriali
 
 public abstract interface annotation class kotlinx/serialization/UseContextualSerialization : java/lang/annotation/Annotation {
 	public abstract fun forClasses ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class kotlinx/serialization/UseSerialPolymorphicNumbers : java/lang/annotation/Annotation {
+}
+
+public synthetic class kotlinx/serialization/UseSerialPolymorphicNumbers$Impl : kotlinx/serialization/UseSerialPolymorphicNumbers {
+	public fun <init> ()V
 }
 
 public abstract interface annotation class kotlinx/serialization/UseSerializers : java/lang/annotation/Annotation {
@@ -280,6 +304,9 @@ public abstract interface class kotlinx/serialization/descriptors/SerialDescript
 	public abstract fun getElementsCount ()I
 	public abstract fun getKind ()Lkotlinx/serialization/descriptors/SerialKind;
 	public abstract fun getSerialName ()Ljava/lang/String;
+	public abstract fun getSerialPolymorphicNumberByBaseClass ()Ljava/util/Map;
+	public abstract fun getSerialPolymorphicNumberByBaseClass (Lkotlin/reflect/KClass;)I
+	public abstract fun getUseSerialPolymorphicNumbers ()Z
 	public abstract fun isElementOptional (I)Z
 	public abstract fun isInline ()Z
 	public abstract fun isNullable ()Z
@@ -287,6 +314,9 @@ public abstract interface class kotlinx/serialization/descriptors/SerialDescript
 
 public final class kotlinx/serialization/descriptors/SerialDescriptor$DefaultImpls {
 	public static fun getAnnotations (Lkotlinx/serialization/descriptors/SerialDescriptor;)Ljava/util/List;
+	public static fun getSerialPolymorphicNumberByBaseClass (Lkotlinx/serialization/descriptors/SerialDescriptor;)Ljava/util/Map;
+	public static fun getSerialPolymorphicNumberByBaseClass (Lkotlinx/serialization/descriptors/SerialDescriptor;Lkotlin/reflect/KClass;)I
+	public static fun getUseSerialPolymorphicNumbers (Lkotlinx/serialization/descriptors/SerialDescriptor;)Z
 	public static fun isInline (Lkotlinx/serialization/descriptors/SerialDescriptor;)Z
 	public static fun isNullable (Lkotlinx/serialization/descriptors/SerialDescriptor;)Z
 }
@@ -561,6 +591,7 @@ public abstract class kotlinx/serialization/internal/AbstractPolymorphicSerializ
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
+	public fun findPolymorphicSerializerWithNumberOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/Integer;)Lkotlinx/serialization/DeserializationStrategy;
 	public abstract fun getBaseClass ()Lkotlin/reflect/KClass;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
@@ -958,7 +989,7 @@ public final class kotlinx/serialization/internal/PluginExceptionsKt {
 	public static final fun throwMissingFieldException (IILkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
-public class kotlinx/serialization/internal/PluginGeneratedSerialDescriptor : kotlinx/serialization/descriptors/SerialDescriptor, kotlinx/serialization/internal/CachedNames {
+public class kotlinx/serialization/internal/PluginGeneratedSerialDescriptor : kotlinx/serialization/internal/CachedNames {
 	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V
 	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addElement (Ljava/lang/String;Z)V
@@ -975,8 +1006,6 @@ public class kotlinx/serialization/internal/PluginGeneratedSerialDescriptor : ko
 	public fun getSerialNames ()Ljava/util/Set;
 	public fun hashCode ()I
 	public fun isElementOptional (I)Z
-	public fun isInline ()Z
-	public fun isNullable ()Z
 	public final fun pushAnnotation (Ljava/lang/annotation/Annotation;)V
 	public final fun pushClassAnnotation (Ljava/lang/annotation/Annotation;)V
 	public fun toString ()Ljava/lang/String;
@@ -1286,6 +1315,7 @@ public final class kotlinx/serialization/modules/PolymorphicModuleBuilder {
 	public final fun buildTo (Lkotlinx/serialization/modules/SerializersModuleBuilder;)V
 	public final fun default (Lkotlin/jvm/functions/Function1;)V
 	public final fun defaultDeserializer (Lkotlin/jvm/functions/Function1;)V
+	public final fun defaultDeserializerForNumber (Lkotlin/jvm/functions/Function1;)V
 	public final fun subclass (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 }
 
@@ -1296,6 +1326,7 @@ public abstract class kotlinx/serialization/modules/SerializersModule {
 	public static synthetic fun getContextual$default (Lkotlinx/serialization/modules/SerializersModule;Lkotlin/reflect/KClass;Ljava/util/List;ILjava/lang/Object;)Lkotlinx/serialization/KSerializer;
 	public abstract fun getPolymorphic (Lkotlin/reflect/KClass;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
 	public abstract fun getPolymorphic (Lkotlin/reflect/KClass;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
+	public abstract fun getPolymorphicWithNumber (Lkotlin/reflect/KClass;Ljava/lang/Integer;)Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class kotlinx/serialization/modules/SerializersModuleBuilder : kotlinx/serialization/modules/SerializersModuleCollector {
@@ -1307,6 +1338,7 @@ public final class kotlinx/serialization/modules/SerializersModuleBuilder : kotl
 	public fun polymorphic (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public fun polymorphicDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 	public fun polymorphicDefaultDeserializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun polymorphicDefaultDeserializerForNumber (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 	public fun polymorphicDefaultSerializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 
@@ -1324,6 +1356,7 @@ public abstract interface class kotlinx/serialization/modules/SerializersModuleC
 	public abstract fun polymorphic (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public abstract fun polymorphicDefault (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun polymorphicDefaultDeserializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun polymorphicDefaultDeserializerForNumber (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun polymorphicDefaultSerializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -155,22 +155,23 @@ public annotation class SerialName(val value: String)
 /**
  * Requires all subclasses to use [SerialPolymorphicNumber].
  */
-@MustBeDocumented
+@SerialInfo
 @Target(AnnotationTarget.CLASS)
-@Repeatable
+@ExperimentalSerializationApi
 public annotation class UseSerialPolymorphicNumbers
 
 /**
  * When its parent class is annotated with [UseSerialPolymorphicNumbers],
  * overrides its [String]-typed serial name when serialized as a subclass of the parent class in [baseClass]
  * (including the value overridden by [SerialName] if set)
- * with a [Int]-typed number in [value].
+ * with a [Int]-typed number in [number].
  *
  * Using a number instead of a string shortens the size of the serialized message, especially in a binary format.
  */
-@MustBeDocumented
+@SerialInfo
 @Target(AnnotationTarget.CLASS)
 @Repeatable
+@ExperimentalSerializationApi
 public annotation class SerialPolymorphicNumber(val baseClass: KClass<*>, val number: Int)
 
 /**

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -153,7 +153,7 @@ public annotation class Serializer(
 public annotation class SerialName(val value: String)
 
 /**
- * Requires all subclasses to use [SerialPolymorphicNumber].
+ * Requires all subclasses marked with this annotation to use [SerialPolymorphicNumber].
  */
 @SerialInfo
 @Target(AnnotationTarget.CLASS)

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -153,6 +153,27 @@ public annotation class Serializer(
 public annotation class SerialName(val value: String)
 
 /**
+ * Requires all subclasses to use [SerialPolymorphicNumber].
+ */
+@MustBeDocumented
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+public annotation class UseSerialPolymorphicNumbers
+
+/**
+ * When its parent class is annotated with [UseSerialPolymorphicNumbers],
+ * overrides its [String]-typed serial name when serialized as a subclass of the parent class in [baseClass]
+ * (including the value overridden by [SerialName] if set)
+ * with a [Int]-typed number in [value].
+ *
+ * Using a number instead of a string shortens the size of the serialized message, especially in a binary format.
+ */
+@MustBeDocumented
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+public annotation class SerialPolymorphicNumber(val baseClass: KClass<*>, val value: Int)
+
+/**
  * Indicates that property must be present during deserialization process, despite having a default value.
  */
 @MustBeDocumented

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -171,7 +171,7 @@ public annotation class UseSerialPolymorphicNumbers
 @MustBeDocumented
 @Target(AnnotationTarget.CLASS)
 @Repeatable
-public annotation class SerialPolymorphicNumber(val baseClass: KClass<*>, val value: Int)
+public annotation class SerialPolymorphicNumber(val baseClass: KClass<*>, val number: Int)
 
 /**
  * Indicates that property must be present during deserialization process, despite having a default value.

--- a/core/commonMain/src/kotlinx/serialization/PolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/PolymorphicSerializer.kt
@@ -102,6 +102,13 @@ public fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicSerializer(
     findPolymorphicSerializerOrNull(decoder, klassName) ?: throwSubtypeNotRegistered(klassName, baseClass)
 
 @InternalSerializationApi
+public fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicSerializerWithNumber(
+    decoder: CompositeDecoder,
+    serialPolymorphicNumber: Int?
+): DeserializationStrategy<T> =
+    findPolymorphicSerializerWithNumberOrNull(decoder, serialPolymorphicNumber) ?: throwSubtypeNotRegistered(serialPolymorphicNumber, baseClass)
+
+@InternalSerializationApi
 public fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicSerializer(
     encoder: Encoder,
     value: T

--- a/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -144,7 +144,7 @@ public class SealedClassSerializer<T : Any>(
     private val serialPolymorphicNumber2Serializer: Map<Int, KSerializer<out T>>? by lazy(LazyThreadSafetyMode.PUBLICATION) {
         if (descriptor.useSerialPolymorphicNumbers)
             class2Serializer.entries.groupingBy {
-                it.value.descriptor.serialPolymorphicNumberByBaseClass.getValue(baseClass)
+                it.value.descriptor.getSerialPolymorphicNumberByBaseClass(baseClass)
             }
                 .aggregate<Map.Entry<KClass<out T>, KSerializer<out T>>, Int, Map.Entry<KClass<*>, KSerializer<out T>>>
                 { key, accumulator, element, _ ->

--- a/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -127,7 +127,6 @@ public class SealedClassSerializer<T : Any>(
         // Plugin should produce identical serializers, although they are not always strictly equal (e.g. new ObjectSerializer
         // may be created every time)
         class2Serializer = subclasses.zip(subclassSerializers).toMap()
-
         serialName2Serializer = class2Serializer.entries.groupingBy { it.value.descriptor.serialName }
             .aggregate<Map.Entry<KClass<out T>, KSerializer<out T>>, String, Map.Entry<KClass<*>, KSerializer<out T>>>
             { key, accumulator, element, _ ->

--- a/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -117,7 +117,6 @@ public class SealedClassSerializer<T : Any>(
 
     private val class2Serializer: Map<KClass<out T>, KSerializer<out T>>
     private val serialName2Serializer: Map<String, KSerializer<out T>>
-    private val serialPolymorphicNumber2Serializer : Map<Int, KSerializer<out T>>?
 
     init {
         if (subclasses.size != subclassSerializers.size) {
@@ -140,8 +139,10 @@ public class SealedClassSerializer<T : Any>(
                 }
                 element
             }.mapValues { it.value.value }
+    }
 
-        serialPolymorphicNumber2Serializer = if (descriptor.useSerialPolymorphicNumbers)
+    private val serialPolymorphicNumber2Serializer: Map<Int, KSerializer<out T>>? by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        if (descriptor.useSerialPolymorphicNumbers)
             class2Serializer.entries.groupingBy {
                 it.value.descriptor.serialPolymorphicNumberByBaseClass.getValue(baseClass)
             }

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
@@ -208,6 +208,13 @@ public interface SerialDescriptor {
     @ExperimentalSerializationApi
     public val serialPolymorphicNumberByBaseClass: Map<KClass<*>, Int> get() = emptyMap()
 
+    @ExperimentalSerializationApi
+    public fun getSerialPolymorphicNumberByBaseClass(baseClass: KClass<*>): Int =
+        serialPolymorphicNumberByBaseClass.getOrElse(baseClass) {
+            throw SerializationException("The serial polymorphic number for $serialName in the scope of ${baseClass.simpleName} is not found. " +
+                "Please annotate the class with `@SerialPolymorphicNumber` with the first argument ${baseClass.simpleName}.")
+        }
+
     /**
      * Returns serial annotations of the associated class.
      * Serial annotations can be used to specify an additional metadata that may be used during serialization.

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.descriptors
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.encoding.*
+import kotlin.reflect.*
 
 /**
  * Serial descriptor is an inherent property of [KSerializer] that describes the structure of the serializable type.
@@ -194,6 +195,18 @@ public interface SerialDescriptor {
      */
     @ExperimentalSerializationApi
     public val elementsCount: Int
+
+    /**
+     * TODO
+     */
+    @ExperimentalSerializationApi
+    public val useSerialPolymorphicNumbers: Boolean get() = false
+
+    /**
+     * TODO
+     */
+    @ExperimentalSerializationApi
+    public val serialPolymorphicNumberByBaseClass: Map<KClass<*>, Int> get() = emptyMap()
 
     /**
      * Returns serial annotations of the associated class.

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -53,8 +53,6 @@ import kotlin.reflect.*
 public fun buildClassSerialDescriptor(
     serialName: String,
     vararg typeParameters: SerialDescriptor,
-    useSerialPolymorphicNumbers: Boolean = false,
-    serialPolymorphicNumbers: Map<KClass<*>, Int> = emptyMap(),
     builderAction: ClassSerialDescriptorBuilder.() -> Unit = {}
 ): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
@@ -65,8 +63,6 @@ public fun buildClassSerialDescriptor(
         StructureKind.CLASS,
         sdBuilder.elementNames.size,
         typeParameters.toList(),
-        useSerialPolymorphicNumbers,
-        serialPolymorphicNumbers,
         sdBuilder
     )
 }
@@ -143,23 +139,13 @@ public fun buildSerialDescriptor(
     serialName: String,
     kind: SerialKind,
     vararg typeParameters: SerialDescriptor,
-    useSerialPolymorphicNumbers: Boolean = false,
-    serialPolymorphicNumbers: Map<KClass<*>, Int> = emptyMap(),
     builder: ClassSerialDescriptorBuilder.() -> Unit = {}
 ): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
     require(kind != StructureKind.CLASS) { "For StructureKind.CLASS please use 'buildClassSerialDescriptor' instead" }
     val sdBuilder = ClassSerialDescriptorBuilder(serialName)
     sdBuilder.builder()
-    return SerialDescriptorImpl(
-        serialName,
-        kind,
-        sdBuilder.elementNames.size,
-        typeParameters.toList(),
-        useSerialPolymorphicNumbers,
-        serialPolymorphicNumbers,
-        sdBuilder
-    )
+    return SerialDescriptorImpl(serialName, kind, sdBuilder.elementNames.size, typeParameters.toList(), sdBuilder)
 }
 
 
@@ -322,8 +308,6 @@ internal class SerialDescriptorImpl(
     override val kind: SerialKind,
     override val elementsCount: Int,
     typeParameters: List<SerialDescriptor>,
-    override val useSerialPolymorphicNumbers : Boolean,
-    override val serialPolymorphicNumberByBaseClass : Map<KClass<*>, Int>,
     builder: ClassSerialDescriptorBuilder
 ) : SerialDescriptor, CachedNames {
 

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -49,7 +49,6 @@ import kotlin.reflect.*
  * }
  * ```
  */
-@Suppress("FunctionName")
 @OptIn(ExperimentalSerializationApi::class)
 public fun buildClassSerialDescriptor(
     serialName: String,

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -54,6 +54,8 @@ import kotlin.reflect.*
 public fun buildClassSerialDescriptor(
     serialName: String,
     vararg typeParameters: SerialDescriptor,
+    useSerialPolymorphicNumbers: Boolean = false,
+    serialPolymorphicNumbers: Map<KClass<*>, Int> = emptyMap(),
     builderAction: ClassSerialDescriptorBuilder.() -> Unit = {}
 ): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
@@ -64,6 +66,8 @@ public fun buildClassSerialDescriptor(
         StructureKind.CLASS,
         sdBuilder.elementNames.size,
         typeParameters.toList(),
+        useSerialPolymorphicNumbers,
+        serialPolymorphicNumbers,
         sdBuilder
     )
 }
@@ -140,13 +144,23 @@ public fun buildSerialDescriptor(
     serialName: String,
     kind: SerialKind,
     vararg typeParameters: SerialDescriptor,
+    useSerialPolymorphicNumbers: Boolean = false,
+    serialPolymorphicNumbers: Map<KClass<*>, Int> = emptyMap(),
     builder: ClassSerialDescriptorBuilder.() -> Unit = {}
 ): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
     require(kind != StructureKind.CLASS) { "For StructureKind.CLASS please use 'buildClassSerialDescriptor' instead" }
     val sdBuilder = ClassSerialDescriptorBuilder(serialName)
     sdBuilder.builder()
-    return SerialDescriptorImpl(serialName, kind, sdBuilder.elementNames.size, typeParameters.toList(), sdBuilder)
+    return SerialDescriptorImpl(
+        serialName,
+        kind,
+        sdBuilder.elementNames.size,
+        typeParameters.toList(),
+        useSerialPolymorphicNumbers,
+        serialPolymorphicNumbers,
+        sdBuilder
+    )
 }
 
 
@@ -309,6 +323,8 @@ internal class SerialDescriptorImpl(
     override val kind: SerialKind,
     override val elementsCount: Int,
     typeParameters: List<SerialDescriptor>,
+    override val useSerialPolymorphicNumbers : Boolean,
+    override val serialPolymorphicNumberByBaseClass : Map<KClass<*>, Int>,
     builder: ClassSerialDescriptorBuilder
 ) : SerialDescriptor, CachedNames {
 

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -309,7 +309,7 @@ internal class SerialDescriptorImpl(
     override val elementsCount: Int,
     typeParameters: List<SerialDescriptor>,
     builder: ClassSerialDescriptorBuilder
-) : SerialDescriptor, CachedNames {
+) : CommonSerialDescriptor(), CachedNames {
 
     override val annotations: List<Annotation> = builder.annotations
     override val serialNames: Set<String> = builder.elementNames.toHashSet()

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -36,7 +36,6 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
                 encodeIntElement(
                     descriptor,
                     0,
-                    // it seems not possible to cache this with the current implementation that serializers are completely separated from serializers modules
                     actualSerializer.descriptor.serialPolymorphicNumberByBaseClass.getValue(baseClass)
                 )
             else

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -143,11 +143,11 @@ internal fun throwSubtypeNotRegistered(serialPolymorphicNumber: Int?, baseClass:
     throw SerializationException(
         (
             if (serialPolymorphicNumber == null)
-                "Class discriminator serial polymorphic number was missing and no default serializers were registered $scope."
+                "Class discriminator (serial polymorphic number) was missing and no default serializers were registered $scope."
             else
-                "Serializer for subclass serial polymorphic number '$serialPolymorphicNumber' is not found $scope.\n" +
+                "Serializer for subclass serial polymorphic number '$serialPolymorphicNumber' is not found in $scope.\n" +
                     "Check if class with serial polymorphic number '$serialPolymorphicNumber' exists and serializer is registered in a corresponding SerializersModule.\n" +
-                    "To be registered automatically, class annotated with '@SerialPolymorphicNumber($serialPolymorphicNumber)' has to be '@Serializable', and the base class '${baseClass.simpleName}' has to be sealed and '@Serializable'.\n"
+                    "To be registered automatically, class annotated with '@SerialPolymorphicNumber($serialPolymorphicNumber)' has to be '@Serializable', and the base class '${baseClass.simpleName}' marked with `@UseSerialPolymorphicNumbers` has to be sealed and '@Serializable'.\n"
             ) +
             "\nRemove the `@UseSerialPolymorphicNumbers` annotation from the base class `${baseClass.simpleName}` if you want to switch back to polymorphic serialization using the serial name strings."
     )

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -34,9 +34,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
         encoder.encodeStructure(descriptor) {
             if (descriptor.useSerialPolymorphicNumbers)
                 encodeIntElement(
-                    descriptor,
-                    0,
-                    actualSerializer.descriptor.serialPolymorphicNumberByBaseClass.getValue(baseClass)
+                    descriptor, 0, actualSerializer.descriptor.getSerialPolymorphicNumberByBaseClass(baseClass)
                 )
             else
                 encodeStringElement(descriptor, 0, actualSerializer.descriptor.serialName)

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.internal
 import kotlinx.serialization.*
 import kotlinx.serialization.encoding.*
 import kotlin.jvm.*
+import kotlin.properties.*
 import kotlin.reflect.*
 
 /**
@@ -31,13 +32,22 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
     public final override fun serialize(encoder: Encoder, value: T) {
         val actualSerializer = findPolymorphicSerializer(encoder, value)
         encoder.encodeStructure(descriptor) {
-            encodeStringElement(descriptor, 0, actualSerializer.descriptor.serialName)
+            if (descriptor.useSerialPolymorphicNumbers)
+                encodeIntElement(
+                    descriptor,
+                    0,
+                    // it seems not possible to cache this with the current implementation that serializers are completely separated from serializers modules
+                    actualSerializer.descriptor.serialPolymorphicNumberByBaseClass.getValue(baseClass)
+                )
+            else
+                encodeStringElement(descriptor, 0, actualSerializer.descriptor.serialName)
             encodeSerializableElement(descriptor, 1, actualSerializer.cast(), value)
         }
     }
 
     public final override fun deserialize(decoder: Decoder): T = decoder.decodeStructure(descriptor) {
         var klassName: String? = null
+        var serialPolymorphicNumber: Int? = null
         var value: Any? = null
         if (decodeSequentially()) {
             return@decodeStructure decodeSequentially(this)
@@ -48,14 +58,25 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
                 CompositeDecoder.DECODE_DONE -> {
                     break@mainLoop
                 }
+
                 0 -> {
-                    klassName = decodeStringElement(descriptor, index)
+                    if (descriptor.useSerialPolymorphicNumbers)
+                        serialPolymorphicNumber = decodeIntElement(descriptor, index)
+                    else
+                        klassName = decodeStringElement(descriptor, index)
                 }
+
                 1 -> {
-                    klassName = requireNotNull(klassName) { "Cannot read polymorphic value before its type token" }
-                    val serializer = findPolymorphicSerializer(this, klassName)
+                    val serializer = if (descriptor.useSerialPolymorphicNumbers) {
+                        requireNotNull(serialPolymorphicNumber) { "Cannot read polymorphic value before its type token" }
+                        findPolymorphicSerializerWithNumber(this, serialPolymorphicNumber)
+                    } else {
+                        requireNotNull(klassName) { "Cannot read polymorphic value before its type token" }
+                        findPolymorphicSerializer(this, klassName)
+                    }
                     value = decodeSerializableElement(descriptor, index, serializer)
                 }
+
                 else -> throw SerializationException(
                     "Invalid index in polymorphic deserialization of " +
                         (klassName ?: "unknown class") +
@@ -83,6 +104,16 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
         klassName: String?
     ): DeserializationStrategy<T>? = decoder.serializersModule.getPolymorphic(baseClass, klassName)
 
+    /**
+     * TODO
+     */
+    @InternalSerializationApi
+    public open fun findPolymorphicSerializerWithNumberOrNull(
+        decoder: CompositeDecoder,
+        serialPolymorphicNumber: Int?
+    ): DeserializationStrategy<T>? =
+        decoder.serializersModule.getPolymorphicWithNumber(baseClass, serialPolymorphicNumber)
+
 
     /**
      * Lookups an actual serializer for given [value] within the current [base class][baseClass].
@@ -106,6 +137,22 @@ internal fun throwSubtypeNotRegistered(subClassName: String?, baseClass: KClass<
             "Serializer for subclass '$subClassName' is not found $scope.\n" +
                 "Check if class with serial name '$subClassName' exists and serializer is registered in a corresponding SerializersModule.\n" +
                 "To be registered automatically, class '$subClassName' has to be '@Serializable', and the base class '${baseClass.simpleName}' has to be sealed and '@Serializable'."
+    )
+}
+
+@JvmName("throwSubtypeNotRegistered")
+internal fun throwSubtypeNotRegistered(serialPolymorphicNumber: Int?, baseClass: KClass<*>): Nothing {
+    val scope = "in the polymorphic scope of '${baseClass.simpleName}'"
+    throw SerializationException(
+        (
+            if (serialPolymorphicNumber == null)
+                "Class discriminator serial polymorphic number was missing and no default serializers were registered $scope."
+            else
+                "Serializer for subclass serial polymorphic number '$serialPolymorphicNumber' is not found $scope.\n" +
+                    "Check if class with serial polymorphic number '$serialPolymorphicNumber' exists and serializer is registered in a corresponding SerializersModule.\n" +
+                    "To be registered automatically, class annotated with '@SerialPolymorphicNumber($serialPolymorphicNumber)' has to be '@Serializable', and the base class '${baseClass.simpleName}' has to be sealed and '@Serializable'.\n"
+            ) +
+            "\nRemove the `@UseSerialPolymorphicNumbers` annotation from the base class `${baseClass.simpleName}` if you want to switch back to polymorphic serialization using the serial name strings."
     )
 }
 

--- a/core/commonMain/src/kotlinx/serialization/internal/CommonSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/CommonSerialDescriptor.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.internal
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlin.reflect.*
+
+internal abstract class CommonSerialDescriptor : SerialDescriptor {
+    @ExperimentalSerializationApi
+    override val useSerialPolymorphicNumbers: Boolean by lazy { super.useSerialPolymorphicNumbers }
+
+    @ExperimentalSerializationApi
+    override val serialPolymorphicNumberByBaseClass: Map<KClass<*>, Int> by lazy { super.serialPolymorphicNumberByBaseClass }
+}

--- a/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -8,6 +8,7 @@ package kotlinx.serialization.internal
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
+import kotlin.reflect.*
 
 /**
  * Implementation that plugin uses to implement descriptors for auto-generated serializers.
@@ -17,7 +18,9 @@ import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 internal open class PluginGeneratedSerialDescriptor(
     override val serialName: String,
     private val generatedSerializer: GeneratedSerializer<*>? = null,
-    final override val elementsCount: Int
+    final override val elementsCount: Int,
+    override val useSerialPolymorphicNumbers: Boolean = false,
+    override val serialPolymorphicNumberByBaseClass: Map<KClass<*>, Int> = emptyMap()
 ) : SerialDescriptor, CachedNames {
     override val kind: SerialKind get() = StructureKind.CLASS
     override val annotations: List<Annotation> get() = classAnnotations ?: emptyList()

--- a/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -8,7 +8,6 @@ package kotlinx.serialization.internal
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
-import kotlin.reflect.*
 
 /**
  * Implementation that plugin uses to implement descriptors for auto-generated serializers.
@@ -18,10 +17,8 @@ import kotlin.reflect.*
 internal open class PluginGeneratedSerialDescriptor(
     override val serialName: String,
     private val generatedSerializer: GeneratedSerializer<*>? = null,
-    final override val elementsCount: Int,
-    override val useSerialPolymorphicNumbers: Boolean = false,
-    override val serialPolymorphicNumberByBaseClass: Map<KClass<*>, Int> = emptyMap()
-) : SerialDescriptor, CachedNames {
+    final override val elementsCount: Int
+) : CommonSerialDescriptor(), CachedNames {
     override val kind: SerialKind get() = StructureKind.CLASS
     override val annotations: List<Annotation> get() = classAnnotations ?: emptyList()
 

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -75,17 +75,6 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
         this.defaultDeserializerProvider = defaultDeserializerProvider
     }
 
-    /*
-    // TODO remove
-    @Deprecated(
-        "Deprecated in favor of function with new `PolymorphicDeserializerProvider` API",
-        level = DeprecationLevel.WARNING // Since TODO. Raise to ERROR in TODO, hide in TODO
-    )
-    public fun defaultDeserializer(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<Base>?) {
-        defaultDeserializer(defaultDeserializerProvider.toNewApi())
-    }
-    */
-
     /**
      * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
      * This function affect only deserialization process. To avoid confusion, it was deprecated and replaced with [defaultDeserializer].

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -22,6 +22,7 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
     private val subclasses: MutableList<Pair<KClass<out Base>, KSerializer<out Base>>> = mutableListOf()
     private var defaultSerializerProvider: ((Base) -> SerializationStrategy<Base>?)? = null
     private var defaultDeserializerProvider: PolymorphicDeserializerProvider<Base>? = null
+    private var defaultDeserializerProviderForNumber: PolymorphicDeserializerProviderForNumber<Base>? = null
 
     /*
     // TODO implement this or remove?
@@ -76,6 +77,16 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
     }
 
     /**
+     * TODO
+     */
+    public fun defaultDeserializerForNumber(defaultDeserializerProviderForNumber: (serialPolymorphicNumber: Int?) -> DeserializationStrategy<Base>?) {
+        require(this.defaultDeserializerProviderForNumber == null) {
+            "Default deserializer provider for number is already registered for class $baseClass: ${this.defaultDeserializerProvider}"
+        }
+        this.defaultDeserializerProviderForNumber = defaultDeserializerProviderForNumber
+    }
+
+    /**
      * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.
      * This function affect only deserialization process. To avoid confusion, it was deprecated and replaced with [defaultDeserializer].
      * To affect serialization process, use [SerializersModuleBuilder.polymorphicDefaultSerializer].
@@ -122,6 +133,10 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
         val defaultDeserializer = defaultDeserializerProvider
         if (defaultDeserializer != null) {
             builder.registerDefaultPolymorphicDeserializer(baseClass, defaultDeserializer, false)
+        }
+
+        defaultDeserializerProviderForNumber?.let {
+            builder.registerDefaultPolymorphicDeserializerForNumber(baseClass, it, false)
         }
     }
 }

--- a/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/PolymorphicModuleBuilder.kt
@@ -21,7 +21,15 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
 ) {
     private val subclasses: MutableList<Pair<KClass<out Base>, KSerializer<out Base>>> = mutableListOf()
     private var defaultSerializerProvider: ((Base) -> SerializationStrategy<Base>?)? = null
-    private var defaultDeserializerProvider: ((String?) -> DeserializationStrategy<Base>?)? = null
+    private var defaultDeserializerProvider: PolymorphicDeserializerProvider<Base>? = null
+
+    /*
+    // TODO implement this or remove?
+    /**
+     * If specified, overrides [SerializersModuleBuilder.allUseSerialPolymorphicNumbers] and the [UseSerialPolymorphicNumbers] annotation.
+     */
+    public var useSerialPolymorphicNumbers: Boolean? = null
+    */
 
     /**
      * Registers a [subclass] [serializer] in the resulting module under the [base class][Base].
@@ -29,6 +37,19 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
     public fun <T : Base> subclass(subclass: KClass<T>, serializer: KSerializer<T>) {
         subclasses.add(subclass to serializer)
     }
+
+    /*
+    // TODO implement this or remove
+    /**
+     * Registers a [subclass] [serializer] in the resulting module under the [base class][Base] with the serial polymorphic number.
+     * If the class already has a [SerialPolymorphicNumber] annotation it's overridden by [serialPolymorphicNumber] here.
+     */
+    public fun <T : Base> subclassWithSerialPolymorphicNumber(
+        subclass: KClass<T>, serialPolymorphicNumber: Int, serializer: KSerializer<T>
+    ) {
+        // TODO
+    }
+    */
 
     /**
      * Adds a default serializers provider associated with the given [baseClass] to the resulting module.
@@ -53,6 +74,17 @@ public class PolymorphicModuleBuilder<in Base : Any> @PublishedApi internal cons
         }
         this.defaultDeserializerProvider = defaultDeserializerProvider
     }
+
+    /*
+    // TODO remove
+    @Deprecated(
+        "Deprecated in favor of function with new `PolymorphicDeserializerProvider` API",
+        level = DeprecationLevel.WARNING // Since TODO. Raise to ERROR in TODO, hide in TODO
+    )
+    public fun defaultDeserializer(defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<Base>?) {
+        defaultDeserializer(defaultDeserializerProvider.toNewApi())
+    }
+    */
 
     /**
      * Adds a default deserializers provider associated with the given [baseClass] to the resulting module.

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -69,11 +69,6 @@ public sealed class SerializersModule {
         baseClass: KClass<in T>, serializedNumber: Int?
     ): DeserializationStrategy<T>?
 
-    // TODO remove or use
-    // TODO old design for cashing serializers by number in `AbstractPolymorphicSerializer` which probably doesn't work and is not needed
-    @ExperimentalSerializationApi
-    public abstract fun <T : Any> getPolymorphicForAllSubclasses(baseClass: KClass<T>): Map<KClass<out T>, KSerializer<out T>>
-
     /**
      * Copies contents of this module to the given [collector].
      */
@@ -202,11 +197,6 @@ internal class SerialModuleImpl(
             serializedNumber
         )
     }
-
-    // TODO remove or use
-    @ExperimentalSerializationApi
-    override fun <T : Any> getPolymorphicForAllSubclasses(baseClass: KClass<T>): Map<KClass<out T>, KSerializer<out T>> =
-        polyBase2Serializers.getValue(baseClass) as Map<KClass<out T>, KSerializer<out T>>
 
     override fun <T : Any> getContextual(kClass: KClass<T>, typeArgumentsSerializers: List<KSerializer<*>>): KSerializer<T>? {
         return (class2ContextualFactory[kClass]?.invoke(typeArgumentsSerializers)) as? KSerializer<T>?

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -69,7 +69,7 @@ public sealed class SerializersModule {
         baseClass: KClass<in T>, serializedNumber: Int?
     ): DeserializationStrategy<T>?
 
-    // TODO remove
+    // TODO remove or use
     // TODO old design for cashing serializers by number in `AbstractPolymorphicSerializer` which probably doesn't work and is not needed
     @ExperimentalSerializationApi
     public abstract fun <T : Any> getPolymorphicForAllSubclasses(baseClass: KClass<T>): Map<KClass<out T>, KSerializer<out T>>
@@ -169,7 +169,7 @@ internal class SerialModuleImpl(
     @JvmField val polyBase2Serializers: Map<KClass<*>, Map<KClass<*>, KSerializer<*>>>,
     private val polyBase2DefaultSerializerProvider: Map<KClass<*>, PolymorphicSerializerProvider<*>>,
     private val polyBase2NamedSerializers: Map<KClass<*>, Map<String, KSerializer<*>>>,
-    private val polyBase2NumberedSerializers: Map<KClass<*>, Map<Int, KSerializer<*>>>, // TODO remove
+    private val polyBase2NumberedSerializers: Map<KClass<*>, Map<Int, KSerializer<*>>>,
     private val polyBase2DefaultDeserializerProvider: Map<KClass<*>, PolymorphicDeserializerProvider<*>>,
     private val polyBase2DefaultDeserializerProviderForNumber: Map<KClass<*>, PolymorphicDeserializerProviderForNumber<*>>
 ) : SerializersModule() {
@@ -203,7 +203,7 @@ internal class SerialModuleImpl(
         )
     }
 
-    // TODO remove
+    // TODO remove or use
     @ExperimentalSerializationApi
     override fun <T : Any> getPolymorphicForAllSubclasses(baseClass: KClass<T>): Map<KClass<out T>, KSerializer<out T>> =
         polyBase2Serializers.getValue(baseClass) as Map<KClass<out T>, KSerializer<out T>>
@@ -243,23 +243,6 @@ internal class SerialModuleImpl(
     }
 }
 
-/*
-// TODO remove old suboptimal design
-
-public interface PolymorphicDeserializerProvider<out Base> {
-    public fun fromClassName(className: String?): DeserializationStrategy<Base>?
-    public fun fromSerialPolymorphicNumber(serialPolymorphicNumber: Int?): DeserializationStrategy<Base>?
-}
-
-internal fun <Base> ((className: String?) -> DeserializationStrategy<Base>?).toNewApi() =
-    object : PolymorphicDeserializerProvider<Base> {
-        override fun fromClassName(className: String?): DeserializationStrategy<Base>? =
-            this@toNewApi(className)
-
-        override fun fromSerialPolymorphicNumber(serialPolymorphicNumber: Int?): DeserializationStrategy<Base>? =
-            throw AssertionError("This instance should only be created by legacy code therefore this function shouldn't be invoked here.")
-    }
-*/
 internal typealias PolymorphicDeserializerProvider<Base> = (className: String?) -> DeserializationStrategy<Base>?
 internal typealias PolymorphicDeserializerProviderForNumber<Base> = (serialPolymorphicNumber: Int?) -> DeserializationStrategy<Base>?
 internal typealias PolymorphicSerializerProvider<Base> = (value: Base) -> SerializationStrategy<Base>?

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -188,7 +188,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
     internal fun <Base : Any> registerDefaultPolymorphicDeserializer(
         baseClass: KClass<Base>,
         defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<Base>?,
-        //defaultDeserializerProvider: PolymorphicDeserializerProvider<Base>,
+        //defaultDeserializerProvider: PolymorphicDeserializerProvider<Base>, // this causes the build to fail on JS, but only when there is no trailing comment such as this one, which is strange
         allowOverwrite: Boolean
     ) {
         val previous = polyBase2DefaultDeserializerProvider[baseClass]
@@ -202,7 +202,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
     internal fun <Base : Any> registerDefaultPolymorphicDeserializerForNumber(
         baseClass: KClass<Base>,
         defaultDeserializerProvider: (polymorphicSerialNumber: Int?) -> DeserializationStrategy<Base>?,
-        //defaultDeserializerProvider: PolymorphicDeserializerProviderForNumber<Base>,
+        //defaultDeserializerProvider: PolymorphicDeserializerProviderForNumber<Base>, // this causes the build to fail on JS, but only when there is no trailing comment such as this one, which is strange
         allowOverwrite: Boolean
     ) {
         val previous = polyBase2DefaultDeserializerProviderForNumber[baseClass]

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleBuilders.kt
@@ -230,7 +230,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
             // Remove previous serializers from name mapping
             if (previousSerializer != null) {
                 names.remove(previousSerializer.descriptor.serialName)
-                numbers.remove(previousSerializer.descriptor.serialPolymorphicNumberByBaseClass[baseClass])
+                previousSerializer.descriptor.serialPolymorphicNumberByBaseClass[baseClass]?.let { numbers.remove(it) }
             }
             // Update mappings
             baseClassSerializers[concreteClass] = concreteSerializer
@@ -245,7 +245,7 @@ public class SerializersModuleBuilder @PublishedApi internal constructor() : Ser
             } else {
                 // Cleanup name mapping
                 names.remove(previousSerializer.descriptor.serialName)
-                numbers.remove(previousSerializer.descriptor.serialPolymorphicNumberByBaseClass[baseClass])
+                previousSerializer.descriptor.serialPolymorphicNumberByBaseClass[baseClass]?.let { numbers.remove(it) }
             }
         }
         val previousByName = names[name]

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
@@ -59,6 +59,20 @@ public interface SerializersModuleCollector {
         defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
     )
 
+    /*
+    // TODO remove
+    @Deprecated(
+        "Deprecated in favor of function with new `PolymorphicDeserializerProvider` API",
+        level = DeprecationLevel.WARNING // Since TODO. Raise to ERROR in TODO, hide in TODO
+    )
+    public fun <Base : Any> polymorphicDefaultDeserializer(
+        baseClass: KClass<Base>,
+        defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<Base>?
+    ) {
+        polymorphicDefaultDeserializer(baseClass, defaultDeserializerProvider.toNewApi())
+    }
+    */
+
     /**
      * Accept a default deserializer provider, associated with the [baseClass] for polymorphic deserialization.
      * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`
@@ -72,7 +86,7 @@ public interface SerializersModuleCollector {
      */
     public fun <Base : Any> polymorphicDefaultDeserializer(
         baseClass: KClass<Base>,
-        defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<Base>?
+        defaultDeserializerProvider: PolymorphicDeserializerProvider<Base>
     )
 
     /**
@@ -101,4 +115,9 @@ public interface SerializersModuleCollector {
     ) {
         polymorphicDefaultDeserializer(baseClass, defaultDeserializerProvider)
     }
+
+    public fun <Base : Any> polymorphicDefaultDeserializerForNumber(
+        baseClass: KClass<Base>,
+        defaultDeserializerProvider: PolymorphicDeserializerProviderForNumber<Base>
+    )
 }

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
@@ -59,20 +59,6 @@ public interface SerializersModuleCollector {
         defaultSerializerProvider: (value: Base) -> SerializationStrategy<Base>?
     )
 
-    /*
-    // TODO remove
-    @Deprecated(
-        "Deprecated in favor of function with new `PolymorphicDeserializerProvider` API",
-        level = DeprecationLevel.WARNING // Since TODO. Raise to ERROR in TODO, hide in TODO
-    )
-    public fun <Base : Any> polymorphicDefaultDeserializer(
-        baseClass: KClass<Base>,
-        defaultDeserializerProvider: (className: String?) -> DeserializationStrategy<Base>?
-    ) {
-        polymorphicDefaultDeserializer(baseClass, defaultDeserializerProvider.toNewApi())
-    }
-    */
-
     /**
      * Accept a default deserializer provider, associated with the [baseClass] for polymorphic deserialization.
      * [defaultDeserializerProvider] is invoked when no polymorphic serializers associated with the `className`

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/SerialPolymorphicNumberTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/SerialPolymorphicNumberTest.kt
@@ -32,6 +32,19 @@ class SerialPolymorphicNumberTest {
         class Case : Sealed3()
     }
 
+    @Serializable
+    @UseSerialPolymorphicNumbers
+    sealed class Sealed4 {
+        @Serializable
+        @UseSerialPolymorphicNumbers
+        sealed class Sealed41 : Sealed4(){
+            @Serializable
+            @SerialPolymorphicNumber(Sealed4::class, 1)
+            @SerialPolymorphicNumber(Sealed41::class, 2)
+            class Case : Sealed41()
+        }
+    }
+
     @Test
     fun testSealed() {
         testConversion<Sealed1>(Sealed1.Case(), """{"type":1}""")
@@ -42,6 +55,8 @@ class SerialPolymorphicNumberTest {
         assertFailsWith(SerializationException::class) {
             Json.decodeFromString<Sealed3>("{}")
         }
+        testConversion<Sealed4>(Sealed4.Sealed41.Case(), """{"type":1}""")
+        testConversion<Sealed4.Sealed41>(Sealed4.Sealed41.Case(), """{"type":2}""")
     }
 
     @Serializable

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/SerialPolymorphicNumberTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/SerialPolymorphicNumberTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+import kotlinx.serialization.test.*
+import kotlin.test.*
+
+class SerialPolymorphicNumberTest {
+    @Serializable
+    @UseSerialPolymorphicNumbers
+    sealed class Sealed1 {
+        @Serializable
+        @SerialPolymorphicNumber(Sealed1::class, 1)
+        class Case : Sealed1()
+    }
+
+    @Serializable
+    sealed class Sealed2 {
+        @Serializable
+        @SerialPolymorphicNumber(Sealed2::class, 1)
+        class Case : Sealed2()
+    }
+
+    @Serializable
+    @UseSerialPolymorphicNumbers
+    sealed class Sealed3 {
+        @Serializable
+        class Case : Sealed3()
+    }
+
+    @Test
+    fun testSealed() {
+        testConversion<Sealed1>(Sealed1.Case(), """{"type":1}""")
+        testConversion<Sealed2>(Sealed2.Case(), """{"type":"kotlinx.serialization.SerialPolymorphicNumberTest.Case"}""")
+        assertFailsWith(SerializationException::class) {
+            Json.encodeToString<Sealed3>(Sealed3.Case())
+        }
+        assertFailsWith(SerializationException::class) {
+            Json.decodeFromString<Sealed3>("{}")
+        }
+    }
+
+    @Serializable
+    @UseSerialPolymorphicNumbers
+    sealed class Abstract {
+        @Serializable
+        @SerialPolymorphicNumber(Abstract::class, 1)
+        class Case : Abstract()
+
+        @Serializable
+        class Default(val type: Int?):Abstract()
+    }
+
+    val json = Json {
+        serializersModule = SerializersModule {
+            polymorphic(Abstract::class) {
+                subclass(Abstract.Case::class)
+                defaultDeserializerForNumber {
+                    Abstract.Default.serializer()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testPolymorphicModule() {
+        testConversion<Abstract>(json, Abstract.Case(), """{"type":1}""")
+        testConversion<Abstract>(json, Abstract.Default(0), """{"type":0}""")
+    }
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/test/JsonTestHelpers.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/test/JsonTestHelpers.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.test
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+inline fun <reified T> testConversion(json: Json, data: T, expectedHexString: String) {
+    val string = json.encodeToString(data)
+    assertEquals(expectedHexString, string)
+    assertEquals(data, json.decodeFromString(string))
+}
+
+inline fun <reified T> testConversion(data: T, expectedHexString: String) =
+    testConversion(Json, data, expectedHexString)

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/test/JsonTestHelpers.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/test/JsonTestHelpers.kt
@@ -8,11 +8,19 @@ import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import kotlin.test.*
 
-inline fun <reified T> testConversion(json: Json, data: T, expectedHexString: String) {
-    val string = json.encodeToString(data)
-    assertEquals(expectedHexString, string)
-    assertEquals(data, json.decodeFromString(string))
+inline fun <reified T> testConversion(json: Json, data: T, expectedString: String) {
+    assertEquals(expectedString, json.encodeToString(data))
+    assertEquals(data, json.decodeFromString(expectedString))
+
+    jvmOnly {
+        assertEquals(expectedString, json.encodeViaStream(serializer(), data))
+        assertEquals(data, json.decodeViaStream(serializer(), expectedString))
+    }
+
+    val jsonElement = json.encodeToJsonElement(data)
+    assertEquals(expectedString, jsonElement.toString())
+    assertEquals(data, json.decodeFromJsonElement(jsonElement))
 }
 
-inline fun <reified T> testConversion(data: T, expectedHexString: String) =
-    testConversion(Json, data, expectedHexString)
+inline fun <reified T> testConversion(data: T, expectedString: String) =
+    testConversion(Json, data, expectedString)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphismValidator.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphismValidator.kt
@@ -87,4 +87,11 @@ internal class PolymorphismValidator(
     ) {
         // Nothing here
     }
+
+    override fun <Base : Any> polymorphicDefaultDeserializerForNumber(
+        baseClass: KClass<Base>,
+        defaultDeserializerProvider: (serialPolymorphicNumber: Int?) -> DeserializationStrategy<Base>?
+    ) {
+        // Nothing here
+    }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -43,6 +43,7 @@ internal class StreamingJsonEncoder(
     // Forces serializer to wrap all values into quotes
     private var forceQuoting: Boolean = false
     private var polymorphicDiscriminator: String? = null
+    private var serialPolymorphicNumber : Int? = null
 
     init {
         val i = mode.ordinal
@@ -61,9 +62,7 @@ internal class StreamingJsonEncoder(
     }
 
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-        encodePolymorphically(serializer, value) {
-            polymorphicDiscriminator = it
-        }
+        encodePolymorphically(serializer, value, { polymorphicDiscriminator = it }, { serialPolymorphicNumber = it })
     }
 
     private fun encodeTypeInfo(descriptor: SerialDescriptor) {
@@ -71,7 +70,11 @@ internal class StreamingJsonEncoder(
         encodeString(polymorphicDiscriminator!!)
         composer.print(COLON)
         composer.space()
-        encodeString(descriptor.serialName)
+        serialPolymorphicNumber?.let {
+            encodeInt(it)
+            serialPolymorphicNumber = null
+        }
+            ?: encodeString(descriptor.serialName)
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
@@ -62,6 +62,7 @@ private class DynamicObjectEncoder(
      * Flag of usage polymorphism with discriminator attribute
      */
     private var polymorphicDiscriminator: String? = null
+    private var serialPolymorphicNumber: Int? = null
 
     private object NoOutputMark
 
@@ -183,9 +184,7 @@ private class DynamicObjectEncoder(
     private fun isNotStructured() = result === NoOutputMark
 
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-        encodePolymorphically(serializer, value) {
-            polymorphicDiscriminator = it
-        }
+        encodePolymorphically(serializer, value, { polymorphicDiscriminator = it }, { serialPolymorphicNumber = it })
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
@@ -208,8 +207,9 @@ private class DynamicObjectEncoder(
             enterNode(child, newMode)
         }
 
-        if (polymorphicDiscriminator != null) {
-            current.jsObject[polymorphicDiscriminator!!] = descriptor.serialName
+        polymorphicDiscriminator?.let {
+            current.jsObject[it] =
+                serialPolymorphicNumber?.also { serialPolymorphicNumber = null } ?: descriptor.serialName
             polymorphicDiscriminator = null
         }
 

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/SerialPolymorphicNumberTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/SerialPolymorphicNumberTest.kt
@@ -89,7 +89,7 @@ class SerialPolymorphicNumberTest {
         object Case : Abstract()
 
         @Serializable
-        data class Default(val type: Int?) : Abstract()
+        object Default : Abstract()
     }
 
     val protoBuf = ProtoBuf {
@@ -106,7 +106,6 @@ class SerialPolymorphicNumberTest {
     @Test
     fun testPolymorphicModule() {
         testConversion<Abstract>(protoBuf, Abstract.Case, "08011200")
-        // TODO Not working. However, even the original default serializer for serial names is not working for Protobuf as tested.
-        // assertEquals(Abstract.Default(0), protoBuf.decodeFromHexString<Abstract>("08001200"))
+        assertEquals(Abstract.Default, protoBuf.decodeFromHexString<Abstract>("08001200"))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,9 @@ version=1.6.3-SNAPSHOT
 
 kotlin.version=1.9.21
 
+bootstrap=true
 # This version takes precedence if 'bootstrap' property passed to project
-kotlin.version.snapshot=1.9.255-SNAPSHOT
+kotlin.version.snapshot=1.9.255-serialization-plugin-polymorphic-number-SNAPSHOT
 # Also set KONAN_LOCAL_DIST environment variable in bootstrap mode to auto-assign konan.home
 
 junit_version=4.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,8 @@ version=1.6.3-SNAPSHOT
 
 kotlin.version=1.9.21
 
-bootstrap=true
 # This version takes precedence if 'bootstrap' property passed to project
-kotlin.version.snapshot=1.9.255-serialization-plugin-polymorphic-number-SNAPSHOT
+kotlin.version.snapshot=1.9.255-SNAPSHOT
 # Also set KONAN_LOCAL_DIST environment variable in bootstrap mode to auto-assign konan.home
 
 junit_version=4.12


### PR DESCRIPTION
As for now, this library serializes the class/type of a subclass using a `serialName` in polymorphic serialization, which can be overridden with the `@SerialName` annotation. I'd like to propose supporting using a number and requiring subclasses to use numbers in polymorphic serialization, as it shortens the size of the serialized message greatly, especially in a binary format such as Protobuf.

When choosing to use a binary format such as Protobuf, one of the biggest concerns is shortening the size of serialized messages. In such a case serializing a fully qualified name of a subclass by default doesn't make much sense, as the binary format such as Protobuf compared to a readable string format as JSON reduces the serialized size of other fields by more than 50%, while a class discriminator takes the same size and takes up the majority of the message size, which defies the whole point. An alternative might be to override the serial name with a short name or a single letter, but IMO, still, the message is longer and it's less elegant than using a number.