### PR TITLE
Remove methods used only for tests and fix 'Overload resolution ambiguity'

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -361,8 +361,6 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
         return res
     }
 
-    fun nextDouble(tag: ULong) = nextDouble(ulongArrayOf(tag))
-
     fun nextDouble(tags: ULongArray? = null): Double {
         processTags(tags)
         val res = when (curByte) {
@@ -411,7 +409,7 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
      * been skipped, the "length stack" is [pruned][prune]. For indefinite length elements, a special marker is added to
      * the "length stack" which is only popped from the "length stack" when a CBOR [break][isEnd] is encountered.
      */
-    fun skipElement(tags: ULongArray? = null) {
+    fun skipElement(tags: ULongArray?) {
         val lengthStack = mutableListOf<Int>()
 
         processTags(tags)
@@ -440,8 +438,6 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
             readByte()
         } while (lengthStack.isNotEmpty())
     }
-
-    fun skipElement(singleTag: ULong?) = skipElement(singleTag?.let { ulongArrayOf(it) })
 
     /**
      * Removes an item from the top of the [lengthStack], cascading the removal if the item represents the last item

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborParserTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborParserTest.kt
@@ -540,11 +540,17 @@ class CborParserTest {
 
 private fun CborParser.nextNumber(tag: ULong): Long = nextNumber(ulongArrayOf(tag))
 
+private fun CborParser.nextDouble(tag: ULong) = nextDouble(ulongArrayOf(tag))
+
 private fun CborParser.nextString(tag: ULong) = nextString(ulongArrayOf(tag))
 
 private fun CborParser.startArray(tag: ULong): Int = startArray(ulongArrayOf(tag))
 
 private fun CborParser.startMap(tag: ULong) = startMap(ulongArrayOf(tag))
+
+private fun CborParser.skipElement(singleTag: ULong) = skipElement(ulongArrayOf(singleTag))
+
+private fun CborParser.skipElement() = skipElement(null)
 
 private fun CborParser.expect(expected: String, tag: ULong? = null) {
     assertEquals(expected, actual = nextString(tag?.let { ulongArrayOf(it) }), "string")


### PR DESCRIPTION
 that happens with LV=2.1 (see https://youtrack.jetbrains.com/issue/KT-70201)