### PR TITLE
Prohibited use of elements other than JsonObject in JsonTransformingSerializer with polymorphic serialization

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/JsonElementPolymorphicErrorTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/JsonElementPolymorphicErrorTest.kt
@@ -50,7 +50,7 @@ class JsonElementPolymorphicErrorTest : JsonTestBase() {
 
     @Test
     fun test() = parametrizedTest { mode ->
-        assertFailsWithMessage<SerializationException>("Json element JsonLiteral cannot be serialized polymorphous, for serial name 'kotlinx.serialization.JsonElementPolymorphicErrorTest.IntChild'") {
+        assertFailsWithMessage<SerializationException>("Class with serial name kotlinx.serialization.JsonElementPolymorphicErrorTest.IntChild cannot be serialized polymorphically because it is represented as JsonLiteral. Make sure that its JsonTransformingSerializer returns JsonObject, so class discriminator can be added to it") {
             format.encodeToString(
                 Holder.serializer(),
                 Holder(IntChild(42)),
@@ -58,7 +58,7 @@ class JsonElementPolymorphicErrorTest : JsonTestBase() {
             )
         }
 
-        assertFailsWithMessage<SerializationException>("Json element JsonArray cannot be serialized polymorphous, for serial name 'kotlinx.serialization.JsonElementPolymorphicErrorTest.CollectionChild'") {
+        assertFailsWithMessage<SerializationException>("Class with serial name kotlinx.serialization.JsonElementPolymorphicErrorTest.CollectionChild cannot be serialized polymorphically because it is represented as JsonArray. Make sure that its JsonTransformingSerializer returns JsonObject, so class discriminator can be added to it") {
             format.encodeToString(
                 Holder.serializer(),
                 Holder(CollectionChild(42)),

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/JsonElementPolymorphicErrorTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/JsonElementPolymorphicErrorTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.test.*
+import kotlin.test.*
+
+class JsonElementPolymorphicErrorTest : JsonTestBase() {
+
+    @Serializable
+    abstract class Abstract
+
+    @Serializable
+    data class IntChild(val value: Int) : Abstract()
+
+    @Serializable
+    data class CollectionChild(val value: Int) : Abstract()
+
+    @Serializable
+    data class Holder(val value: Abstract)
+
+    private val format = Json {
+        prettyPrint = false
+        serializersModule = SerializersModule {
+            polymorphic(Abstract::class) {
+                subclass(IntChild::class, IntChildSerializer)
+                subclass(CollectionChild::class, CollectionChildSerializer)
+            }
+        }
+    }
+
+    object IntChildSerializer : JsonTransformingSerializer<IntChild>(serializer()) {
+        override fun transformSerialize(element: JsonElement): JsonElement {
+            return element.jsonObject.getValue("value")
+        }
+    }
+
+    object CollectionChildSerializer : JsonTransformingSerializer<CollectionChild>(serializer()) {
+        override fun transformSerialize(element: JsonElement): JsonElement {
+            val value = element.jsonObject.getValue("value")
+            return JsonArray(listOf(value))
+        }
+    }
+
+    @Test
+    fun test() = parametrizedTest { mode ->
+        assertFailsWithMessage<SerializationException>("Json element JsonLiteral cannot be serialized polymorphous, for serial name 'kotlinx.serialization.JsonElementPolymorphicErrorTest.IntChild'") {
+            format.encodeToString(
+                Holder.serializer(),
+                Holder(IntChild(42)),
+                mode
+            )
+        }
+
+        assertFailsWithMessage<SerializationException>("Json element JsonArray cannot be serialized polymorphous, for serial name 'kotlinx.serialization.JsonElementPolymorphicErrorTest.CollectionChild'") {
+            format.encodeToString(
+                Holder.serializer(),
+                Holder(CollectionChild(42)),
+                mode
+            )
+        }
+
+    }
+
+}

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
@@ -101,6 +101,6 @@ internal fun SerialDescriptor.classDiscriminator(json: Json): String {
 }
 
 internal fun throwJsonElementPolymorphicException(serialName: String?, element: JsonElement): Nothing {
-    throw JsonEncodingException("Json element ${element::class.simpleName} cannot be serialized polymorphous, for serial name '$serialName'. Make sure that all JsonTransformingSerializer serializers return JsonObject")
+    throw JsonEncodingException("Class with serial name $serialName cannot be serialized polymorphically because it is represented as ${element::class.simpleName}. Make sure that its JsonTransformingSerializer returns JsonObject, so class discriminator can be added to it.")
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
@@ -100,3 +100,7 @@ internal fun SerialDescriptor.classDiscriminator(json: Json): String {
     return json.configuration.classDiscriminator
 }
 
+internal fun throwJsonElementPolymorphicException(serialName: String?, element: JsonElement): Nothing {
+    throw JsonEncodingException("Json element ${element::class.simpleName} cannot be serialized polymorphous, for serial name '$serialName'. Make sure that all JsonTransformingSerializer serializers return JsonObject")
+}
+

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -54,6 +54,9 @@ internal class StreamingJsonEncoder(
     }
 
     override fun encodeJsonElement(element: JsonElement) {
+        if (polymorphicDiscriminator != null && element !is JsonObject) {
+            throwJsonElementPolymorphicException(polymorphicSerialName, element)
+        }
         encodeSerializableValue(JsonElementSerializer, element)
     }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -41,6 +41,9 @@ private sealed class AbstractJsonTreeEncoder(
         descriptor.getJsonElementName(json, index)
 
     override fun encodeJsonElement(element: JsonElement) {
+        if (polymorphicDiscriminator != null && element !is JsonObject) {
+            throwJsonElementPolymorphicException(polymorphicSerialName, element)
+        }
         encodeSerializableValue(JsonElementSerializer, element)
     }
 

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicEncoders.kt
@@ -165,6 +165,9 @@ private class DynamicObjectEncoder(
     }
 
     override fun encodeJsonElement(element: JsonElement) {
+        if (polymorphicDiscriminator != null && element !is JsonObject) {
+            throwJsonElementPolymorphicException(polymorphicSerialName, element)
+        }
         encodeSerializableValue(JsonElementSerializer, element)
     }
 


### PR DESCRIPTION
If JsonTransformingSerializer is used as a serializer for the descendant of a polymorphic class, then we do not know how to add a type discriminator to the returned result of a primitive or array type.

Since there is no general solution to this problem on the library side, the user must take care of the correct processing of such types and, possibly, manually implement polymorphism.

Resolves #2164