### PR TITLE
Remove redundant toString()

### DIFF
--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
@@ -248,7 +248,7 @@ private class DynamicMapInput(
         if (isKey) {
             val value = decodeTaggedValue(tag)
             if (value !is String) return decode(tag)
-            return value.toString().cast() ?: throwIllegalKeyType(tag, value, type)
+            return value.cast() ?: throwIllegalKeyType(tag, value, type)
         }
         return decode(tag)
     }


### PR DESCRIPTION
The corresponding checker may be promoted to a default one, resulting in a warning in this place. See: https://youtrack.jetbrains.com/issue/KT-69938

PR to `kotlin-community/dev`: https://github.com/Kotlin/kotlinx.serialization/pull/2789
