### PR TITLE
ProtoName is now supported, allowing the overriding of the field name for ProtoBuf only.

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/ProtoTypes.kt
@@ -8,6 +8,16 @@ import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 
 /**
+ * Specifies protobuf field name assigned to a Kotlin property or class.
+ *
+ * Used to get around invalid naming conventions.
+ */
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@ExperimentalSerializationApi
+public annotation class ProtoName(public val name: String)
+
+/**
  * Specifies protobuf field number (a unique number for a field in the protobuf message)
  * assigned to a Kotlin property.
  *

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
@@ -16,7 +16,8 @@ import kotlinx.serialization.protobuf.internal.*
  * An arbitrary Kotlin class represent much wider object domain than the ProtoBuf specification, thus schema generator
  * has the following list of restrictions:
  *
- *  * Serial name of the class and all its fields should be a valid Proto [identifier](https://developers.google.com/protocol-buffers/docs/reference/proto2-spec)
+ *  * Serial name of the class and all its fields should be a valid Proto [identifier](https://developers.google.com/protocol-buffers/docs/reference/proto2-spec).
+ *    If this is a problem for you, you many override serial names for ProtoBuf only by using the [ProtoName] annotation for specific fields or classes.
  *  * Nullable values are allowed only for Kotlin [nullable][SerialDescriptor.isNullable] types, but not [optional][SerialDescriptor.isElementOptional]
  *    in order to properly distinguish "default" and "absent" values.
  *  * The name of the type without the package directive uniquely identifies the proto message type and two or more fields with the same serial name

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/schema/SchemaValidationsTest.kt
@@ -18,7 +18,15 @@ class SchemaValidationsTest {
     data class InvalidClassName(val i: Int)
 
     @Serializable
+    @SerialName("invalid serial name")
+    @ProtoName("ValidSerialName")
+    data class InvalidClassNameFixed(val i: Int)
+
+    @Serializable
     data class InvalidClassFieldName(@SerialName("invalid serial name") val i: Int)
+
+    @Serializable
+    data class InvalidClassFieldNameFixed(@ProtoName("okProtoName") @SerialName("invalid serial name") val i: Int)
 
     @Serializable
     data class FieldNumberDuplicates(@ProtoNumber(42) val i: Int, @ProtoNumber(42) val j: Int)
@@ -31,10 +39,24 @@ class SchemaValidationsTest {
     enum class InvalidEnumName { SINGLETON }
 
     @Serializable
+    @SerialName("invalid serial name")
+    @ProtoName("ValidEnumNameFixed")
+    enum class InvalidEnumNameFixed { SINGLETON }
+
+    @Serializable
     enum class InvalidEnumElementName {
         FIRST,
 
         @SerialName("invalid serial name")
+        SECOND
+    }
+
+    @Serializable
+    enum class InvalidEnumElementNameFixed {
+        FIRST,
+
+        @SerialName("invalid serial name")
+        @ProtoName("validSerialName")
         SECOND
     }
 
@@ -72,15 +94,33 @@ class SchemaValidationsTest {
     }
 
     @Test
+    fun testInvalidEnumElementSerialNameFixed() {
+        val descriptors = listOf(InvalidEnumElementNameFixed.serializer().descriptor)
+        println(ProtoBufSchemaGenerator.generateSchemaText(descriptors))
+    }
+
+    @Test
     fun testInvalidClassSerialName() {
         val descriptors = listOf(InvalidClassName.serializer().descriptor)
         assertFailsWith(IllegalArgumentException::class) { ProtoBufSchemaGenerator.generateSchemaText(descriptors) }
     }
 
     @Test
+    fun testInvalidClassSerialNameFixed() {
+        val descriptors = listOf(InvalidClassNameFixed.serializer().descriptor)
+        println(ProtoBufSchemaGenerator.generateSchemaText(descriptors))
+    }
+
+    @Test
     fun testInvalidClassFieldSerialName() {
         val descriptors = listOf(InvalidClassFieldName.serializer().descriptor)
         assertFailsWith(IllegalArgumentException::class) { ProtoBufSchemaGenerator.generateSchemaText(descriptors) }
+    }
+
+    @Test
+    fun testInvalidClassFieldSerialNameFixed() {
+        val descriptors = listOf(InvalidClassFieldNameFixed.serializer().descriptor)
+        println(ProtoBufSchemaGenerator.generateSchemaText(descriptors))
     }
 
     @Test
@@ -93,6 +133,12 @@ class SchemaValidationsTest {
     fun testInvalidEnumSerialName() {
         val descriptors = listOf(InvalidEnumName.serializer().descriptor)
         assertFailsWith(IllegalArgumentException::class) { ProtoBufSchemaGenerator.generateSchemaText(descriptors) }
+    }
+
+    @Test
+    fun testInvalidEnumSerialNameFixed() {
+        val descriptors = listOf(InvalidEnumNameFixed.serializer().descriptor)
+        println(ProtoBufSchemaGenerator.generateSchemaText(descriptors))
     }
 
     @Test


### PR DESCRIPTION
This is required for circumstances where an existing model in JSON has a name that is illegal in ProtoBuf, such as `_id` as one would find in a MongoDB model.