### PR TITLE
Fix all misuses of the article "the" before a class name enclosed in backticks

### DIFF
--- a/docs/builtin-classes.md
+++ b/docs/builtin-classes.md
@@ -427,7 +427,7 @@ fun main() {
 ``` 
 > You can get the full code [here](../guide/example/example-builtin-13.kt).
 
-When encoding, the serializer for the `Nothing` was not used
+When encoding, the serializer for `Nothing` was not used
 
 ```text
 {"value":42}

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -648,7 +648,7 @@ A decoder needs to implement more substance.
   in the `elementIndex` variable. See 
   the [Hand-written composite serializer](serializers.md#hand-written-composite-serializer) section 
   on how it ends up being used.
-* [beginStructure][Decoder.beginStructure] &mdash; returns a new instance of the `ListDecoder`, so that
+* [beginStructure][Decoder.beginStructure] &mdash; returns a new instance of `ListDecoder`, so that
   each structure that is being recursively decoded keeps track of its own `elementIndex` state separately.  
 
 ```kotlin

--- a/docs/polymorphism.md
+++ b/docs/polymorphism.md
@@ -713,7 +713,7 @@ data class OkResponse<out T>(val data: T) : Response<T>()
  
 Kotlin Serialization does not have a builtin strategy to represent the actually provided argument type for the
 type parameter `T` when serializing a property of the polymorphic type `OkResponse<T>`. We have to provide this 
-strategy explicitly when defining the serializers module for the `Response`. In the below example we
+strategy explicitly when defining the serializers module for `Response`. In the below example we
 use `OkResponse.serializer(...)` to retrieve 
 the [Plugin-generated generic serializer](serializers.md#plugin-generated-generic-serializer) of
 the `OkResponse` class and instantiate it with the [PolymorphicSerializer] instance with 

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -387,7 +387,7 @@ String is considered to be a primitive type, therefore we used `PrimitiveClassDe
 Now let's see what our actions would be if we have to serialize `Color` as another non-primitive type, let's say `IntArray`.
 
 An implementation of [KSerializer] for our original `Color` class is going to perform a conversion between
-`Color` and `IntArray`, but delegate the actual serialization logic to the `IntArraySerializer`
+`Color` and `IntArray`, but delegate the actual serialization logic to `IntArraySerializer`
 using [encodeSerializableValue][Encoder.encodeSerializableValue] and
 [decodeSerializableValue][Decoder.decodeSerializableValue].
 


### PR DESCRIPTION
This is similar to #2562. I found there are more of them.