### PR TITLE
Disallow missing commas between fields (#2287 #2520)

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonParserTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonParserTest.kt
@@ -6,7 +6,6 @@ package kotlinx.serialization.json
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
-import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 
@@ -79,11 +78,11 @@ class JsonParserTest : JsonTestBase() {
     fun testTrailingComma() {
         testTrailingComma("{\"id\":0,}")
         testTrailingComma("{\"id\":0  ,}")
-        testTrailingComma("{\"id\":0  , ,}")
+        testTrailingComma("{\"id\":0  , ,}", message = "Multiple consecutive commas are not allowed in JSON")
     }
 
-    private fun testTrailingComma(content: String) {
-        assertFailsWithSerialMessage("JsonDecodingException", "Trailing comma before the end of JSON object") {  Json.parseToJsonElement(content) }
+    private fun testTrailingComma(content: String, message: String = "Trailing comma before the end of JSON object") {
+        assertFailsWithSerialMessage("JsonDecodingException", message) { Json.parseToJsonElement(content) }
     }
 
     @Test

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/MissingCommaTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/MissingCommaTest.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 
-class MissingCommaTest: JsonTestBase() {
+class MissingCommaTest : JsonTestBase() {
     @Serializable
     class Holder(
         val i: Int,
@@ -68,7 +68,7 @@ class MissingCommaTest: JsonTestBase() {
     }
 
     @Test
-    fun missingCommaInDynamicMap(){
+    fun missingCommaInDynamicMap() {
         val m = "Unexpected JSON token at offset 9: Expected end of the object or comma at path: \$"
         val json = """{"i":42 "c":{"i":"string"}}"""
         assertFailsWithSerialMessage("JsonDecodingException", m) {
@@ -77,12 +77,22 @@ class MissingCommaTest: JsonTestBase() {
     }
 
     @Test
-    fun missingCommaInArray(){
+    fun missingCommaInArray() {
         val m = "Unexpected JSON token at offset 3: Expected end of the array or comma at path: \$[0]"
         val json = """[1 2 3 4]"""
 
         assertFailsWithSerialMessage("JsonDecodingException", m) {
             default.decodeFromString<List<Int>>(json)
+        }
+    }
+
+    @Test
+    fun missingCommaInStringMap() {
+        val m = "Unexpected JSON token at offset 9: Expected comma after the key-value pair at path: \$['a']"
+        val json = """{"a":"1" "b":"2"}"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", m) {
+            default.decodeFromString<Map<String, String>>(json)
         }
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/MissingCommaTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/MissingCommaTest.kt
@@ -26,7 +26,7 @@ class MissingCommaTest : JsonTestBase() {
     @Test
     fun missingCommaBetweenFieldsAfterPrimitive() {
         val message =
-            "Unexpected JSON token at offset 8: Expected comma after the key-value pair at path: \$.i"
+            "Unexpected JSON token at offset 8: Expected end of the object or comma at path: \$"
         val json = """{"i":42 "c":{"i":"string"}}"""
 
         assertFailsWithSerialMessage("JsonDecodingException", message) {
@@ -37,7 +37,7 @@ class MissingCommaTest : JsonTestBase() {
     @Test
     fun missingCommaBetweenFieldsAfterObject() {
         val message =
-            "Unexpected JSON token at offset 19: Expected comma after the key-value pair at path: \$.c"
+            "Unexpected JSON token at offset 19: Expected end of the object or comma at path: \$"
         val json = """{"c":{"i":"string"}"i":42}"""
 
         assertFailsWithSerialMessage("JsonDecodingException", message) {
@@ -48,7 +48,7 @@ class MissingCommaTest : JsonTestBase() {
     @Test
     fun allowTrailingCommaDoesNotApplyToCommaBetweenFields() {
         val message =
-            "Unexpected JSON token at offset 8: Expected comma after the key-value pair at path: \$.i"
+            "Unexpected JSON token at offset 8: Expected end of the object or comma at path: \$"
         val json = """{"i":42 "c":{"i":"string"}}"""
 
         assertFailsWithSerialMessage("JsonDecodingException", message) {
@@ -59,7 +59,7 @@ class MissingCommaTest : JsonTestBase() {
     @Test
     fun lenientSerializeDoesNotAllowToSkipCommaBetweenFields() {
         val message =
-            "Unexpected JSON token at offset 8: Expected comma after the key-value pair at path: \$.i"
+            "Unexpected JSON token at offset 8: Expected end of the object or comma at path: \$"
         val json = """{"i":42 "c":{"i":"string"}}"""
 
         assertFailsWithSerialMessage("JsonDecodingException", message) {
@@ -69,7 +69,7 @@ class MissingCommaTest : JsonTestBase() {
 
     @Test
     fun missingCommaInDynamicMap() {
-        val m = "Unexpected JSON token at offset 9: Expected end of the object or comma at path: \$"
+        val m = "Unexpected JSON token at offset 8: Expected end of the object or comma at path: \$"
         val json = """{"i":42 "c":{"i":"string"}}"""
         assertFailsWithSerialMessage("JsonDecodingException", m) {
             default.parseToJsonElement(json)
@@ -78,7 +78,7 @@ class MissingCommaTest : JsonTestBase() {
 
     @Test
     fun missingCommaInArray() {
-        val m = "Unexpected JSON token at offset 3: Expected end of the array or comma at path: \$[0]"
+        val m = "Unexpected JSON token at offset 3: Expected end of the array or comma at path: \$"
         val json = """[1 2 3 4]"""
 
         assertFailsWithSerialMessage("JsonDecodingException", m) {
@@ -88,11 +88,21 @@ class MissingCommaTest : JsonTestBase() {
 
     @Test
     fun missingCommaInStringMap() {
-        val m = "Unexpected JSON token at offset 9: Expected comma after the key-value pair at path: \$['a']"
+        val m = "Unexpected JSON token at offset 9: Expected end of the object or comma at path: \$"
         val json = """{"a":"1" "b":"2"}"""
 
         assertFailsWithSerialMessage("JsonDecodingException", m) {
             default.decodeFromString<Map<String, String>>(json)
+        }
+    }
+
+    @Test
+    fun missingCommaInUnknownKeys() {
+        val m = "Unexpected JSON token at offset 17: Expected end of the object or comma at path: \$"
+        val json = """{"i":"1","b":"2" "c":"2"}"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", m) {
+            lenient.decodeFromString<Child>(json)
         }
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/MissingCommaTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/MissingCommaTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+
+import kotlinx.serialization.*
+import kotlinx.serialization.test.*
+import kotlin.test.*
+
+class MissingCommaTest: JsonTestBase() {
+    @Serializable
+    class Holder(
+        val i: Int,
+        val c: Child,
+    )
+
+    @Serializable
+    class Child(
+        val i: String
+    )
+
+    private val withTrailingComma = Json { allowTrailingComma = true }
+
+    @Test
+    fun missingCommaBetweenFieldsAfterPrimitive() {
+        val message =
+            "Unexpected JSON token at offset 8: Expected comma after the key-value pair at path: \$.i"
+        val json = """{"i":42 "c":{"i":"string"}}"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", message) {
+            default.decodeFromString<Holder>(json)
+        }
+    }
+
+    @Test
+    fun missingCommaBetweenFieldsAfterObject() {
+        val message =
+            "Unexpected JSON token at offset 19: Expected comma after the key-value pair at path: \$.c"
+        val json = """{"c":{"i":"string"}"i":42}"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", message) {
+            default.decodeFromString<Holder>(json)
+        }
+    }
+
+    @Test
+    fun allowTrailingCommaDoesNotApplyToCommaBetweenFields() {
+        val message =
+            "Unexpected JSON token at offset 8: Expected comma after the key-value pair at path: \$.i"
+        val json = """{"i":42 "c":{"i":"string"}}"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", message) {
+            withTrailingComma.decodeFromString<Holder>(json)
+        }
+    }
+
+    @Test
+    fun lenientSerializeDoesNotAllowToSkipCommaBetweenFields() {
+        val message =
+            "Unexpected JSON token at offset 8: Expected comma after the key-value pair at path: \$.i"
+        val json = """{"i":42 "c":{"i":"string"}}"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", message) {
+            lenient.decodeFromString<Holder>(json)
+        }
+    }
+
+    @Test
+    fun missingCommaInDynamicMap(){
+        val m = "Unexpected JSON token at offset 9: Expected end of the object or comma at path: \$"
+        val json = """{"i":42 "c":{"i":"string"}}"""
+        assertFailsWithSerialMessage("JsonDecodingException", m) {
+            default.parseToJsonElement(json)
+        }
+    }
+
+    @Test
+    fun missingCommaInArray(){
+        val m = "Unexpected JSON token at offset 3: Expected end of the array or comma at path: \$[0]"
+        val json = """[1 2 3 4]"""
+
+        assertFailsWithSerialMessage("JsonDecodingException", m) {
+            default.decodeFromString<List<Int>>(json)
+        }
+    }
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/TrailingCommaTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/TrailingCommaTest.kt
@@ -125,4 +125,45 @@ class TrailingCommaTest : JsonTestBase() {
             "wl":{"l":[1, 2, 3,],},}"""
         assertEquals(Mixed(multipleFields, withMap, withList), tj.decodeFromString(input, mode))
     }
+
+    @Test
+    fun testCommaReportedPosition() = parametrizedTest { mode ->
+        val sd = """{"a":"1",    }"""
+
+        checkSerializationException({
+            default.decodeFromString<Map<String, String>>(sd, mode)
+        }, { message ->
+            assertContains(
+                message,
+                """Unexpected JSON token at offset 8: Trailing comma before the end of JSON object"""
+            )
+        })
+    }
+
+    @Test
+    fun testMultipleTrailingCommasAreNotAllowedEvenWhenTrailingIsEnabled() = parametrizedTest { mode ->
+        val sd = """{"a":"1",,}"""
+        checkSerializationException({
+            tj.decodeFromString<Map<String, String>>(sd, mode)
+        }, { message ->
+            assertContains(
+                message,
+                """Unexpected JSON token at offset 9: Multiple consecutive commas are not allowed in JSON"""
+            )
+        })
+    }
+
+    @Test
+    fun testMultipleTrailingCommasError() = parametrizedTest { mode ->
+        val sd = """{"a":"1",,,}"""
+
+        checkSerializationException({
+            default.decodeFromString<Map<String, String>>(sd, mode)
+        }, { message ->
+            assertContains(
+                message,
+                """Unexpected JSON token at offset 9: Multiple consecutive commas are not allowed in JSON"""
+            )
+        })
+    }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
@@ -46,13 +46,6 @@ internal fun AbstractJsonLexer.throwInvalidFloatingPointDecoded(result: Number):
         hint = specialFlowingValuesHint)
 }
 
-internal fun AbstractJsonLexer.invalidTrailingComma(entity: String = "object"): Nothing {
-    fail("Trailing comma before the end of JSON $entity",
-        position = currentPosition - 1,
-        hint = "Trailing commas are non-complaint JSON and not allowed by default. Use 'allowTrailingComma = true' in 'Json {}' builder to support them."
-    )
-}
-
 @OptIn(ExperimentalSerializationApi::class)
 internal fun InvalidKeyKindException(keyDescriptor: SerialDescriptor) = JsonEncodingException(
     "Value of type '${keyDescriptor.serialName}' can't be used in JSON as a key in the map. " +

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -45,7 +45,8 @@ internal open class StreamingJsonDecoder(
     private var discriminatorHolder: DiscriminatorHolder? = discriminatorHolder
     private val configuration = json.configuration
 
-    private val elementMarker: JsonElementMarker? = if (configuration.explicitNulls) null else JsonElementMarker(descriptor)
+    private val elementMarker: JsonElementMarker? =
+        if (configuration.explicitNulls) null else JsonElementMarker(descriptor)
 
     override fun decodeJsonElement(): JsonElement = JsonTreeReader(json.configuration, lexer).read()
 
@@ -76,14 +77,14 @@ internal open class StreamingJsonDecoder(
 
             @Suppress("UNCHECKED_CAST")
             val actualSerializer = try {
-                    deserializer.findPolymorphicSerializer(this, type)
-                } catch (it: SerializationException) { // Wrap SerializationException into JsonDecodingException to preserve position, path, and input.
-                    // Split multiline message from private core function:
-                    // core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt:102
-                    val message = it.message!!.substringBefore('\n').removeSuffix(".")
-                    val hint = it.message!!.substringAfter('\n', missingDelimiterValue = "")
-                    lexer.fail(message, hint = hint)
-                } as DeserializationStrategy<T>
+                deserializer.findPolymorphicSerializer(this, type) as DeserializationStrategy<T>
+            } catch (it: SerializationException) { // Wrap SerializationException into JsonDecodingException to preserve position, path, and input.
+                // Split multiline message from private core function:
+                // core/commonMain/src/kotlinx/serialization/internal/AbstractPolymorphicSerializer.kt:102
+                val message = it.message!!.substringBefore('\n').removeSuffix(".")
+                val hint = it.message!!.substringAfter('\n', missingDelimiterValue = "")
+                lexer.fail(message, hint = hint)
+            }
 
             discriminatorHolder = DiscriminatorHolder(discriminator)
             return actualSerializer.deserialize(this)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -239,18 +239,18 @@ internal open class StreamingJsonDecoder(
             val key = decodeStringKey()
             lexer.consumeNextToken(COLON)
             val index = descriptor.getJsonNameIndex(json, key)
+            currentIndex = index
 
             if (index == UNKNOWN_NAME) {
                 handleUnknown(descriptor, key)
-                currentIndex = UNKNOWN_NAME
                 continue
             }
 
             if (configuration.coerceInputValues && coerceInputValue(descriptor, index)) {
                 continue
             }
+
             elementMarker?.mark(index)
-            currentIndex = index
             return index
         }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
@@ -765,7 +765,6 @@ internal abstract class AbstractJsonLexer {
 
         if (peeked == charToTokenClass(expectedEnd) && !allowTrailing) {
             path.popDescriptor()
-
             fail(
                 "Trailing comma before the end of JSON $entity",
                 position = commaPosition,
@@ -774,11 +773,7 @@ internal abstract class AbstractJsonLexer {
         }
         if (peeked == TC_COMMA) {
             path.popDescriptor()
-            fail(
-                "Multiple consecutive commas are not allowed in JSON",
-                position = currentPosition,
-                hint = "Trailing commas are non-complaint JSON and not allowed by default. Use 'allowTrailingComma = true' in 'Json {}' builder to support them."
-            )
+            fail("Multiple consecutive commas are not allowed in JSON")
         }
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
@@ -760,9 +760,10 @@ internal abstract class AbstractJsonLexer {
             path.popDescriptor()
             fail("Expected end of the $entity or comma")
         }
-        val commaPosition = currentPosition++ // consumes peeked comma
-        val peeked = peekNextToken()
+        val commaPosition = currentPosition
+        consumeNextToken() // consume comma
 
+        val peeked = peekNextToken()
         if (peeked == charToTokenClass(expectedEnd) && !allowTrailing) {
             path.popDescriptor()
             fail(


### PR DESCRIPTION
Fixes #2287 and #2520, makes sure that comma between key-value pairs is required in `Json.decodeFromString`