### PR TITLE
docs(serializers): Improve sentence clarity and consistency

### DIFF
--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -253,7 +253,7 @@ object ColorAsStringSerializer : KSerializer<Color> {
 }
 ```
 
-Serializer has three required pieces. 
+A serializer has three required pieces. 
 
 * The [serialize][SerializationStrategy.serialize] function implements [SerializationStrategy].
   It receives an instance of [Encoder] and a value to serialize.


### PR DESCRIPTION
Replace "Serializer has three required pieces" with "A serializer has three required pieces" for better specificity, consistency, and readability.