### PR TITLE
Fixed type discriminator value for custom serializer that uses `encodeJsonElement`

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/PolymorphismForCustomTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/PolymorphismForCustomTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.features
+
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+import kotlin.test.*
+
+class PolymorphismForCustomTest : JsonTestBase() {
+
+    private val customSerializer = object : KSerializer<VImpl> {
+        override val descriptor: SerialDescriptor =
+            buildClassSerialDescriptor("VImpl") {
+                element("a", String.serializer().descriptor)
+                element("b", Int.serializer().descriptor)
+            }
+
+        override fun deserialize(decoder: Decoder): VImpl {
+            decoder as JsonDecoder
+            val jsonObject = decoder.decodeJsonElement() as JsonObject
+            return VImpl(
+                (jsonObject["a"] as JsonPrimitive).content
+            )
+        }
+
+        override fun serialize(encoder: Encoder, value: VImpl) {
+            encoder as JsonEncoder
+            encoder.encodeJsonElement(
+                JsonObject(mapOf("a" to JsonPrimitive(value.a)))
+            )
+        }
+    }
+
+    @Serializable
+    data class ValueHolder<V : Any>(
+        @Polymorphic val value: V,
+    )
+
+    data class VImpl(val a: String)
+
+    val json = Json {
+        serializersModule = SerializersModule {
+            polymorphic(Any::class, VImpl::class, customSerializer)
+        }
+    }
+
+    @Test
+    fun test() = parametrizedTest { mode ->
+        val valueHolder = ValueHolder(VImpl("aaa"))
+        val encoded = json.encodeToString(ValueHolder.serializer(customSerializer), valueHolder, mode)
+        assertEquals("""{"value":{"type":"VImpl","a":"aaa"}}""", encoded)
+
+        val decoded = json.decodeFromString<ValueHolder<*>>(ValueHolder.serializer(customSerializer), encoded, mode)
+
+        assertEquals(valueHolder, decoded)
+    }
+
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/PolymorphismForCustomTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/PolymorphismForCustomTest.kt
@@ -18,7 +18,6 @@ class PolymorphismForCustomTest : JsonTestBase() {
         override val descriptor: SerialDescriptor =
             buildClassSerialDescriptor("VImpl") {
                 element("a", String.serializer().descriptor)
-                element("b", Int.serializer().descriptor)
             }
 
         override fun deserialize(decoder: Decoder): VImpl {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
@@ -16,7 +16,7 @@ import kotlin.jvm.*
 internal inline fun <T> JsonEncoder.encodePolymorphically(
     serializer: SerializationStrategy<T>,
     value: T,
-    ifPolymorphic: (String, String) -> Unit
+    ifPolymorphic: (discriminatorName: String, serialName: String) -> Unit
 ) {
     if (json.configuration.useArrayPolymorphism) {
         serializer.serialize(this, value)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
@@ -16,7 +16,7 @@ import kotlin.jvm.*
 internal inline fun <T> JsonEncoder.encodePolymorphically(
     serializer: SerializationStrategy<T>,
     value: T,
-    ifPolymorphic: (String) -> Unit
+    ifPolymorphic: (String, String) -> Unit
 ) {
     if (json.configuration.useArrayPolymorphism) {
         serializer.serialize(this, value)
@@ -42,7 +42,7 @@ internal inline fun <T> JsonEncoder.encodePolymorphically(
         actual as SerializationStrategy<T>
     } else serializer
 
-    if (baseClassDiscriminator != null) ifPolymorphic(baseClassDiscriminator)
+    if (baseClassDiscriminator != null) ifPolymorphic(baseClassDiscriminator, actualSerializer.descriptor.serialName)
     actualSerializer.serialize(this, value)
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -62,8 +62,9 @@ internal class StreamingJsonEncoder(
     }
 
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-        encodePolymorphically(serializer, value) {
-            polymorphicDiscriminator = it
+        encodePolymorphically(serializer, value) { discriminatorName, serialName ->
+            polymorphicDiscriminator = discriminatorName
+            polymorphicSerialName = serialName
         }
     }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -159,7 +159,7 @@ private sealed class AbstractJsonTreeEncoder(
         val discriminator = polymorphicDiscriminator
         if (discriminator != null) {
             if (encoder is JsonTreeMapEncoder) {
-                // first parameter is ignored in JsonTreeMapEncoder
+                // first parameter of `putElement` is ignored in JsonTreeMapEncoder
                 encoder.putElement("key", JsonPrimitive(discriminator))
                 encoder.putElement("value", JsonPrimitive(polymorphicSerialName ?: descriptor.serialName))
 

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
@@ -62,6 +62,8 @@ private class DynamicObjectEncoder(
      * Flag of usage polymorphism with discriminator attribute
      */
     private var polymorphicDiscriminator: String? = null
+    private var polymorphicSerialName: String? = null
+
 
     private object NoOutputMark
 
@@ -183,8 +185,9 @@ private class DynamicObjectEncoder(
     private fun isNotStructured() = result === NoOutputMark
 
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-        encodePolymorphically(serializer, value) {
-            polymorphicDiscriminator = it
+        encodePolymorphically(serializer, value) { discriminatorName, serialName ->
+            polymorphicDiscriminator = discriminatorName
+            polymorphicSerialName = serialName
         }
     }
 
@@ -209,8 +212,9 @@ private class DynamicObjectEncoder(
         }
 
         if (polymorphicDiscriminator != null) {
-            current.jsObject[polymorphicDiscriminator!!] = descriptor.serialName
+            current.jsObject[polymorphicDiscriminator!!] = polymorphicSerialName ?: descriptor.serialName
             polymorphicDiscriminator = null
+            polymorphicSerialName = null
         }
 
         current.index = 0


### PR DESCRIPTION
Fixes #2451