### PR TITLE
Introduce @SealedSerializationApi to codebase and stabilize part of SerialDescriptor's API

### DIFF
--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -68,7 +68,9 @@ kotlin {
             progressiveMode = true
 
             optIn("kotlin.ExperimentalMultiplatform")
+            optIn("kotlin.ExperimentalSubclassOptIn")
             optIn("kotlinx.serialization.InternalSerializationApi")
+            optIn("kotlinx.serialization.SealedSerializationApi")
         }
     }
 
@@ -112,6 +114,7 @@ kotlin {
     sourceSets.matching({ it.name.contains("Test") }).configureEach {
         languageSettings {
             optIn("kotlinx.serialization.InternalSerializationApi")
+            optIn("kotlinx.serialization.SealedSerializationApi")
             optIn("kotlinx.serialization.ExperimentalSerializationApi")
         }
     }

--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -86,6 +86,9 @@ public final class kotlinx/serialization/SealedClassSerializer : kotlinx/seriali
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 }
 
+public abstract interface annotation class kotlinx/serialization/SealedSerializationApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface class kotlinx/serialization/SerialFormat {
 	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 }

--- a/core/api/kotlinx-serialization-core.klib.api
+++ b/core/api/kotlinx-serialization-core.klib.api
@@ -61,6 +61,10 @@ open annotation class kotlinx.serialization/Required : kotlin/Annotation { // ko
     constructor <init>() // kotlinx.serialization/Required.<init>|<init>(){}[0]
 }
 
+open annotation class kotlinx.serialization/SealedSerializationApi : kotlin/Annotation { // kotlinx.serialization/SealedSerializationApi|null[0]
+    constructor <init>() // kotlinx.serialization/SealedSerializationApi.<init>|<init>(){}[0]
+}
+
 open annotation class kotlinx.serialization/SerialInfo : kotlin/Annotation { // kotlinx.serialization/SerialInfo|null[0]
     constructor <init>() // kotlinx.serialization/SerialInfo.<init>|<init>(){}[0]
 }

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -347,33 +347,3 @@ public annotation class Polymorphic
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class KeepGeneratedSerializer
-
-/**
- * Marks declarations that are still **experimental** in kotlinx.serialization, which means that the design of the
- * corresponding declarations has open issues which may (or may not) lead to their changes in the future.
- * Roughly speaking, there is a chance that those declarations will be deprecated in the near future or
- * the semantics of their behavior may change in some way that may break some code.
- *
- * By default, the following categories of API are experimental:
- *
- * * Writing 3rd-party serialization formats
- * * Writing non-trivial custom serializers
- * * Implementing [SerialDescriptor] interfaces
- * * Not-yet-stable serialization formats that require additional polishing
- */
-@MustBeDocumented
-@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS)
-@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
-public annotation class ExperimentalSerializationApi
-
-/**
- * Public API marked with this annotation is effectively **internal**, which means
- * it should not be used outside of `kotlinx.serialization`.
- * Signature, semantics, source and binary compatibilities are not guaranteed for this API
- * and will be changed without any warnings or migration aids.
- * If you cannot avoid using internal API to solve your problem, please report your use-case to serialization's issue tracker.
- */
-@MustBeDocumented
-@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS)
-@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
-public annotation class InternalSerializationApi

--- a/core/commonMain/src/kotlinx/serialization/ApiLevels.kt
+++ b/core/commonMain/src/kotlinx/serialization/ApiLevels.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.descriptors.*
+
+/**
+ * Marks declarations that are still **experimental** in kotlinx.serialization, which means that the design of the
+ * corresponding declarations has open issues which may (or may not) lead to their changes in the future.
+ * Roughly speaking, there is a chance that those declarations will be deprecated in the near future or
+ * the semantics of their behavior may change in some way that may break some code.
+ *
+ * By default, the following categories of API are experimental:
+ *
+ * * Writing 3rd-party serialization formats
+ * * Writing non-trivial custom serializers
+ * * Implementing [SerialDescriptor] interfaces
+ * * Not-yet-stable serialization formats that require additional polishing
+ */
+@MustBeDocumented
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS)
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+public annotation class ExperimentalSerializationApi
+
+/**
+ * Public API marked with this annotation is effectively **internal**, which means
+ * it should not be used outside of `kotlinx.serialization`.
+ * Signature, semantics, source and binary compatibilities are not guaranteed for this API
+ * and will be changed without any warnings or migration aids.
+ * If you cannot avoid using internal API to solve your problem, please report your use-case to serialization's issue tracker.
+ */
+@MustBeDocumented
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS)
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+public annotation class InternalSerializationApi
+
+/**
+ * Marks interfaces and non-final classes that can be freely referenced in users' code but should not be
+ * implemented or inherited. Such declarations are effectively `sealed` and do not have this modifier purely for technical reasons.
+ *
+ * kotlinx.serialization library provides compatibility guarantees for existing signatures of such classes;
+ * however, new functions or properties can be added to them in any release.
+ */
+@MustBeDocumented
+@Target() // no direct targets, only argument to @SubclassOptInRequired
+@RequiresOptIn(message = "This class or interface should not be inherited/implemented outside of kotlinx.serialization library. " +
+    "Note it is still permitted to use it directly. Read its documentation about inheritance for details.", level = RequiresOptIn.Level.ERROR)
+public annotation class SealedSerializationApi
+

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
@@ -142,6 +142,7 @@ import kotlinx.serialization.encoding.*
  * might be added to this interface when kotlinx.serialization adds support for new Kotlin features.
  * This interface is safe to use and construct via [buildClassSerialDescriptor], [PrimitiveSerialDescriptor], and `SerialDescriptor` factory function.
  */
