### PR TITLE
Make type argument in JsonTransformingSerializer nullable 

### DIFF
--- a/formats/json/api/kotlinx-serialization-json.klib.api
+++ b/formats/json/api/kotlinx-serialization-json.klib.api
@@ -111,7 +111,7 @@ abstract class <#A: kotlin/Any> kotlinx.serialization.json/JsonContentPolymorphi
     final fun serialize(kotlinx.serialization.encoding/Encoder, #A) // kotlinx.serialization.json/JsonContentPolymorphicSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;1:0){}[0]
 }
 
-abstract class <#A: kotlin/Any> kotlinx.serialization.json/JsonTransformingSerializer : kotlinx.serialization/KSerializer<#A> { // kotlinx.serialization.json/JsonTransformingSerializer|null[0]
+abstract class <#A: kotlin/Any?> kotlinx.serialization.json/JsonTransformingSerializer : kotlinx.serialization/KSerializer<#A> { // kotlinx.serialization.json/JsonTransformingSerializer|null[0]
     constructor <init>(kotlinx.serialization/KSerializer<#A>) // kotlinx.serialization.json/JsonTransformingSerializer.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
 
     open val descriptor // kotlinx.serialization.json/JsonTransformingSerializer.descriptor|{}descriptor[0]

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt
@@ -52,7 +52,7 @@ import kotlinx.serialization.json.internal.*
  *        Should be able to parse [JsonElement] from [transformDeserialize] function.
  *        Usually, default [serializer] is sufficient.
  */
-public abstract class JsonTransformingSerializer<T : Any>(
+public abstract class JsonTransformingSerializer<T : Any?>(
     private val tSerializer: KSerializer<T>
 ) : KSerializer<T> {
 


### PR DESCRIPTION
This will allow for more flexible Json transformations, replacing invalid/unexpected input data with `null`s.