### PR TITLE
Add Wasm-Wasi target to Okio integration

### DIFF
--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -25,11 +25,6 @@ tasks.withType<JavaCompile>().configureEach {
     options.release = 8
 }
 
-// Unfortunately there is no compatible version of okio for Wasm WASI target, so we need to skip to configure WASI for json-okio and json-tests.
-// json-tests uses okio with incorporate with other formatter tests so it is hard and not worth to separate it for two projects for WASI.
-// So we disable WASI target in it and we hope, that WASI version of compiler and serialization plugin are identical to the WasmJS target so WASI target is being covered.
-val isOkIoOrFormatTests = (name == "kotlinx-serialization-json-okio" || name == "kotlinx-serialization-json-tests")
-
 kotlin {
     explicitApi()
 
@@ -63,10 +58,8 @@ kotlin {
         nodejs()
     }
 
-    if (!isOkIoOrFormatTests) {
-        wasmWasi {
-            nodejs()
-        }
+    wasmWasi {
+        nodejs()
     }
 
     sourceSets.all {
@@ -140,19 +133,17 @@ kotlin {
             }
         }
 
-        if (!isOkIoOrFormatTests) {
-            named("wasmWasiMain") {
-                dependsOn(named("wasmMain").get())
-                dependencies {
-                    api("org.jetbrains.kotlin:kotlin-stdlib-wasm-wasi")
-                }
+        named("wasmWasiMain") {
+            dependsOn(named("wasmMain").get())
+            dependencies {
+                api("org.jetbrains.kotlin:kotlin-stdlib-wasm-wasi")
             }
+        }
 
-            named("wasmWasiTest") {
-                dependsOn(named("wasmTest").get())
-                dependencies {
-                    api("org.jetbrains.kotlin:kotlin-test-wasm-wasi")
-                }
+        named("wasmWasiTest") {
+            dependsOn(named("wasmTest").get())
+            dependencies {
+                api("org.jetbrains.kotlin:kotlin-test-wasm-wasi")
             }
         }
     }

--- a/formats/json-okio/api/kotlinx-serialization-json-okio.klib.api
+++ b/formats/json-okio/api/kotlinx-serialization-json-okio.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/gradle/artifacts.txt
+++ b/gradle/artifacts.txt
@@ -109,6 +109,7 @@ kotlinx-serialization-json-okio-tvosarm64
 kotlinx-serialization-json-okio-tvossimulatorarm64
 kotlinx-serialization-json-okio-tvosx64
 kotlinx-serialization-json-okio-wasm-js
+kotlinx-serialization-json-okio-wasm-wasi
 kotlinx-serialization-json-okio-watchosarm32
 kotlinx-serialization-json-okio-watchosarm64
 kotlinx-serialization-json-okio-watchossimulatorarm64

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version")
                 // To check that all expected artifacts are resolvable:
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-io:$serialization_version")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-okio:$serialization_version")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:$serialization_version")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serialization_version")
             }


### PR DESCRIPTION
Initially, Okio 3.6.0 did not have wasi target, so we excluded it while setting up Wasm. Since we now use Okio 3.9.0, we can provide Wasm-wasi too.