### PR TITLE
Check against serialName instead of simpleClassName

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/Primitives.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Primitives.kt
@@ -75,14 +75,13 @@ internal fun PrimitiveDescriptorSafe(serialName: String, kind: PrimitiveKind): S
 }
 
 private fun checkName(serialName: String) {
-    val keys = BUILTIN_SERIALIZERS.keys
-    for (primitive in keys) {
-        val simpleName = primitive.simpleName!!.capitalize()
-        val qualifiedName = "kotlin.$simpleName" // KClass.qualifiedName is not supported in JS
-        if (serialName.equals(qualifiedName, ignoreCase = true) || serialName.equals(simpleName, ignoreCase = true)) {
+    val values = BUILTIN_SERIALIZERS.values
+    for (primitive in values) {
+        val primitiveName = primitive.descriptor.serialName
+        if (serialName == primitiveName) {
             throw IllegalArgumentException("""
                 The name of serial descriptor should uniquely identify associated serializer.
-                For serial name $serialName there already exist ${simpleName.capitalize()}Serializer.
+                For serial name $serialName there already exists ${primitive::class.simpleName}.
                 Please refer to SerialDescriptor documentation for additional information.
             """.trimIndent())
         }

--- a/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -204,9 +204,10 @@ class SerialDescriptorSpecificationTest {
 
     @Test
     fun testCustomPrimitiveDescriptor() {
+        // It is allowed to have a custom descriptor with 'Int' or 'int', but not 'kotlin.Int'.
         assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("kotlin.Int", PrimitiveKind.INT) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("Int", PrimitiveKind.INT) }
-        assertFailsWith<IllegalArgumentException> { PrimitiveSerialDescriptor("int", PrimitiveKind.INT) }
+        assertEquals("Int", PrimitiveSerialDescriptor("Int", PrimitiveKind.INT).serialName)
+        assertEquals("int", PrimitiveSerialDescriptor("int", PrimitiveKind.INT).serialName)
     }
 
     private fun checkPrimitiveDescriptor(type: String, descriptor: SerialDescriptor) {

--- a/formats/json-tests/jvmTest/src/kotlinx/serialization/UuidPlatformClashTest.kt
+++ b/formats/json-tests/jvmTest/src/kotlinx/serialization/UuidPlatformClashTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
+import kotlin.test.*
+import kotlin.uuid.*
+import java.util.UUID as JUuid
+import kotlin.uuid.Uuid as KUuid
+
+@OptIn(ExperimentalUuidApi::class)
+class UuidPlatformClashTest : JsonTestBase() {
+    object JavaUuidSerializer : KSerializer<JUuid> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Uuid", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: JUuid) {
+            encoder.encodeString(value.toString().uppercase())
+        }
+
+        override fun deserialize(decoder: Decoder): JUuid {
+            return JUuid.fromString(decoder.decodeString())
+        }
+    }
+
+
+    @Serializable
+    data class UuidPair(
+        @Contextual val jUuid: JUuid,
+        @Contextual val kUuid: KUuid,
+    )
+
+    @Test
+    fun testUuids() {
+        val module = SerializersModule {
+            contextual(JavaUuidSerializer)
+            contextual(KUuid.serializer())
+        }
+        val json = Json { serializersModule = module }
+        val pair = UuidPair(
+            JUuid.fromString("252660b8-9a2b-44d1-a804-9a23f881cec5"),
+            KUuid.parse("c8ad1526-4b7c-4b67-9f77-6d05e580ad71")
+        )
+        assertJsonFormAndRestored(
+            UuidPair.serializer(),
+            pair,
+            """{"jUuid":"252660B8-9A2B-44D1-A804-9A23F881CEC5","kUuid":"c8ad1526-4b7c-4b67-9f77-6d05e580ad71"}""",
+            json
+        )
+    }
+}


### PR DESCRIPTION
in PrimitiveSerialDescriptor constructor.

By doing so, we allow users to declare their own serializers with short names like "Uuid" or "Duration", even though it is not recommended — because they may have been declared before library updates.

Fixes #2799