+@SubclassOptInRequired(SealedSerializationApi::class)
 public interface SerialDescriptor {
     /**
      * Serial name of the descriptor that identifies a pair of the associated serializer and target class.

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -49,8 +49,6 @@ import kotlin.reflect.*
  * }
  * ```
  */
-@Suppress("FunctionName")
-@OptIn(ExperimentalSerializationApi::class)
 public fun buildClassSerialDescriptor(
     serialName: String,
     vararg typeParameters: SerialDescriptor,
@@ -69,7 +67,7 @@ public fun buildClassSerialDescriptor(
 }
 
 /**
- * Factory to create a trivial primitive descriptors.
+ * Factory to create trivial primitive descriptors. [serialName] must be non-blank and unique.
  * Primitive descriptors should be used when the serialized form of the data has a primitive form, for example:
  * ```
  * object LongAsStringSerializer : KSerializer<Long> {
@@ -86,6 +84,7 @@ public fun buildClassSerialDescriptor(
  * }
  * ```
  */
+@Suppress("FunctionName")
 public fun PrimitiveSerialDescriptor(serialName: String, kind: PrimitiveKind): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
     return PrimitiveDescriptorSafe(serialName, kind)
@@ -93,9 +92,8 @@ public fun PrimitiveSerialDescriptor(serialName: String, kind: PrimitiveKind): S
 
 /**
  * Factory to create a new descriptor that is identical to [original] except that the name is equal to [serialName].
- * Should be used when you want to serialize a type as another non-primitive type.
- * Don't use this if you want to serialize a type as a primitive value, use [PrimitiveSerialDescriptor] instead.
- * 
+ * Usually used when you want to serialize a type as another type, delegating implementation of `serialize` and `deserialize`.
+ *
  * Example:
  * ```
  * @Serializable(CustomSerializer::class)
@@ -115,27 +113,24 @@ public fun PrimitiveSerialDescriptor(serialName: String, kind: PrimitiveKind): S
  * }
  * ```
  */
-@ExperimentalSerializationApi
 public fun SerialDescriptor(serialName: String, original: SerialDescriptor): SerialDescriptor {
     require(serialName.isNotBlank()) { "Blank serial names are prohibited" }
-    require(original.kind !is PrimitiveKind) { "For primitive descriptors please use 'PrimitiveSerialDescriptor' instead" }
     require(serialName != original.serialName) { "The name of the wrapped descriptor ($serialName) cannot be the same as the name of the original descriptor (${original.serialName})" }
-    
+    if (original.kind is PrimitiveKind) checkNameIsNotAPrimitive(serialName)
+
     return WrappedSerialDescriptor(serialName, original)
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 internal class WrappedSerialDescriptor(override val serialName: String, original: SerialDescriptor) : SerialDescriptor by original
 
 /**
  * An unsafe alternative to [buildClassSerialDescriptor] that supports an arbitrary [SerialKind].
  * This function is left public only for migration of pre-release users and is not intended to be used
- * as generally-safe and stable mechanism. Beware that it can produce inconsistent or non spec-compliant instances.
+ * as a generally safe and stable mechanism. Beware that it can produce inconsistent or non-spec-compliant instances.
  *
- * If you end up using this builder, please file an issue with your use-case in kotlinx.serialization issue tracker.
+ * If you end up using this builder, please file an issue with your use-case to the kotlinx.serialization issue tracker.
  */
 @InternalSerializationApi
-@OptIn(ExperimentalSerializationApi::class)
 public fun buildSerialDescriptor(
     serialName: String,
     kind: SerialKind,
@@ -152,13 +147,31 @@ public fun buildSerialDescriptor(
 
 /**
  * Retrieves descriptor of type [T] using reified [serializer] function.
+ *
+ * Example:
+ * ```
+ * serialDescriptor<List<String>>() // Returns kotlin.collections.ArrayList(PrimitiveDescriptor(kotlin.String))
+ * ```
  */
 public inline fun <reified T> serialDescriptor(): SerialDescriptor = serializer<T>().descriptor
 
 /**
- * Retrieves descriptor of type associated with the given [KType][type]
+ * Retrieves descriptor of a type associated with the given [KType][type].
+ *
+ * Example:
+ * ```
+ * val type = typeOf<List<String>>()
+ *
+ * serialDescriptor(type) // Returns kotlin.collections.ArrayList(PrimitiveDescriptor(kotlin.String))
+ * ```
  */
 public fun serialDescriptor(type: KType): SerialDescriptor = serializer(type).descriptor
+
+/* The rest of the functions intentionally left experimental for later stabilization
+ It is unclear whether they should be left as-is,
+ or moved to ClassSerialDescriptorBuilder (because this is the main place for them to be used),
+ or simply deprecated in favor of ListSerializer(Element.serializer()).descriptor
+*/
 
 /**
  * Creates a descriptor for the type `List<T>` where `T` is the type associated with [elementDescriptor].
@@ -227,9 +240,10 @@ public val SerialDescriptor.nullable: SerialDescriptor
  * Returns non-nullable serial descriptor for the type if this descriptor has been auto-generated (plugin
  * generated descriptors) or created with `.nullable` extension on a descriptor or serializer.
  *
- * Otherwise, returns this.
+ * Otherwise, returns `this`.
  *
- * It may return nullable descriptor if this descriptor has been created manually as nullable by directly implementing SerialDescriptor interface.
+ * It may return a nullable descriptor
+ * if `this` descriptor has been created manually as nullable by directly implementing SerialDescriptor interface.
  *
  * @see SerialDescriptor.nullable
  * @see KSerializer.nullable

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialKinds.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialKinds.kt
@@ -25,7 +25,6 @@ import kotlinx.serialization.modules.*
  * as a single `Long` value, its descriptor should have [PrimitiveKind.LONG] without nested elements even though the class itself
  * represents a structure with two primitive fields.
  */
-@ExperimentalSerializationApi
 public sealed class SerialKind {
 
     /**
@@ -37,7 +36,6 @@ public sealed class SerialKind {
      *
      * Corresponding encoder and decoder methods are [Encoder.encodeEnum] and [Decoder.decodeEnum].
      */
-    @ExperimentalSerializationApi
     public object ENUM : SerialKind()
 
     /**
@@ -50,7 +48,6 @@ public sealed class SerialKind {
      * However, if possible options are known statically (e.g. for sealed classes), they can be
      * enumerated in child descriptors similarly to [ENUM].
      */
-    @ExperimentalSerializationApi
     public object CONTEXTUAL : SerialKind()
 
     override fun toString(): String {
@@ -85,7 +82,6 @@ public sealed class SerialKind {
  * For the `Color` example, represented as single [Int], its descriptor should have [INT] kind, zero elements and serial name **not equals**
  * to `kotlin.Int`: `PrimitiveDescriptor("my.package.ColorAsInt", PrimitiveKind.INT)`
  */
-@OptIn(ExperimentalSerializationApi::class) // May be @Experimental, but break clients + makes impossible to use stable PrimitiveSerialDescriptor
 public sealed class PrimitiveKind : SerialKind() {
     /**
      * Primitive kind that represents a boolean `true`/`false` value.
@@ -188,7 +184,6 @@ public sealed class PrimitiveKind : SerialKind() {
  * For example, provided serializer for [Map.Entry] represents it as [Map] type, so it is serialized
  * as `{"actualKey": "actualValue"}` map directly instead of `{"key": "actualKey", "value": "actualValue"}`
  */
-@ExperimentalSerializationApi
 public sealed class StructureKind : SerialKind() {
 
     /**
@@ -239,7 +234,7 @@ public sealed class StructureKind : SerialKind() {
  * bounded and sealed polymorphism common property: not knowing the actual type statically and requiring
  * formats to additionally encode it.
  */
-@ExperimentalSerializationApi
+@ExperimentalSerializationApi // Intentionally left experimental to sort out things with buildSerialDescriptor(PolymorphicKind.SEALED)
 public sealed class PolymorphicKind : SerialKind() {
     /**
      * Sealed kind represents Kotlin sealed classes, where all subclasses are known statically at the moment of declaration.

--- a/core/commonMain/src/kotlinx/serialization/internal/Primitives.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/Primitives.kt
@@ -37,15 +37,15 @@ internal class PrimitiveSerialDescriptor(
         return false
     }
     override fun hashCode() = serialName.hashCode() + 31 * kind.hashCode()
-    private fun error(): Nothing = throw IllegalStateException("Primitive descriptor does not have elements")
+    private fun error(): Nothing = throw IllegalStateException("Primitive descriptor $serialName does not have elements")
 }
 
 internal fun PrimitiveDescriptorSafe(serialName: String, kind: PrimitiveKind): SerialDescriptor {
-    checkName(serialName)
+    checkNameIsNotAPrimitive(serialName)
     return PrimitiveSerialDescriptor(serialName, kind)
 }
 
-private fun checkName(serialName: String) {
+internal fun checkNameIsNotAPrimitive(serialName: String) {
     val values = BUILTIN_SERIALIZERS.values
     for (primitive in values) {
         val primitiveName = primitive.descriptor.serialName

--- a/core/commonTest/src/kotlinx/serialization/WrappedSerialDescriptorTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/WrappedSerialDescriptorTest.kt
@@ -58,4 +58,21 @@ class WrappedSerialDescriptorTest {
     fun testWrappedComplexClass() {
         checkWrapped(ComplexType.serializer().descriptor, "WrappedComplexType")
     }
+
+    @Test
+    fun testWrappedPrimitive() {
+        checkWrapped(Int.serializer().descriptor, "MyInt")
+    }
+
+    @Test
+    fun testWrappedPrimitiveContract() {
+        assertFails { SerialDescriptor("   ", ComplexType.serializer().descriptor) }
+        assertFails {
+            SerialDescriptor(
+                SimpleType.serializer().descriptor.serialName,
+                SimpleType.serializer().descriptor
+            )
+        }
+        assertFails { SerialDescriptor("kotlin.Int", Int.serializer().descriptor) }
+    }
 }

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborDecoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborDecoder.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.encoding.*
  * ```
  */
 @ExperimentalSerializationApi
+@SubclassOptInRequired(SealedSerializationApi::class)
 public interface CborDecoder : Decoder {
     /**
      * Exposes the current [Cbor] instance and all its configuration flags. Useful for low-level custom serializers.

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborEncoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborEncoder.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.encoding.*
  * ```
  */
 @ExperimentalSerializationApi
+@SubclassOptInRequired(SealedSerializationApi::class)
 public interface CborEncoder : Encoder {
     /**
      * Exposes the current [Cbor] instance and all its configuration flags. Useful for low-level custom serializers.

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonDecoder.kt
@@ -51,6 +51,7 @@ import kotlinx.serialization.descriptors.*
  * Accepting this interface in your API methods, casting [Decoder] to [JsonDecoder] and invoking its
  * methods is considered stable.
  */
+@SubclassOptInRequired(SealedSerializationApi::class)
 public interface JsonDecoder : Decoder, CompositeDecoder {
     /**
      * An instance of the current [Json].

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonEncoder.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.serialization.json
 
+import kotlinx.serialization.*
 import kotlinx.serialization.encoding.*
 
 /**
@@ -49,6 +50,7 @@ import kotlinx.serialization.encoding.*
  * Accepting this interface in your API methods, casting [Encoder] to [JsonEncoder] and invoking its
  * methods is considered stable.
  */
+@SubclassOptInRequired(SealedSerializationApi::class)
 public interface JsonEncoder : Encoder, CompositeEncoder {
     /**
      * An instance of the current [Json].

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -22,7 +22,6 @@ public fun <T> writeJson(json: Json, value: T, serializer: SerializationStrategy
     return result
 }
 
-@ExperimentalSerializationApi
 private sealed class AbstractJsonTreeEncoder(
     final override val json: Json,
     protected val nodeConsumer: (JsonElement) -> Unit

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,5 @@ org.gradle.caching=true
 kotlin.native.distribution.type=prebuilt
 
 org.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"
+
+org.jetbrains.dokka.experimental.tryK2=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.20"
 kover = "0.8.2"
-dokka = "1.9.20"
+dokka = "2.0.0-Beta"
 knit = "0.5.0"
 bcv = "0.16.2"
 animalsniffer = "1.7.1"


### PR DESCRIPTION
Same as #2764 but without `@AdvancedEncodingApi`. It seems that https://youtrack.jetbrains.com/issue/KTIJ-30831 is fixed only in K2 IDE and only in Kotlin 2.1, so introducing `@AdvancedEncodingApi` now may lead to poor UX for 3rd party format authors