### PR TITLE
Use explicit kotlin-stdlib and kotlin-test versions from version catalog

### DIFF
--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -22,6 +22,8 @@ tasks.withType<JavaCompile>().configureEach {
     options.release = 8
 }
 
+internal fun Project.versionCatalog(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
 kotlin {
     explicitApi()
 
@@ -73,38 +75,13 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("org.jetbrains.kotlin:kotlin-stdlib-common")
+                api(versionCatalog().findLibrary("kotlin.stdlib").get())
             }
         }
 
         commonTest {
             dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-common")
-                api("org.jetbrains.kotlin:kotlin-test-annotations-common")
-            }
-        }
-
-        jvmMain {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-stdlib")
-            }
-        }
-
-        jvmTest {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-junit")
-            }
-        }
-
-        jsMain {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-stdlib-js")
-            }
-        }
-
-        jsTest {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-js")
+                api(versionCatalog().findLibrary("kotlin.test").get())
             }
         }
 
@@ -117,30 +94,18 @@ kotlin {
 
         named("wasmJsMain") {
             dependsOn(named("wasmMain").get())
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-stdlib-wasm-js")
-            }
         }
 
         named("wasmJsTest") {
             dependsOn(named("wasmTest").get())
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-js")
-            }
         }
 
         named("wasmWasiMain") {
             dependsOn(named("wasmMain").get())
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-stdlib-wasm-wasi")
-            }
         }
 
         named("wasmWasiTest") {
             dependsOn(named("wasmTest").get())
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-wasi")
-            }
         }
     }
 

--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
     options.release = 8
 }
 
-internal fun Project.versionCatalog(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+internal fun Project.versionCatalog(): VersionCatalog = versionCatalogs.named("libs")
 
 kotlin {
     explicitApi()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,9 @@ gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", versi
 gradlePlugin-animalsniffer = { module = "ru.vyarus:gradle-animalsniffer-plugin", version.ref = "animalsniffer"}
 gradlePlugin-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "bcv"}
 
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+
 dokka-pathsaver = { module = "org.jetbrains.kotlinx:dokka-pathsaver-plugin", version.ref = "knit"}
 knitTest = { module = "org.jetbrains.kotlinx:kotlinx-knit-test", version.ref = "knit"}
 jmhCore = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh-core"}


### PR DESCRIPTION
Using explicit versions helps work around the issue where the stdlib version was missing from the POM (https://youtrack.jetbrains.com/issue/KT-71443/Unexpected-POM-file-change-when-updating-from-Kotlin-2.0.0-to-Kotlin-2.0.20).

Also, simplify dependencies' setup since `stdlib-common` does not have to be declared explicitly since 1.9.20 (https://kotlinlang.org/docs/whatsnew1920.html#easier-configuration-of-new-standard-library-versions-in-gradle) and kotlin-test-junit is selected automatically if no other runner is specified (https://kotlinlang.org/docs/gradle-configure-project.html#jvm-variants-of-kotlin-test).

Fixes #2810