### PR TITLE
Setup running native tests in release mode

### DIFF
--- a/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.*
 
 /*
  * Copyright 2017-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
@@ -47,6 +48,15 @@ kotlin {
         linuxArm32Hfp()
     }
 
+    // setup tests running in RELEASE mode
+    targets.withType<KotlinNativeTarget>().configureEach {
+        binaries.test(listOf(NativeBuildType.RELEASE))
+    }
+    targets.withType<KotlinNativeTargetWithTests<*>>().configureEach {
+        testRuns.create("releaseTest") {
+            setExecutionSourceFrom(binaries.getTest(NativeBuildType.RELEASE))
+        }
+    }
 }
 
 fun doesNotDependOnOkio(project: Project): Boolean {

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -3,6 +3,7 @@
  */
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
+import org.jetbrains.kotlin.gradle.plugin.mpp.*
 
 val serialization_version = property("mainLibVersion") as String
 
@@ -130,6 +131,16 @@ kotlin {
             allWarningsAsErrors = true
             // Suppress 'K2 kapt is an experimental feature' warning:
             freeCompilerArgs += "-Xsuppress-version-warnings"
+        }
+    }
+
+    // setup tests running in RELEASE mode
+    targets.withType<KotlinNativeTarget>().configureEach {
+        binaries.test(listOf(NativeBuildType.RELEASE))
+    }
+    targets.withType<KotlinNativeTargetWithTests<*>>().configureEach {
+        testRuns.create("releaseTest") {
+            setExecutionSourceFrom(binaries.getTest(NativeBuildType.RELEASE))
         }
     }
 }


### PR DESCRIPTION
Proposed here: https://github.com/Kotlin/kotlinx.serialization/issues/2608#issuecomment-2077438394

To run native tests in release mode, separate tasks are created by KGP for additional test runs, f.e `macosArm64ReleaseTest` or `linuxX64ReleaseTest`. By default, they will be run also on `build`, `check` and `allTests` tasks, so they should automatically run on TC.

Note: with Kotlin 1.9.22 the original issue (#2608) doesn't reproduce nor via running `protobuf` tests (which contains tests for inner classes, so I haven't added additional test from original issue), nor via running tests in `integration-test` module (by adding reproducer test there, not included)

But another tests failed there:
* `kotlinx.serialization.json.polymorphic.JsonListPolymorphismTest#testPolymorphicNullableValues`
* `kotlinx.serialization.json.polymorphic.JsonMapPolymorphismTest#testPolymorphicNullableValues`

With the same exception: 
```
kotlinx.serialization.json.internal.JsonDecodingException: Expected class kotlinx.serialization.json.JsonArray as the serialized body of kotlinx.serialization.Polymorphic<InnerBase>, but had class kotlinx.serialization.json.JsonObject
```

Those tests are now finish successfully with Kotlin 2.0.0-RC3.