### PR TITLE
Remove redundandant `toString()`

### DIFF
--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
@@ -248,7 +248,7 @@ private class DynamicMapInput(
         if (isKey) {
             val value = decodeTaggedValue(tag)
             if (value !is String) return decode(tag)
-            return value.toString().cast() ?: throwIllegalKeyType(tag, value, type)
+            return value.cast() ?: throwIllegalKeyType(tag, value, type)
         }
         return decode(tag)
     }


### PR DESCRIPTION
The corresponding checker may be promoted to a default one, resulting into a warning in this place. See: KT-69938.

Sorry for the outdated commit title & message. If there are no other changes needed, I'd prefer having the right one during the rebase&merge rather than doing a force push.
