### PR TITLE
Improve readability of proto decode exception message

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -22,7 +22,7 @@ internal enum class ProtoWireType(val typeId: Int) {
     ;
 
     companion object {
-        fun fromTypeId(typeId: Int): ProtoWireType {
+        fun from(typeId: Int): ProtoWireType {
             return ProtoWireType.entries.find { it.typeId == typeId } ?: INVALID
         }
     }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -12,10 +12,29 @@ import kotlinx.serialization.modules.*
 import kotlinx.serialization.protobuf.*
 
 internal typealias ProtoDesc = Long
-internal const val VARINT = 0
-internal const val i64 = 1
-internal const val SIZE_DELIMITED = 2
-internal const val i32 = 5
+
+internal enum class ProtoWireType(val typeId: Int) {
+    INVALID(-1),
+    VARINT(0),
+    i64(1),
+    SIZE_DELIMITED(2),
+    i32(5),
+    ;
+
+    companion object {
+        fun fromTypeId(typeId: Int): ProtoWireType {
+            return ProtoWireType.entries.find { it.typeId == typeId } ?: INVALID
+        }
+    }
+
+    fun wireIntWithTag(tag: Int): Int {
+        return ((tag shl 3) or typeId)
+    }
+
+    override fun toString(): String {
+        return "${this.name}($typeId)"
+    }
+}
 
 internal const val ID_HOLDER_ONE_OF = -2
 
@@ -104,7 +123,7 @@ internal fun extractProtoId(descriptor: SerialDescriptor, index: Int, zeroBasedD
     return result
 }
 
-internal class ProtobufDecodingException(message: String) : SerializationException(message)
+internal class ProtobufDecodingException(message: String, e: Throwable? = null) : SerializationException(message, e)
 
 internal expect fun Int.reverseBytes(): Int
 internal expect fun Long.reverseBytes(): Long

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -185,14 +185,12 @@ internal open class ProtobufDecoder(
     override fun decodeTaggedByte(tag: ProtoDesc): Byte = decodeTaggedInt(tag).toByte()
     override fun decodeTaggedShort(tag: ProtoDesc): Short = decodeTaggedInt(tag).toShort()
     override fun decodeTaggedInt(tag: ProtoDesc): Int {
-        try {
-            return if (tag == MISSING_TAG) {
+        return decodeOrThrow(tag) {
+            if (tag == MISSING_TAG) {
                 reader.readInt32NoTag()
             } else {
                 reader.readInt(tag.integerType)
             }
-        } catch (e: ProtobufDecodingException) {
-            rethrowException(tag, e)
         }
     }
     override fun decodeTaggedLong(tag: ProtoDesc): Long {
@@ -352,7 +350,7 @@ internal open class ProtobufDecoder(
         return false
     }
 
-    private inline fun <T> decodeOrThrow(tag: ProtoDesc, crossinline action: (tag: ProtoDesc) -> T): T {
+    private inline fun <T> decodeOrThrow(tag: ProtoDesc, action: (tag: ProtoDesc) -> T): T {
         try {
             return action(tag)
         } catch (e: ProtobufDecodingException) {

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufDecoding.kt
@@ -258,7 +258,18 @@ internal open class ProtobufDecoder(
         val currentTag = currentTagOrDefault
         val msg = if (descriptor != deserializer.descriptor) {
             // Decoding child element
-            "Error while decoding ${deserializer.descriptor.serialName} at proto number ${currentTag.protoId} of ${descriptor.serialName}"
+            if (descriptor.kind == StructureKind.LIST && deserializer.descriptor.kind != StructureKind.MAP) {
+                // Decoding repeated field
+                "Error while decoding index ${currentTag.protoId - 1} in repeated field of ${deserializer.descriptor.serialName}"
+            } else if (descriptor.kind == StructureKind.MAP) {
+                // Decoding map field
+                val index = (currentTag.protoId - 1) / 2
+                val field = if ((currentTag.protoId - 1) % 2 == 0) { "key" } else "value"
+                "Error while decoding $field of index $index in map field of ${deserializer.descriptor.serialName}"
+            } else {
+                // Decoding common class
+                "Error while decoding ${deserializer.descriptor.serialName} at proto number ${currentTag.protoId} of ${descriptor.serialName}"
+            }
         } else {
             // Decoding self
             "Error while decoding ${descriptor.serialName}"

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
@@ -13,7 +13,7 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
     @JvmField
     public var currentId = -1
     @JvmField
-    public var currentType : ProtoWireType = ProtoWireType.INVALID
+    public var currentType = ProtoWireType.INVALID
     private var pushBack = false
     private var pushBackHeader = 0
 
@@ -42,7 +42,7 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
             -1
         } else {
             currentId = header ushr 3
-            currentType = ProtoWireType.fromTypeId(header and 0b111)
+            currentType = ProtoWireType.from(header and 0b111)
             currentId
         }
     }

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufWriter.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufWriter.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.protobuf.*
 
 internal class ProtobufWriter(private val out: ByteArrayOutput) {
     fun writeBytes(bytes: ByteArray, tag: Int) {
-        out.encode32((tag shl 3) or SIZE_DELIMITED)
+        out.encode32(ProtoWireType.SIZE_DELIMITED.wireIntWithTag(tag))
         writeBytes(bytes)
     }
 
@@ -20,7 +20,7 @@ internal class ProtobufWriter(private val out: ByteArrayOutput) {
     }
 
     fun writeOutput(output: ByteArrayOutput, tag: Int) {
-        out.encode32((tag shl 3) or SIZE_DELIMITED)
+        out.encode32(ProtoWireType.SIZE_DELIMITED.wireIntWithTag(tag))
         writeOutput(output)
     }
 
@@ -30,8 +30,8 @@ internal class ProtobufWriter(private val out: ByteArrayOutput) {
     }
 
     fun writeInt(value: Int, tag: Int, format: ProtoIntegerType) {
-        val wireType = if (format == ProtoIntegerType.FIXED) i32 else VARINT
-        out.encode32((tag shl 3) or wireType)
+        val wireType = if (format == ProtoIntegerType.FIXED) ProtoWireType.i32 else ProtoWireType.VARINT
+        out.encode32(wireType.wireIntWithTag(tag))
         out.encode32(value, format)
     }
 
@@ -40,8 +40,8 @@ internal class ProtobufWriter(private val out: ByteArrayOutput) {
     }
 
     fun writeLong(value: Long, tag: Int, format: ProtoIntegerType) {
-        val wireType = if (format == ProtoIntegerType.FIXED) i64 else VARINT
-        out.encode32((tag shl 3) or wireType)
+        val wireType = if (format == ProtoIntegerType.FIXED) ProtoWireType.i64 else ProtoWireType.VARINT
+        out.encode32(wireType.wireIntWithTag(tag))
         out.encode64(value, format)
     }
 
@@ -60,7 +60,7 @@ internal class ProtobufWriter(private val out: ByteArrayOutput) {
     }
 
     fun writeDouble(value: Double, tag: Int) {
-        out.encode32((tag shl 3) or i64)
+        out.encode32(ProtoWireType.i64.wireIntWithTag(tag))
         out.writeLong(value.reverseBytes())
     }
 
@@ -69,7 +69,7 @@ internal class ProtobufWriter(private val out: ByteArrayOutput) {
     }
 
     fun writeFloat(value: Float, tag: Int) {
-        out.encode32((tag shl 3) or i32)
+        out.encode32(ProtoWireType.i32.wireIntWithTag(tag))
         out.writeInt(value.reverseBytes())
     }
 

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoTagExceptionTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoTagExceptionTest.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromHexString
 import kotlinx.serialization.encodeToHexString
 import kotlinx.serialization.protobuf.internal.ProtobufDecodingException
-import kotlin.js.JsName
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -56,8 +55,7 @@ class ProtoTagExceptionTest {
     )
 
     @Test
-    @JsName("require_string_in_nested_message_but_got_int")
-    fun `require string in nested message but got int`() {
+    fun testWrongIntFieldInNestedMessage() {
         val build = ProtoBuf.encodeToHexString(TestNestedDataToBuild(TestDataToBuildWrongWireType(42, 42), "foo"))
 
         assertFailsWith<IllegalArgumentException>(
@@ -86,8 +84,7 @@ class ProtoTagExceptionTest {
     }
 
     @Test
-    @JsName("require_int_in_nested_message_but_got_string")
-    fun `require int in top message but get nested message`() {
+    fun testWrongStringFieldInNestedMessage() {
         val build = ProtoBuf.encodeToHexString(TestNestedDataToBuild(TestDataToBuildWrongWireType(42, 42), "foo"))
         assertFailsWith<IllegalArgumentException>(
             assertion = {
@@ -109,8 +106,7 @@ class ProtoTagExceptionTest {
     data class TestDataWithWrongList(@ProtoNumber(1) @ProtoPacked val list: List<TestDataToBuildWrongWireType>)
 
     @Test
-    @JsName("require_string_in_list_nested_message_but_get_int")
-    fun `require string in list nested message but get int`() {
+    fun testWrongIntFieldInNestedMessageInList() {
         val build = ProtoBuf.encodeToHexString(TestDataWithWrongList(listOf(TestDataToBuildWrongWireType(42, 42))))
         assertFailsWith<ProtobufDecodingException>(
             assertion = {
@@ -138,8 +134,7 @@ class ProtoTagExceptionTest {
     data class TestDataWithWrongMapValue(@ProtoNumber(1) val map: Map<String, TestDataToBuildWrongWireType>)
 
     @Test
-    @JsName("require_string_in_map_nested_value_but_get_int")
-    fun `require string in map nested value but get int`() {
+    fun testWrongIntFieldInNestedMapValue() {
         val build = ProtoBuf.encodeToHexString(TestDataWithWrongMapValue(map = mapOf("1" to TestDataToBuildWrongWireType(42, 42))))
         assertFailsWith<ProtobufDecodingException>(
             assertion = {
@@ -186,10 +181,7 @@ class ProtoTagExceptionTest {
             assertEquals("1a03666f6f182a", it)
         }
 
-        // Without checking duplication of proto numbers,
-        // ProtoBuf just throw exception about wrong wire type
         assertFailsWith<IllegalArgumentException>(
-//            "Duplicated proto number 3 in kotlinx.serialization.protobuf.ProtobufOneOfTest.DuplicatingIdData for elements: d, bad."
             assertion = {
                 assertFailsWith(
                     "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.DuplicatingIdData",

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoTagExceptionTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoTagExceptionTest.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromHexString
 import kotlinx.serialization.encodeToHexString
 import kotlinx.serialization.protobuf.internal.ProtobufDecodingException
-import kotlinx.serialization.protobuf.internal.protoId
+import kotlin.js.JsName
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -56,6 +56,7 @@ class ProtoTagExceptionTest {
     )
 
     @Test
+    @JsName("require_string_in_nested_message_but_got_int")
     fun `require string in nested message but got int`() {
         val build = ProtoBuf.encodeToHexString(TestNestedDataToBuild(TestDataToBuildWrongWireType(42, 42), "foo"))
 
@@ -85,6 +86,7 @@ class ProtoTagExceptionTest {
     }
 
     @Test
+    @JsName("require_int_in_nested_message_but_got_string")
     fun `require int in top message but get nested message`() {
         val build = ProtoBuf.encodeToHexString(TestNestedDataToBuild(TestDataToBuildWrongWireType(42, 42), "foo"))
         assertFailsWith<IllegalArgumentException>(
@@ -107,6 +109,7 @@ class ProtoTagExceptionTest {
     data class TestDataWithWrongList(@ProtoNumber(1) @ProtoPacked val list: List<TestDataToBuildWrongWireType>)
 
     @Test
+    @JsName("require_string_in_list_nested_message_but_get_int")
     fun `require string in list nested message but get int`() {
         val build = ProtoBuf.encodeToHexString(TestDataWithWrongList(listOf(TestDataToBuildWrongWireType(42, 42))))
         assertFailsWith<ProtobufDecodingException>(
@@ -135,6 +138,7 @@ class ProtoTagExceptionTest {
     data class TestDataWithWrongMapValue(@ProtoNumber(1) val map: Map<String, TestDataToBuildWrongWireType>)
 
     @Test
+    @JsName("require_string_in_map_nested_value_but_get_int")
     fun `require string in map nested value but get int`() {
         val build = ProtoBuf.encodeToHexString(TestDataWithWrongMapValue(map = mapOf("1" to TestDataToBuildWrongWireType(42, 42))))
         assertFailsWith<ProtobufDecodingException>(

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoTagExceptionTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtoTagExceptionTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromHexString
+import kotlinx.serialization.encodeToHexString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProtoTagExceptionTest {
+
+    @Serializable
+    data class TestDataToBuildWrongWireType(
+        @ProtoNumber(1) val a: Int,
+        @ProtoNumber(2) val b: Int,
+    )
+
+    @Serializable
+    data class TestData(
+        @ProtoNumber(1) val a: Int,
+        @ProtoNumber(2) val b: String,
+    )
+
+    @Test
+    fun testWrongTypeMessage() {
+        val build = ProtoBuf.encodeToHexString(TestDataToBuildWrongWireType(42, 42))
+
+        assertFailsWith<IllegalArgumentException>(
+            assertion = {
+                assertFailsWith(
+                    "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Error while decoding proto number 2 of kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Expected wire type SIZE_DELIMITED(2), but found VARINT(0)",
+                )
+            }
+        ) {
+            ProtoBuf.decodeFromHexString<TestData>(build)
+        }
+    }
+
+    @Serializable
+    data class TestNestedDataToBuild(
+        @ProtoNumber(1) val nested: TestDataToBuildWrongWireType,
+        @ProtoNumber(2) val a: String,
+    )
+
+    @Serializable
+    data class TestNestedData(
+        @ProtoNumber(1) val nested: TestData,
+        @ProtoNumber(2) val a: String,
+    )
+
+    @Test
+    fun `require string in nested message but got int`() {
+        val build = ProtoBuf.encodeToHexString(TestNestedDataToBuild(TestDataToBuildWrongWireType(42, 42), "foo"))
+
+        assertFailsWith<IllegalArgumentException>(
+            assertion = {
+                assertFailsWith(
+                    "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestNestedData",
+                    "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData at proto number 1 of kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestNestedData",
+                    "Error while decoding proto number 2 of kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Expected wire type SIZE_DELIMITED(2), but found VARINT(0)",
+                )
+            }
+        ) {
+            ProtoBuf.decodeFromHexString<TestNestedData>(build)
+        }
+        assertFailsWith<IllegalArgumentException>(
+            assertion = {
+                assertFailsWith(
+                    "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Error while decoding proto number 1 of kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Expected wire type VARINT(0), but found SIZE_DELIMITED(2)",
+                )
+            }
+        ) {
+            ProtoBuf.decodeFromHexString<TestData>(build)
+        }
+    }
+
+    @Test
+    fun `require int in top message but get nested message`() {
+        val build = ProtoBuf.encodeToHexString(TestNestedDataToBuild(TestDataToBuildWrongWireType(42, 42), "foo"))
+        assertFailsWith<IllegalArgumentException>(
+            assertion = {
+                assertFailsWith(
+                    "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Error while decoding proto number 1 of kotlinx.serialization.protobuf.ProtoTagExceptionTest.TestData",
+                    "Expected wire type VARINT(0), but found SIZE_DELIMITED(2)",
+                )
+            }
+        ) {
+            ProtoBuf.decodeFromHexString<TestData>(build)
+        }
+    }
+
+
+    @Serializable
+    data class DuplicatingIdData(
+        @ProtoOneOf val bad: IDuplicatingIdType,
+        @ProtoNumber(3) val d: Int,
+    )
+
+    @Serializable
+    sealed interface IDuplicatingIdType
+
+    @Serializable
+    data class DuplicatingIdStringType(@ProtoNumber(3) val s: String) : IDuplicatingIdType
+
+    @Test
+    fun testDuplicatedIdClass() {
+        val duplicated = DuplicatingIdData(DuplicatingIdStringType("foo"), 42)
+        // Fine to encode duplicated proto number properties in wire data
+        ProtoBuf.encodeToHexString(duplicated).also {
+            /**
+             * 3:LEN {"foo"}
+             * 3:VARINT 42
+             */
+            assertEquals("1a03666f6f182a", it)
+        }
+
+        // Without checking duplication of proto numbers,
+        // ProtoBuf just throw exception about wrong wire type
+        assertFailsWith<IllegalArgumentException>(
+//            "Duplicated proto number 3 in kotlinx.serialization.protobuf.ProtobufOneOfTest.DuplicatingIdData for elements: d, bad."
+            assertion = {
+                assertFailsWith(
+                    "Error while decoding kotlinx.serialization.protobuf.ProtoTagExceptionTest.DuplicatingIdData",
+                    "Error while decoding proto number 3 of kotlinx.serialization.protobuf.ProtoTagExceptionTest.DuplicatingIdData",
+                    "Expected wire type VARINT(0), but found SIZE_DELIMITED(2)",
+                )
+            }
+        ) {
+            /**
+             * 3:LEN {"foo"}
+             * 3:VARINT 42
+             */
+            ProtoBuf.decodeFromHexString<DuplicatingIdData>("1a03666f6f182a")
+        }
+    }
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -361,7 +361,9 @@ class ProtobufOneOfTest {
         }
 
         assertFailsWithMessage<SerializationException>(
-            message = "Serializer for subclass 'OtherIntType' is not found in the polymorphic scope of 'OtherType'."
+            message = "Serializer for subclass 'OtherIntType' is not found in the polymorphic scope of 'OtherType'.\n" +
+                "Check if class with serial name 'OtherIntType' exists and serializer is registered in a corresponding SerializersModule.\n" +
+                "To be registered automatically, class 'OtherIntType' has to be '@Serializable', and the base class 'OtherType' has to be sealed and '@Serializable'."
         ) {
             buf.encodeToHexString(
                 DoubleOneOfElement.serializer(), DoubleOneOfElement(
@@ -701,7 +703,7 @@ class ProtobufOneOfTest {
     fun testNonePolymorphicClass() {
         val data = Outer(Inner(42))
         assertFailsWithMessage<IllegalArgumentException>(
-            "The serializer of one of type kotlinx.serialization.protobuf.ProtobufOneOfTest.Inner should be using generic polymorphic serializer, but got CLASS"
+            "The serializer of one of type kotlinx.serialization.protobuf.ProtobufOneOfTest.Inner should be using generic polymorphic serializer, but got CLASS."
         ) {
             // Fails in [kotlinx.serialization.protobuf.internal.OneOfPolymorphicEncoder.init]
             ProtoBuf.encodeToHexString(data)

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -532,44 +532,6 @@ class ProtobufOneOfTest {
     }
 
     @Serializable
-    data class DuplicatingIdData(
-        @ProtoOneOf val bad: IDuplicatingIdType,
-        @ProtoNumber(3) val d: Int,
-    )
-
-    @Serializable
-    sealed interface IDuplicatingIdType
-
-    @Serializable
-    data class DuplicatingIdStringType(@ProtoNumber(3) val s: String) : IDuplicatingIdType
-
-    @Test
-    fun testDuplicatedIdClass() {
-        val duplicated = DuplicatingIdData(DuplicatingIdStringType("foo"), 42)
-        // Fine to encode duplicated proto number properties in wire data
-        ProtoBuf.encodeToHexString(duplicated).also {
-            /**
-             * 3:LEN {"foo"}
-             * 3:VARINT 42
-             */
-            assertEquals("1a03666f6f182a", it)
-        }
-
-        // Without checking duplication of proto numbers,
-        // ProtoBuf just throw exception about wrong wire type
-        assertFailsWithMessage<IllegalArgumentException>(
-//            "Duplicated proto number 3 in kotlinx.serialization.protobuf.ProtobufOneOfTest.DuplicatingIdData for elements: d, bad."
-            "Expected wire type 0, but found 2"
-        ) {
-            /**
-             * 3:LEN {"foo"}
-             * 3:VARINT 42
-             */
-            ProtoBuf.decodeFromHexString<DuplicatingIdData>("1a03666f6f182a")
-        }
-    }
-
-    @Serializable
     data class TypedIntOuter(
         @ProtoOneOf val i: ITypedInt,
     )

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctionTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.protobuf
+
+import kotlinx.serialization.protobuf.internal.ProtobufDecodingException
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+/**
+ * Tests for [assertFailsWith] to see if output in IDEA can be checked with <Click to see difference> button.
+ * Expected to fail so ignore in CI.
+ */
+@Ignore
+class TestFunctionTest {
+    @Test
+    fun testAssertionMessage() {
+        assertFailsWith<IllegalArgumentException>(assertion = {
+            assertFailsWith("expected message")
+        }) {
+            throw IllegalArgumentException("actual message")
+        }
+    }
+    @Test
+    fun testAssertionType() {
+        assertFailsWith<IllegalArgumentException>(assertion = {
+            assertFailsWith("")
+            assertCausedBy<ProtobufDecodingException> {
+                assertFailsWith("expected message")
+            }
+        }) {
+            throw IllegalArgumentException("", IllegalArgumentException())
+        }
+    }
+    @Test
+    fun testAssertionFailWith() {
+        assertFailsWith<NumberFormatException>(assertion = {}) {
+            throw ProtobufDecodingException("expected message")
+        }
+    }
+}

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctions.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctions.kt
@@ -58,7 +58,7 @@ inline fun <reified T : Throwable> assertFailsWith(
     scope.assertion()
 }
 
-fun <T : Throwable> buildExceptionCheckScope(exception: T): ExceptionCheckScope<T> = object : ExceptionCheckScope<T> {
+fun <T : Throwable> buildExceptionCheckScope(exception: T, depth: Int = 0): ExceptionCheckScope<T> = object : ExceptionCheckScope<T> {
     override fun assertFailsWith(vararg message: String) {
         val exceptionStackSize = exception.exceptionStackSize
         assertTrue(message.size <= exceptionStackSize, "Expected exception to be assembled by ${message.size} throwable, but it has $exceptionStackSize, is $exception")
@@ -68,7 +68,7 @@ fun <T : Throwable> buildExceptionCheckScope(exception: T): ExceptionCheckScope<
             val currentMessage = message[index]
             assertNotNull(currentException, "Expected exception to have a cause with message $currentMessage, but it was null")
             require(currentException != null)
-            assertTrue(currentException.message?.contains(currentMessage) == true, "Expected exception to have a cause with message <$currentMessage>, but it was <${currentException.message}> at cause stack $index")
+            assertEquals(currentMessage, currentException.message, "Expected exception to have a cause with message <$currentMessage>, but it was <${currentException.message}> at cause stack ${index + depth}")
             val nextException = currentException.cause
             currentException = nextException
             index++
@@ -81,7 +81,7 @@ fun <T : Throwable> buildExceptionCheckScope(exception: T): ExceptionCheckScope<
         assertNotNull(cause, "Expected exception to have a cause of type $byType, but it was null")
         require(cause != null)
         assertEquals(byType, cause::class, "Expected exception to have a cause of type $byType, but it was ${cause::class}")
-        buildExceptionCheckScope<R>(cause as R).assertion()
+        buildExceptionCheckScope<R>(cause as R, depth + 1).assertion()
     }
 
 }

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctions.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/TestFunctions.kt
@@ -64,7 +64,7 @@ fun <T : Throwable> buildExceptionCheckScope(exception: T, depth: Int = 0): Exce
             val exceptionStackSize = exception.exceptionStackSize
             assertTrue(
                 message.size <= exceptionStackSize,
-                "Expected exception to be assembled by at least ${message.size} throwable(s), but it has $exceptionStackSize, text is is $exception."
+                "Expected exception to be assembled by at least ${message.size} throwable(s), but it has $exceptionStackSize, actual exception is $exception."
             )
             var index = 0
             var currentException: Throwable? = exception


### PR DESCRIPTION
Found it hard to debug when exceptions with message like `Expected wire type 0, but found 1` were got. This PR is about to make some improvement of these messages for better tracability and readability.

1. Wrap definition of wire types with enum class `ProtoWireType` to show both name and id in message,
2. Catch and rethrow any `ProtobufDecodingException` in most `decodeXXX` functions, with proto number and type name in new exception message.
