### PR TITLE
Should `findPolymorphicSerializer...` functions that return `SerializationStrategy` be renamed to `findPolymorphicDeserializer...`?

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -70,7 +70,7 @@ public final class kotlinx/serialization/PolymorphicSerializer : kotlinx/seriali
 }
 
 public final class kotlinx/serialization/PolymorphicSerializerKt {
-	public static final fun findPolymorphicSerializer (Lkotlinx/serialization/internal/AbstractPolymorphicSerializer;Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
+	public static final fun findPolymorphicDeserializer (Lkotlinx/serialization/internal/AbstractPolymorphicSerializer;Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
 	public static final fun findPolymorphicSerializer (Lkotlinx/serialization/internal/AbstractPolymorphicSerializer;Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
 }
 
@@ -80,7 +80,7 @@ public abstract interface annotation class kotlinx/serialization/Required : java
 public final class kotlinx/serialization/SealedClassSerializer : kotlinx/serialization/internal/AbstractPolymorphicSerializer {
 	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)V
 	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;[Ljava/lang/annotation/Annotation;)V
-	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
+	public fun findPolymorphicDeserializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
 	public fun getBaseClass ()Lkotlin/reflect/KClass;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
@@ -562,7 +562,7 @@ public abstract class kotlinx/serialization/internal/AbstractCollectionSerialize
 
 public abstract class kotlinx/serialization/internal/AbstractPolymorphicSerializer : kotlinx/serialization/KSerializer {
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
+	public fun findPolymorphicDeserializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
 	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
 	public abstract fun getBaseClass ()Lkotlin/reflect/KClass;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V

--- a/core/commonMain/src/kotlinx/serialization/PolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/PolymorphicSerializer.kt
@@ -95,11 +95,11 @@ public class PolymorphicSerializer<T : Any>(override val baseClass: KClass<T>) :
 }
 
 @InternalSerializationApi
-public fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicSerializer(
+public fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicDeserializer(
     decoder: CompositeDecoder,
     klassName: String?
 ): DeserializationStrategy<T> =
-    findPolymorphicSerializerOrNull(decoder, klassName) ?: throwSubtypeNotRegistered(klassName, baseClass)
+    findPolymorphicDeserializerOrNull(decoder, klassName) ?: throwSubtypeNotRegistered(klassName, baseClass)
 
 @InternalSerializationApi
 public fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicSerializer(

--- a/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/SealedSerializer.kt
@@ -140,11 +140,11 @@ public class SealedClassSerializer<T : Any>(
             }.mapValues { it.value.value }
     }
 
-    override fun findPolymorphicSerializerOrNull(
+    override fun findPolymorphicDeserializerOrNull(
         decoder: CompositeDecoder,
         klassName: String?
     ): DeserializationStrategy<T>? {
-        return serialName2Serializer[klassName] ?: super.findPolymorphicSerializerOrNull(decoder, klassName)
+        return serialName2Serializer[klassName] ?: super.findPolymorphicDeserializerOrNull(decoder, klassName)
     }
 
     override fun findPolymorphicSerializerOrNull(encoder: Encoder, value: T): SerializationStrategy<T>? {

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -53,7 +53,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
                 }
                 1 -> {
                     klassName = requireNotNull(klassName) { "Cannot read polymorphic value before its type token" }
-                    val serializer = findPolymorphicSerializer(this, klassName)
+                    val serializer = findPolymorphicDeserializer(this, klassName)
                     value = decodeSerializableElement(descriptor, index, serializer)
                 }
                 else -> throw SerializationException(
@@ -69,7 +69,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
 
     private fun decodeSequentially(compositeDecoder: CompositeDecoder): T {
         val klassName = compositeDecoder.decodeStringElement(descriptor, 0)
-        val serializer = findPolymorphicSerializer(compositeDecoder, klassName)
+        val serializer = findPolymorphicDeserializer(compositeDecoder, klassName)
         return compositeDecoder.decodeSerializableElement(descriptor, 1, serializer)
     }
 
@@ -78,7 +78,7 @@ public abstract class AbstractPolymorphicSerializer<T : Any> internal constructo
      * May use context from the [decoder].
      */
     @InternalSerializationApi
-    public open fun findPolymorphicSerializerOrNull(
+    public open fun findPolymorphicDeserializerOrNull(
         decoder: CompositeDecoder,
         klassName: String?
     ): DeserializationStrategy<T>? = decoder.serializersModule.getPolymorphic(baseClass, klassName)

--- a/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
+++ b/formats/hocon/src/main/kotlin/kotlinx/serialization/hocon/Hocon.kt
@@ -183,7 +183,7 @@ public sealed class Hocon(
 
                     val reader = ConfigReader(config)
                     val type = reader.decodeTaggedString(classDiscriminator)
-                    val actualSerializer = deserializer.findPolymorphicSerializerOrNull(reader, type)
+                    val actualSerializer = deserializer.findPolymorphicDeserializerOrNull(reader, type)
                         ?: throw SerializerNotFoundException(type)
 
                     @Suppress("UNCHECKED_CAST")

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
@@ -9,8 +9,6 @@ import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
-import kotlinx.serialization.modules.*
-import kotlin.jvm.*
 
 @Suppress("UNCHECKED_CAST")
 internal inline fun <T> JsonEncoder.encodePolymorphically(
@@ -83,7 +81,7 @@ internal fun <T> JsonDecoder.decodeSerializableValuePolymorphic(deserializer: De
     @Suppress("UNCHECKED_CAST")
     val actualSerializer =
         try {
-            deserializer.findPolymorphicSerializer(this, type)
+            deserializer.findPolymorphicDeserializer(this, type)
         } catch (it: SerializationException) { //  Wrap SerializationException into JsonDecodingException to preserve input
             throw JsonDecodingException(-1, it.message!!, jsonTree.toString())
         } as DeserializationStrategy<T>

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -76,7 +76,7 @@ internal open class StreamingJsonDecoder(
 
             @Suppress("UNCHECKED_CAST")
             val actualSerializer = try {
-                    deserializer.findPolymorphicSerializer(this, type)
+                    deserializer.findPolymorphicDeserializer(this, type)
                 } catch (it: SerializationException) { // Wrap SerializationException into JsonDecodingException to preserve position, path, and input.
                     // Split multiline message from private core function:
                     // core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt:102

--- a/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
@@ -105,7 +105,7 @@ public sealed class Properties(
         final override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
             if (deserializer is AbstractPolymorphicSerializer<*>) {
                 val type = map[nested("type")]?.toString()
-                val actualSerializer: DeserializationStrategy<Any> = deserializer.findPolymorphicSerializer(this, type)
+                val actualSerializer: DeserializationStrategy<Any> = deserializer.findPolymorphicDeserializer(this, type)
 
                 @Suppress("UNCHECKED_CAST")
                 return actualSerializer.deserialize(this) as T


### PR DESCRIPTION
These functions return `DeserializationStrategy`s. It's a bit misleading. The word "deserializer" is used in other places such as `defaultDeserializer` to refer to a `DeserializationStrategy`.

If breaking compatibility is an issue the old ones can be kept as aliases and marked as deprecated.

These are minor possible improvement I noticed while working on another PR. Just close this PR if I got this wrong.