### PR TITLE
Make serial descriptor equality (and hashcode) include the declared (use side) element names, rather than only the serial names of the element types. This fixes pdvrieze/xmlutil#254.

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -114,6 +114,7 @@ internal inline fun <reified SD : SerialDescriptor> SD.equalsImpl(
     if (!typeParamsAreEqual(other)) return false
     if (this.elementsCount != other.elementsCount) return false
     for (index in 0 until elementsCount) {
+        if (getElementName(index) != other.getElementName(index)) return false
         if (getElementDescriptor(index).serialName != other.getElementDescriptor(index).serialName) return false
         if (getElementDescriptor(index).kind != other.getElementDescriptor(index).kind) return false
     }
@@ -125,8 +126,10 @@ internal fun SerialDescriptor.hashCodeImpl(typeParams: Array<SerialDescriptor>):
     var result = serialName.hashCode()
     result = 31 * result + typeParams.contentHashCode()
     val elementDescriptors = elementDescriptors
+    val elemNamesHash = (0 until elementsCount).elementsHashCodeBy { getElementName(it) }
     val namesHash = elementDescriptors.elementsHashCodeBy { it.serialName }
     val kindHash = elementDescriptors.elementsHashCodeBy { it.kind }
+    result = 31 * result + elemNamesHash
     result = 31 * result + namesHash
     result = 31 * result + kindHash
     return result


### PR DESCRIPTION
The xml parser uses the serial descriptor as part of the lookup key for extended type information. However, this does not work correctly
if two serial descriptors have the same name and member types, even if the element names are different. This pull request includes the
declared element names as part of the hash key and equals checking (I know that multiple types with the same `@SerialName` is not supposed to work, but with this change it at least breaks less.