### PR TITLE
Fix JsonPrimitive.isString documentation

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt
@@ -36,7 +36,7 @@ public sealed class JsonPrimitive : JsonElement() {
      * Indicates whether the primitive was explicitly constructed from [String] and
      * whether it should be serialized as one. E.g. `JsonPrimitive("42")` is represented
      * by a string, while `JsonPrimitive(42)` is not.
-     * These primitives will be serialized as `42` and `"42"` respectively.
+     * These primitives will be serialized as `"42"` and `42` respectively.
      */
     public abstract val isString: Boolean
 


### PR DESCRIPTION
correctly quote primitives

Fixes #2863