### PR TITLE
json: Use @SerialName of inline polymorphic children

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/sealed/SealedInterfacesInlineSerialNameTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/sealed/SealedInterfacesInlineSerialNameTest.kt
@@ -35,8 +35,8 @@ class SealedInterfacesInlineSerialNameTest : JsonTestBase() {
     @JvmInline
     value class Child2(val value: Child2Value) : Parent
 
+    // From https://github.com/Kotlin/kotlinx.serialization/issues/2288
     @Test
-    @Ignore // https://github.com/Kotlin/kotlinx.serialization/issues/2288
     fun testSealedInterfaceInlineSerialName() {
         val messages = listOf(
             Child1(Child1Value(1, "one")),

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/sealed/SealedInterfacesInlineSerialNameTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/sealed/SealedInterfacesInlineSerialNameTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.features.sealed
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlin.jvm.*
+import kotlin.test.*
+
+class SealedInterfacesInlineSerialNameTest : JsonTestBase() {
+    @Serializable
+    data class Child1Value(
+        val a: Int,
+        val b: String
+    )
+
+    @Serializable
+    data class Child2Value(
+        val c: Int,
+        val d: String
+    )
+
+    @Serializable
+    sealed interface Parent
+
+    @Serializable
+    @SerialName("child1")
+    @JvmInline
+    value class Child1(val value: Child1Value) : Parent
+
+    @Serializable
+    @SerialName("child2")
+    @JvmInline
+    value class Child2(val value: Child2Value) : Parent
+
+    @Test
+    @Ignore // https://github.com/Kotlin/kotlinx.serialization/issues/2288
+    fun testSealedInterfaceInlineSerialName() {
+        val messages = listOf(
+            Child1(Child1Value(1, "one")),
+            Child2(Child2Value(2, "two"))
+        )
+        assertJsonFormAndRestored(
+            serializer(),
+            messages,
+            """[{"type":"child1","a":1,"b":"one"},{"type":"child2","c":2,"d":"two"}]"""
+        )
+    }
+}


### PR DESCRIPTION
Fixes #2288 

Currently, the `serialName` of value class children of sealed classes is ignored for encoding. Fix this in by storing the child's `serialName` in `encodeInline`, and consuming it in `beginStructure`. A small fix was needed to support decoding these types in `JsonTreeDecoder`.

