### PR TITLE
docs(builtin-classes): Add a Unit link, fix the singleton object link

### DIFF
--- a/docs/builtin-classes.md
+++ b/docs/builtin-classes.md
@@ -351,8 +351,8 @@ even if they are numbers in Kotlin, as we can see below.
 
 ### Unit and singleton objects
 
-The Kotlin builtin `Unit` type is also serializable. 
-`Unit` is a Kotlin [singleton object](https://kotlinlang.org/docs/tutorials/kotlin-for-py/objects-and-companion-objects.html), 
+The Kotlin builtin [Unit](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-unit/) type is also serializable. 
+`Unit` is a Kotlin [singleton object](https://kotlinlang.org/docs/object-declarations.html#object-declarations-overview), 
 and is handled equally with other Kotlin objects.
 
 Conceptually, a singleton is a class with only one instance, meaning that state does not define the object, 


### PR DESCRIPTION
- Resolves the broken link in the builtin-classes "singleton object" [documentation](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/builtin-classes.md#unit-and-singleton-objects).
-  Adds a link to the "Unit" type documentation.