### PR TITLE
docs(serializers): Improve wording in the Custom serializers section

### DIFF
--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -223,7 +223,8 @@ kotlin.collections.LinkedHashMap(PrimitiveDescriptor(kotlin.String), Color(rgb: 
 ## Custom serializers
 
 A plugin-generated serializer is convenient, but it may not produce the JSON we want 
-for such a class as `Color`. Let's study alternatives.
+for such a class as `Color`.
+Let's study the alternatives.
 
 ### Primitive serializer
 


### PR DESCRIPTION
"Let's study the alternatives" is slightly more formal and emphasizes the specific alternatives.