### PR TITLE
Correctly parse invalid numbers in JsonLiteral.long and other extensions

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonElementDecodingTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonElementDecodingTest.kt
@@ -3,6 +3,7 @@ package kotlinx.serialization.json
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.test.*
 import kotlin.test.*
 
 class JsonElementDecodingTest : JsonTestBase() {
@@ -106,5 +107,14 @@ class JsonElementDecodingTest : JsonTestBase() {
 
         assertJsonFormAndRestored(Wrapper.serializer(), Wrapper(value = JsonNull), """{"value":null}""", noExplicitNullsOrDefaultsJson)
         assertJsonFormAndRestored(Wrapper.serializer(), Wrapper(value = null), """{}""", noExplicitNullsOrDefaultsJson)
+    }
+
+    @Test
+    fun testLiteralIncorrectParsing() {
+        val str = """{"a": "3 digit then random string"}"""
+        val obj = Json.decodeFromString<JsonObject>(str)
+        assertFailsWithMessage<NumberFormatException>("Expected input to contain a single valid number") {
+            println(obj.getValue("a").jsonPrimitive.long)
+        }
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonPrimitiveSerializerTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/serializers/JsonPrimitiveSerializerTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.serialization.json.serializers
 
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
@@ -200,5 +201,18 @@ class JsonPrimitiveSerializerTest : JsonTestBase() {
         expectedActualULongs.forEach { (expected, actual) ->
             assertUnsignedNumberEncoding(expected, actual, JsonPrimitive(actual))
         }
+    }
+
+    @Serializable
+    class OuterLong(val a: Long)
+
+    @Test
+    fun testRejectingIncorrectNumbers() = parametrizedTest { mode ->
+        checkSerializationException({
+            default.decodeFromString(OuterLong.serializer(), """{"a":"12:34:45"}""", mode)
+        }, {
+            if (mode == JsonTestingMode.TREE) assertContains(it, "Failed to parse literal '\"12:34:45\"' as a long value at element: \$.a")
+            else assertContains(it, "Unexpected JSON token at offset 5: Expected closing quotation mark at path: \$.a")
+        })
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -112,19 +112,24 @@ private sealed class AbstractJsonTreeDecoder(
         getPrimitiveValue(tag, "boolean", JsonPrimitive::booleanOrNull)
 
     override fun decodeTaggedByte(tag: String) = getPrimitiveValue(tag, "byte") {
-        val result = int
+        val result = parseLongImpl()
         if (result in Byte.MIN_VALUE..Byte.MAX_VALUE) result.toByte()
         else null
     }
 
     override fun decodeTaggedShort(tag: String) = getPrimitiveValue(tag, "short") {
-        val result = int
+        val result = parseLongImpl()
         if (result in Short.MIN_VALUE..Short.MAX_VALUE) result.toShort()
         else null
     }
 
-    override fun decodeTaggedInt(tag: String) = getPrimitiveValue(tag, "int") { int }
-    override fun decodeTaggedLong(tag: String) = getPrimitiveValue(tag, "long") { long }
+    override fun decodeTaggedInt(tag: String) = getPrimitiveValue(tag, "int") {
+        val result = parseLongImpl()
+        if (result in Int.MIN_VALUE..Int.MAX_VALUE) result.toInt()
+        else null
+    }
+
+    override fun decodeTaggedLong(tag: String) = getPrimitiveValue(tag, "long") { parseLongImpl() }
 
     override fun decodeTaggedFloat(tag: String): Float {
         val result = getPrimitiveValue(tag, "float") { float }


### PR DESCRIPTION
Content must be consumed fully, with no leftovers after number. Also simplify try/catching logic — JsonLiteral.long should throw NumberFormatException, while decoding from JsonElement should throw JsonDecodingException

Fixes #2849