### PR TITLE
Remove yellow code

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -208,7 +208,7 @@ internal class SerialModuleImpl(
         }
 
         polyBase2DefaultDeserializerProvider.forEach { (baseClass, provider) ->
-            collector.polymorphicDefaultDeserializer(baseClass as KClass<Any>, provider as (PolymorphicDeserializerProvider<out Any>))
+            collector.polymorphicDefaultDeserializer(baseClass as KClass<Any>, provider as (PolymorphicDeserializerProvider<Any>))
         }
     }
 }


### PR DESCRIPTION
The corresponding change in the compiler (see [KT-67764](https://youtrack.jetbrains.com/issue/KT-67764)) improves the detection of `CONFLICTING_PROJECTIONS`, which makes this code yellow, because now it provokes `REDUNDANT_PROJECTION`.

^[KT-67764](https://youtrack.jetbrains.com/issue/KT-67764)
^[KT-68488](https://youtrack.jetbrains.com/issue/KT-68488)