### PR TITLE
Replace all "fully-qualified" strings in the docs with "fully qualified"

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -129,7 +129,7 @@ public annotation class Serializer(
  * the name of the property, e.g. by `Json`.
  *
  * By default, [SerialDescriptor.serialName] and [SerialDescriptor.getElementName]
- * are associated with fully-qualified name of the target class and the name of the property respectively.
+ * are associated with fully qualified name of the target class and the name of the property respectively.
  * Applying this annotation changes the visible name to the given [value]:
  *
  * ```

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
@@ -147,7 +147,7 @@ public interface SerialDescriptor {
     /**
      * Serial name of the descriptor that identifies a pair of the associated serializer and target class.
      *
-     * For generated and default serializers, the serial name should be equal to the corresponding class's fully-qualified name
+     * For generated and default serializers, the serial name should be equal to the corresponding class's fully qualified name
      * or, if overridden, [SerialName].
      * Custom serializers should provide a unique serial name that identifies both the serializable class and
      * the serializer itself, ignoring type arguments, if they are present, for example: `my.package.LongAsTrimmedString`

--- a/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.*
  *
  * By default, without special support from [Encoder], polymorphic types are serialized as list with
  * two elements: class [serial name][SerialDescriptor.serialName] (String) and the object itself.
- * Serial name equals to fully-qualified class name by default and can be changed via @[SerialName] annotation.
+ * Serial name equals to fully qualified class name by default and can be changed via @[SerialName] annotation.
  */
 @InternalSerializationApi
 @OptIn(ExperimentalSerializationApi::class)

--- a/docs/builtin-classes.md
+++ b/docs/builtin-classes.md
@@ -383,7 +383,7 @@ which is explained in the [Polymorphism. Objects](polymorphism.md#objects) secti
 <!--- TEST -->
 
 > Serialization of objects is format specific. Other formats may represent objects differently, 
-> e.g. using their fully-qualified names.
+> e.g. using their fully qualified names.
 
 ### Duration
 

--- a/docs/polymorphism.md
+++ b/docs/polymorphism.md
@@ -293,7 +293,7 @@ fun main() {
 
 > You can get the full code [here](../guide/example/example-poly-08.kt).
 
-An object serializes as an empty class, also using its fully-qualified class name as type by default:
+An object serializes as an empty class, also using its fully qualified class name as type by default:
 
 ```text 
 [{"type":"example.examplePoly08.EmptyResponse"},{"type":"example.examplePoly08.TextResponse","text":"OK"}]

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -63,7 +63,7 @@ public class JsonConfiguration @OptIn(ExperimentalSerializationApi::class) inter
  * Defines which classes and objects should have their serial name included in the json as so-called class discriminator.
  *
  * Class discriminator is a JSON field added by kotlinx.serialization that has [JsonBuilder.classDiscriminator] as a key (`type` by default),
- * and class' serial name as a value (fully-qualified name by default, can be changed with [SerialName] annotation).
+ * and class' serial name as a value (fully qualified name by default, can be changed with [SerialName] annotation).
  *
  * Class discriminator is important for serializing and deserializing [polymorphic class hierarchies](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#sealed-classes).
  * Default [ClassDiscriminatorMode.POLYMORPHIC] mode adds discriminator only to polymorphic classes.

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/FormatLanguage.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/FormatLanguage.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.InternalSerializationApi
  * Multiplatform analogue of `org.intellij.lang.annotations.Language` annotation.
  *
  * An alias is used instead of class, because the actual class in the JVM will conflict with the class from the stdlib -
- * we want to avoid the situation with different classes having the same fully-qualified name.
+ * we want to avoid the situation with different classes having the same fully qualified name.
  * [see](https://github.com/JetBrains/java-annotations/issues/34)
  *
  * Specifies that an element of the program represents a string that is a source code on a specified language.


### PR DESCRIPTION
As explained in https://www.merriam-webster.com/grammar/6-common-hypercorrections-and-how-to-avoid-them, hyphen is not needed since 'fully' can refer only to the adjective 'qualified'.