### PR TITLE
Fix confusing description of JsonPrimitive.content

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonTreeTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonTreeTest.kt
@@ -47,7 +47,7 @@ class JsonTreeTest : JsonTestBase() {
         assertTrue(elem.getValue("c") is JsonArray)
 
         val array = elem.getValue("c").jsonArray
-        assertEquals("foo", array.getOrNull(0)?.jsonPrimitive?.content)
+        assertEquals("foo", array.getOrNull(0)?.jsonPrimitive?.contentOrNull)
         assertEquals(100500, array.getOrNull(1)?.jsonPrimitive?.int)
 
         assertTrue(array[2] is JsonObject)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -41,8 +41,8 @@ public sealed class JsonPrimitive : JsonElement() {
     public abstract val isString: Boolean
 
     /**
-     * Content of given element without quotes. For [JsonNull] this method returns `"null"`.
-     * [JsonPrimitive.contentOrNull] should be used for [JsonNull] to return `null`.
+     * Content of given element without quotes. For [JsonNull], this method returns a "null" string.
+     * [JsonPrimitive.contentOrNull] should be used for [JsonNull] to get a `null`.
      */
     public abstract val content: String
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -41,7 +41,8 @@ public sealed class JsonPrimitive : JsonElement() {
     public abstract val isString: Boolean
 
     /**
-     * Content of given element without quotes. For [JsonNull] this methods returns `null`
+     * Content of given element without quotes. For [JsonNull] this method returns `"null"`.
+     * [JsonPrimitive.contentOrNull] should be used for [JsonNull] to return `null`.
      */
     public abstract val content: String
 


### PR DESCRIPTION
#### Summary
- clarifies that JsonPrimitive.content will return `"null"` rather than `null`
- include suggestion that `contentOrNull` should be used if the JsonPrimitive could be `JsonNull`
- fix potentially misleading usage in `JsonTreeTest`

-----  

JsonPrimitive.content returns `"null"` when it is of JsonNull type.
The original comment was like below:
```
public sealed class JsonPrimitive : JsonElement() {
    /**
     * Content of given element without quotes. For [JsonNull] this methods returns `null`
     */
    public abstract val content: String
```
This is potentially confusing if the reader hadn't noticed that `content` is of non-nullable type `String`.

This has led to a **very common** usage of the following code:

`elem?.jsonPrimitive?.content`

I doubt most are aware that `object.get("key")?.jsonPrimitive?.content` returns `"null"` as string if the key was explicitly null like `{"key": null}`, and only returns actual `null` when the key does not exist in the json object.

I'm open to corrections, but I cannot think of any scenarios where
`elem?.jsonPrimitive?.content` that returns `"null"` or `null` depending on the serialization policy of the json producer would be beneficial.

`contentOrNull` should always be preferred over `content` if there's a possibility of the value being null (either by missing key, or explicitly set as null - resulting into a JsonNull), and the revised comment reflects that view.