### PR TITLE
docs(serializers): Fix grammar in typealias serializer documentation

### DIFF
--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -851,7 +851,7 @@ fun main() {
 
 <!--- TEST --> 
 
-### Specifying serializer globally using typealias
+### Specifying a serializer globally using a typealias
 
 kotlinx.serialization tends to be the always-explicit framework when it comes to serialization strategies: normally,
 they should be explicitly mentioned in `@Serializable` annotation. Therefore, we do not provide any kind of global serializer


### PR DESCRIPTION
- Add missing articles to the section header
- Change "Specifying serializer globally using typealias" to "Specifying a serializer globally using a typealias"
- Improve readability and grammatical correctness