### PR TITLE
Fix a typo in the documentation of MapSerializer

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
@@ -216,7 +216,7 @@ public fun <T> SetSerializer(elementSerializer: KSerializer<T>): KSerializer<Set
 
 /**
  * Creates a serializer for [`Map<K, V>`][Map] for the given serializers for
- * its ket type [K] and value type [V].
+ * its key type [K] and value type [V].
  */
 public fun <K, V> MapSerializer(
     keySerializer: KSerializer<K>,


### PR DESCRIPTION
This PR fixes a small typo in the documentation of `MapSerializer` in _BuiltinSerializers.kt_ that I found while browsing the API docs.