### PR TITLE
Fixed VerifyError after ProGuard optimization

### DIFF
--- a/rules/common.pro
+++ b/rules/common.pro
@@ -33,3 +33,9 @@
 # If there is no `java.lang.ClassValue` (for example, in Android), then R8/ProGuard will print a warning.
 # However, since in this case they will not be used, we can disable these warnings
 -dontwarn kotlinx.serialization.internal.ClassValueReferences
+
+# disable optimisation for descriptor field because in some versions of ProGuard, optimization generates incorrect bytecode that causes a verification error
+# see https://github.com/Kotlin/kotlinx.serialization/issues/2719
+-keepclassmembers public class **$$serializer {
+    private ** descriptor;
+}


### PR DESCRIPTION
Disabled optimisation for descriptor field because in some versions of ProGuard, optimization generates incorrect bytecode that causes a verification error.

Fixes #2719