### PR TITLE
Speedup ProtoWriteType.from

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoMapBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/protobuf/ProtoMapBenchmark.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.benchmarks.protobuf
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class ProtoMapBenchmark {
+
+    @Serializable
+    class Holder(val map: Map<String, Int>)
+
+    private val value = Holder((0..128).associateBy { it.toString() })
+    private val bytes = ProtoBuf.encodeToByteArray(value)
+
+    @Benchmark
+    fun toBytes() = ProtoBuf.encodeToByteArray(Holder.serializer(), value)
+
+    @Benchmark
+    fun fromBytes() = ProtoBuf.decodeFromByteArray(Holder.serializer(), bytes)
+}

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -26,11 +26,13 @@ internal enum class ProtoWireType(val typeId: Int) {
             ProtoWireType.entries.find { it.typeId == typeId } ?: INVALID
         }
 
-        fun from(typeId: Int): ProtoWireType {
-            if (typeId < 0 || typeId >= entryArray.size) {
-                return INVALID
-            }
-            return entryArray[typeId]
+        /**
+         * Extracts three least significant bits from the [value] and
+         * returns [ProtoWireType] with corresponding type id, or [ProtoWireType.INVALID]
+         * if there are no such a type.
+         */
+        fun fromLeastSignificantBits(value: Int): ProtoWireType {
+            return entryArray[value and 0b111]
         }
     }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/Helpers.kt
@@ -22,8 +22,15 @@ internal enum class ProtoWireType(val typeId: Int) {
     ;
 
     companion object {
+        private val entryArray = Array(8) { typeId ->
+            ProtoWireType.entries.find { it.typeId == typeId } ?: INVALID
+        }
+
         fun from(typeId: Int): ProtoWireType {
-            return ProtoWireType.entries.find { it.typeId == typeId } ?: INVALID
+            if (typeId < 0 || typeId >= entryArray.size) {
+                return INVALID
+            }
+            return entryArray[typeId]
         }
     }
 

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufReader.kt
@@ -42,7 +42,7 @@ internal class ProtobufReader(private val input: ByteArrayInput) {
             -1
         } else {
             currentId = header ushr 3
-            currentType = ProtoWireType.from(header and 0b111)
+            currentType = ProtoWireType.fromLeastSignificantBits(header)
             currentId
         }
     }


### PR DESCRIPTION
While poking into https://github.com/Kotlin/kotlinx.serialization/issues/2332 I spotted that `ProtoWriteType.from` implementation is pretty inefficient.

There are a few ways to transform integer into a corresponding `ProtoWriteType`.
Corresponding benchmarks are here: https://github.com/fzhinkin/kx-serialization-parse-proto-type/blob/main/src/commonMain/kotlin/ParseProtoTypeBenchmark.kt

On JVM (see https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fzhinkin/c8b3335e6ba79ec06e9acffc85230e28/raw/e420db8bbb80cf03f772862eb6a58cd7509cf617/parsing-jvm.json), both 8-aligned array-based approaches works fine.
On Native (see https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fzhinkin/c8b3335e6ba79ec06e9acffc85230e28/raw/e420db8bbb80cf03f772862eb6a58cd7509cf617/parsing-macos-arm64.json), moving masking into a function works a bit faster.

Here's comparison of results proto-related benchmarks collected with existing implementation (baseline) and the implementation from this PR (optimized): https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fzhinkin/c8b3335e6ba79ec06e9acffc85230e28/raw/e420db8bbb80cf03f772862eb6a58cd7509cf617/baseline.json,https://gist.githubusercontent.com/fzhinkin/c8b3335e6ba79ec06e9acffc85230e28/raw/e420db8bbb80cf03f772862eb6a58cd7509cf617/optimized.json

Suspiciously looking `ProtoBaseline.toBytesExplicit` shows bimodal results, thus the results.
For parsing related benchmarks, the proposed change slightly improves performance.