### PR TITLE
Drop usage of deprecated Any.freeze() in K/N target

### DIFF
--- a/formats/json-tests/nativeTest/src/kotlinx/serialization/json/MultiWorkerJsonTest.kt
+++ b/formats/json-tests/nativeTest/src/kotlinx/serialization/json/MultiWorkerJsonTest.kt
@@ -22,7 +22,7 @@ class MultiWorkerJsonTest {
                 assertEquals(PlainOne(42), json().decodeFromString("""{"one":42,"two":239}"""))
             }
         }
-        worker.executeAfter(1000, operation.freeze())
+        worker.executeAfter(1000, operation)
         for (i in 0..999) {
             assertEquals(PlainTwo(239), json().decodeFromString("""{"one":42,"two":239}"""))
         }


### PR DESCRIPTION
The legacy memory model was removed from the K/N runtime in 1.9.20. Now, this function does nothing, and its usages can be safely dropped. Also, `Worker.execute/executeAfter` functions no longer require the argument to be frozen, as objects can no longer be frozen.

Currently, the opt-in requirement level of APIs marked with `@FreezingIsDeprecated` is being advanced to ERROR. Thus, this usage of the `freeze()` function is blocking that effort.