### PR TITLE
Restructure source-sets-conventions.gradle.kts 

### DIFF
--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -64,14 +64,24 @@ kotlin {
     sourceSets.all {
         kotlin.srcDirs("$name/src")
         resources.srcDirs("$name/resources")
-        languageSettings {
-            progressiveMode = true
+    }
 
-            optIn("kotlin.ExperimentalMultiplatform")
-            optIn("kotlin.ExperimentalSubclassOptIn")
-            optIn("kotlinx.serialization.InternalSerializationApi")
-            optIn("kotlinx.serialization.SealedSerializationApi")
+    compilerOptions {
+        // These configuration replaces 'languageSettings' config on line 67
+        progressiveMode.set(true)
+        optIn.addAll(
+            listOf(
+                "kotlin.ExperimentalMultiplatform",
+                "kotlin.ExperimentalSubclassOptIn",
+                "kotlinx.serialization.InternalSerializationApi",
+                "kotlinx.serialization.SealedSerializationApi",
+            )
+        )
+        if (overriddenLanguageVersion != null) {
+            languageVersion = KotlinVersion.fromVersion(overriddenLanguageVersion!!)
+            freeCompilerArgs.add("-Xsuppress-version-warnings")
         }
+        freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
     sourceSets {
@@ -126,10 +136,5 @@ tasks.withType(KotlinCompilationTask::class).configureEach {
         if (isMainTaskName) {
             allWarningsAsErrors = true
         }
-        if (overriddenLanguageVersion != null) {
-            languageVersion = KotlinVersion.fromVersion(overriddenLanguageVersion!!)
-            freeCompilerArgs.add("-Xsuppress-version-warnings")
-        }
-        freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 }


### PR DESCRIPTION
so it applies overridenLanugageVersion to all source sets using the new compilerOptions DSL.

Previously, only leaf source sets were affected because the language version was applied to the KotlinCompilationTask configuration.