### PR TITLE
Add watchosDeviceArm64 to Okio projects

### DIFF
--- a/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
@@ -36,13 +36,13 @@ kotlin {
 
     // Tier 3
     mingwX64()
+    watchosDeviceArm64()
     // https://github.com/square/okio/issues/1242#issuecomment-1759357336
     if (doesNotDependOnOkio(project)) {
         androidNativeArm32()
         androidNativeArm64()
         androidNativeX86()
         androidNativeX64()
-        watchosDeviceArm64()
 
         // Deprecated, but not removed
         linuxArm32Hfp()

--- a/formats/json-okio/api/kotlinx-serialization-json-okio.klib.api
+++ b/formats/json-okio/api/kotlinx-serialization-json-okio.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true


### PR DESCRIPTION
As of [Okio 3.7.0](https://github.com/square/okio/blob/master/CHANGELOG.md#version-370) (currently using `3.9.0`) projects that depend on Okio can start building and releasing for `watchosDeviceArm64`.