### PR TITLE
Do not check kind or discriminator collisions

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonClassDiscriminatorModeTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonClassDiscriminatorModeTest.kt
@@ -99,7 +99,7 @@ class ClassDiscriminatorModeNoneTest :
                 subclass(Modify::class)
             }
         }
-        val j = Json { serializersModule = module; classDiscriminatorMode = ClassDiscriminatorMode.NONE }
+        val j = Json(default) { serializersModule = module; classDiscriminatorMode = ClassDiscriminatorMode.NONE }
         parametrizedTest { mode ->
             assertEquals("""{"cmd":"CREATE"}""", j.encodeToString(Command(Modify.CREATE), mode))
         }
@@ -115,7 +115,7 @@ class ClassDiscriminatorModeNoneTest :
                 subclass(SomeCommand::class)
             }
         }
-        val j = Json { serializersModule = module; classDiscriminatorMode = ClassDiscriminatorMode.NONE }
+        val j = Json(default) { serializersModule = module; classDiscriminatorMode = ClassDiscriminatorMode.NONE }
         parametrizedTest { mode ->
             assertEquals("""{"cmd":{"type":"foo"}}""", j.encodeToString(Command(SomeCommand("foo")), mode))
         }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonClassDiscriminatorModeTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonClassDiscriminatorModeTest.kt
@@ -4,7 +4,9 @@
 
 package kotlinx.serialization.json.polymorphic
 
+import kotlinx.serialization.*
 import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
 import kotlin.test.*
 
 class ClassDiscriminatorModeAllObjectsTest :
@@ -80,5 +82,43 @@ class ClassDiscriminatorModeNoneTest :
 
     @Test
     fun testNullable() = testNullable("""{"sb":null,"sc":null}""")
+
+    interface CommandType
+
+    enum class Modify : CommandType {
+        CREATE, DELETE
+    }
+
+    @Serializable
+    class Command(val cmd: CommandType)
+
+    @Test
+    fun testNoneModeAllowsPolymorphicEnums() {
+        val module = SerializersModule {
+            polymorphic(CommandType::class) {
+                subclass(Modify::class)
+            }
+        }
+        val j = Json { serializersModule = module; classDiscriminatorMode = ClassDiscriminatorMode.NONE }
+        parametrizedTest { mode ->
+            assertEquals("""{"cmd":"CREATE"}""", j.encodeToString(Command(Modify.CREATE), mode))
+        }
+    }
+
+    @Serializable
+    class SomeCommand(val type: String) : CommandType
+
+    @Test
+    fun testNoneModeAllowsDiscriminatorClash() {
+        val module = SerializersModule {
+            polymorphic(CommandType::class) {
+                subclass(SomeCommand::class)
+            }
+        }
+        val j = Json { serializersModule = module; classDiscriminatorMode = ClassDiscriminatorMode.NONE }
+        parametrizedTest { mode ->
+            assertEquals("""{"cmd":{"type":"foo"}}""", j.encodeToString(Command(SomeCommand("foo")), mode))
+        }
+    }
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -669,7 +669,7 @@ private class JsonImpl(configuration: JsonConfiguration, module: SerializersModu
 
     private fun validateConfiguration() {
         if (serializersModule == EmptySerializersModule()) return // Fast-path for in-place JSON allocations
-        val collector = PolymorphismValidator(configuration.useArrayPolymorphism, configuration.classDiscriminator)
+        val collector = JsonSerializersModuleValidator(configuration)
         serializersModule.dumpTo(collector)
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/Polymorphic.kt
@@ -37,8 +37,10 @@ internal inline fun <T> JsonEncoder.encodePolymorphically(
         val casted = serializer as AbstractPolymorphicSerializer<Any>
         requireNotNull(value) { "Value for serializer ${serializer.descriptor} should always be non-null. Please report issue to the kotlinx.serialization tracker." }
         val actual = casted.findPolymorphicSerializer(this, value)
-        if (baseClassDiscriminator != null) validateIfSealed(serializer, actual, baseClassDiscriminator)
-        checkKind(actual.descriptor.kind)
+        if (baseClassDiscriminator != null) {
+            validateIfSealed(serializer, actual, baseClassDiscriminator)
+            checkKind(actual.descriptor.kind)
+        }
         actual as SerializationStrategy<T>
     } else serializer
 


### PR DESCRIPTION
for subclasses' polymorphic serializers if Json.classDiscriminatorMode is set to NONE.

This should simplify the code in situations where JSON is expected to be only sent and not parsed.

Fixes #2753
Fixes #1486