### PR TITLE
Add kotlin.time.Instant serializers 

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -202,7 +202,17 @@ public final class kotlinx/serialization/builtins/BuiltinSerializersKt {
 	public static final fun serializer (Lkotlin/jvm/internal/ShortCompanionObject;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/jvm/internal/StringCompanionObject;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/time/Duration$Companion;)Lkotlinx/serialization/KSerializer;
+	public static final fun serializer (Lkotlin/time/Instant$Companion;)Lkotlinx/serialization/KSerializer;
 	public static final fun serializer (Lkotlin/uuid/Uuid$Companion;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/serialization/builtins/InstantComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/serialization/builtins/InstantComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlin/time/Instant;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlin/time/Instant;)V
 }
 
 public final class kotlinx/serialization/builtins/LongAsStringSerializer : kotlinx/serialization/KSerializer {
@@ -793,6 +803,15 @@ public final class kotlinx/serialization/internal/InlineClassDescriptor : kotlin
 
 public final class kotlinx/serialization/internal/InlineClassDescriptorKt {
 	public static final fun InlinePrimitiveDescriptor (Ljava/lang/String;Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class kotlinx/serialization/internal/InstantSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/serialization/internal/InstantSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlin/time/Instant;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlin/time/Instant;)V
 }
 
 public final class kotlinx/serialization/internal/IntArrayBuilder : kotlinx/serialization/internal/PrimitiveArrayBuilder {

--- a/core/api/kotlinx-serialization-core.klib.api
+++ b/core/api/kotlinx-serialization-core.klib.api
@@ -890,6 +890,14 @@ sealed class kotlinx.serialization.modules/SerializersModule { // kotlinx.serial
     final fun <#A1: kotlin/Any> getContextual(kotlin.reflect/KClass<#A1>): kotlinx.serialization/KSerializer<#A1>? // kotlinx.serialization.modules/SerializersModule.getContextual|getContextual(kotlin.reflect.KClass<0:0>){0§<kotlin.Any>}[0]
 }
 
+final object kotlinx.serialization.builtins/InstantComponentSerializer : kotlinx.serialization/KSerializer<kotlin.time/Instant> { // kotlinx.serialization.builtins/InstantComponentSerializer|null[0]
+    final val descriptor // kotlinx.serialization.builtins/InstantComponentSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.serialization.builtins/InstantComponentSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlin.time/Instant // kotlinx.serialization.builtins/InstantComponentSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlin.time/Instant) // kotlinx.serialization.builtins/InstantComponentSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlin.time.Instant){}[0]
+}
+
 final object kotlinx.serialization.builtins/LongAsStringSerializer : kotlinx.serialization/KSerializer<kotlin/Long> { // kotlinx.serialization.builtins/LongAsStringSerializer|null[0]
     final val descriptor // kotlinx.serialization.builtins/LongAsStringSerializer.descriptor|{}descriptor[0]
         final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.serialization.builtins/LongAsStringSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
@@ -954,6 +962,14 @@ final object kotlinx.serialization.internal/FloatSerializer : kotlinx.serializat
 
     final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlin/Float // kotlinx.serialization.internal/FloatSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlin/Float) // kotlinx.serialization.internal/FloatSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlin.Float){}[0]
+}
+
+final object kotlinx.serialization.internal/InstantSerializer : kotlinx.serialization/KSerializer<kotlin.time/Instant> { // kotlinx.serialization.internal/InstantSerializer|null[0]
+    final val descriptor // kotlinx.serialization.internal/InstantSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.serialization.internal/InstantSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlin.time/Instant // kotlinx.serialization.internal/InstantSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlin.time/Instant) // kotlinx.serialization.internal/InstantSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlin.time.Instant){}[0]
 }
 
 final object kotlinx.serialization.internal/IntArraySerializer : kotlinx.serialization.internal/PrimitiveArraySerializer<kotlin/Int, kotlin/IntArray, kotlinx.serialization.internal/IntArrayBuilder>, kotlinx.serialization/KSerializer<kotlin/IntArray> // kotlinx.serialization.internal/IntArraySerializer|null[0]
@@ -1074,6 +1090,7 @@ final val kotlinx.serialization.modules/EmptySerializersModule // kotlinx.serial
     final fun <get-EmptySerializersModule>(): kotlinx.serialization.modules/SerializersModule // kotlinx.serialization.modules/EmptySerializersModule.<get-EmptySerializersModule>|<get-EmptySerializersModule>(){}[0]
 
 final fun (kotlin.time/Duration.Companion).kotlinx.serialization.builtins/serializer(): kotlinx.serialization/KSerializer<kotlin.time/Duration> // kotlinx.serialization.builtins/serializer|serializer@kotlin.time.Duration.Companion(){}[0]
+final fun (kotlin.time/Instant.Companion).kotlinx.serialization.builtins/serializer(): kotlinx.serialization/KSerializer<kotlin.time/Instant> // kotlinx.serialization.builtins/serializer|serializer@kotlin.time.Instant.Companion(){}[0]
 final fun (kotlin.uuid/Uuid.Companion).kotlinx.serialization.builtins/serializer(): kotlinx.serialization/KSerializer<kotlin.uuid/Uuid> // kotlinx.serialization.builtins/serializer|serializer@kotlin.uuid.Uuid.Companion(){}[0]
 final fun (kotlin/Boolean.Companion).kotlinx.serialization.builtins/serializer(): kotlinx.serialization/KSerializer<kotlin/Boolean> // kotlinx.serialization.builtins/serializer|serializer@kotlin.Boolean.Companion(){}[0]
 final fun (kotlin/Byte.Companion).kotlinx.serialization.builtins/serializer(): kotlinx.serialization/KSerializer<kotlin/Byte> // kotlinx.serialization.builtins/serializer|serializer@kotlin.Byte.Companion(){}[0]

--- a/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.internal.*
 import kotlin.reflect.*
 import kotlinx.serialization.descriptors.*
 import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlin.uuid.*
 
 /**
@@ -250,6 +252,19 @@ public fun UShort.Companion.serializer(): KSerializer<UShort> = UShortSerializer
  * The result of serialization is similar to calling [Duration.toIsoString], for deserialization is [Duration.parseIsoString].
  */
 public fun Duration.Companion.serializer(): KSerializer<Duration> = DurationSerializer
+
+/**
+ * Returns serializer for [Instant].
+ * It is serialized as a string that represents an instant in the format described in ISO-8601-1:2019, 5.4.2.1b).
+ *
+ * Deserialization is case-insensitive.
+ * More details can be found in the documentation of [Instant.toString] and [Instant.parse] functions.
+ *
+ * @see Instant.toString
+ * @see Instant.parse
+ */
+@ExperimentalTime
+public fun Instant.Companion.serializer(): KSerializer<Instant> = InstantSerializer
 
 /**
  * Returns serializer for [Uuid].

--- a/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
@@ -247,15 +247,20 @@ public fun UShort.Companion.serializer(): KSerializer<UShort> = UShortSerializer
 
 /**
  * Returns serializer for [Duration].
- * It is serialized as a string that represents a duration in the ISO-8601-2 format.
+ * It is serialized as a string that represents a duration in the format used by [Duration.toIsoString],
+ * that is, the ISO-8601-2 format.
  *
- * The result of serialization is similar to calling [Duration.toIsoString], for deserialization is [Duration.parseIsoString].
+ * For deserialization, [Duration.parseIsoString] is used.
+ *
+ * @see Duration.toIsoString
+ * @see Duration.parseIsoString
  */
 public fun Duration.Companion.serializer(): KSerializer<Duration> = DurationSerializer
 
 /**
  * Returns serializer for [Instant].
- * It is serialized as a string that represents an instant in the format described in ISO-8601-1:2019, 5.4.2.1b).
+ * It is serialized as a string that represents an instant in the format used by [Instant.toString]
+ * and described in ISO-8601-1:2019, 5.4.2.1b).
  *
  * Deserialization is case-insensitive.
  * More details can be found in the documentation of [Instant.toString] and [Instant.parse] functions.

--- a/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
@@ -29,11 +29,11 @@ public object InstantComponentSerializer : KSerializer<Instant> {
         decoder.decodeStructure(descriptor) {
             var epochSeconds: Long? = null
             var nanosecondsOfSecond = 0
-            loop@ while (true) {
+            while (true) {
                 when (val index = decodeElementIndex(descriptor)) {
                     0 -> epochSeconds = decodeLongElement(descriptor, 0)
                     1 -> nanosecondsOfSecond = decodeIntElement(descriptor, 1)
-                    CompositeDecoder.DECODE_DONE -> break@loop // https://youtrack.jetbrains.com/issue/KT-42262
+                    CompositeDecoder.DECODE_DONE -> break
                     else -> throw SerializationException("Unexpected index: $index")
                 }
             }

--- a/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.builtins
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@ExperimentalTime
+public object InstantComponentSerializer : KSerializer<Instant> {
+
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("kotlinx.serialization.InstantComponentSerializer") {
+            element<Long>("epochSeconds")
+            element<Long>("nanosecondsOfSecond", isOptional = true)
+        }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun deserialize(decoder: Decoder): Instant =
+        decoder.decodeStructure(descriptor) {
+            var epochSeconds: Long? = null
+            var nanosecondsOfSecond = 0
+            loop@ while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> epochSeconds = decodeLongElement(descriptor, 0)
+                    1 -> nanosecondsOfSecond = decodeIntElement(descriptor, 1)
+                    CompositeDecoder.DECODE_DONE -> break@loop // https://youtrack.jetbrains.com/issue/KT-42262
+                    else -> throw SerializationException("Unexpected index: $index")
+                }
+            }
+            if (epochSeconds == null) throw MissingFieldException(
+                missingField = "epochSeconds",
+                serialName = descriptor.serialName
+            )
+            Instant.fromEpochSeconds(epochSeconds, nanosecondsOfSecond)
+        }
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeStructure(descriptor) {
+            encodeLongElement(descriptor, 0, value.epochSeconds)
+            if (value.nanosecondsOfSecond != 0) {
+                encodeIntElement(descriptor, 1, value.nanosecondsOfSecond)
+            }
+        }
+    }
+
+}

--- a/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
@@ -10,6 +10,11 @@ import kotlinx.serialization.encoding.*
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Serializer that encodes and decodes [Instant] as its second and nanosecond components of the Unix time.
+ *
+ * JSON example: `{"epochSeconds":1607505416,"nanosecondsOfSecond":124000}`.
+ */
 @ExperimentalTime
 public object InstantComponentSerializer : KSerializer<Instant> {
 

--- a/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/InstantComponentSerializer.kt
@@ -52,7 +52,7 @@ public object InstantComponentSerializer : KSerializer<Instant> {
     override fun serialize(encoder: Encoder, value: Instant) {
         encoder.encodeStructure(descriptor) {
             encodeLongElement(descriptor, 0, value.epochSeconds)
-            if (value.nanosecondsOfSecond != 0) {
+            if (value.nanosecondsOfSecond != 0 || shouldEncodeElementDefault(descriptor, 1)) {
                 encodeIntElement(descriptor, 1, value.nanosecondsOfSecond)
             }
         }

--- a/core/commonMain/src/kotlinx/serialization/internal/BuiltInSerializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/BuiltInSerializers.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlin.uuid.*
 
 
@@ -36,6 +38,20 @@ internal object NothingSerializer : KSerializer<Nothing> {
 
     override fun deserialize(decoder: Decoder): Nothing {
         throw SerializationException("'kotlin.Nothing' does not have instances")
+    }
+}
+
+@PublishedApi
+@ExperimentalTime
+internal object InstantSerializer : KSerializer<Instant> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("kotlin.time.Instant", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): Instant {
+        return Instant.parse(decoder.decodeString())
     }
 }
 

--- a/core/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
@@ -10,9 +10,10 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 import kotlinx.serialization.modules.*
-import kotlinx.serialization.test.*
 import kotlin.test.*
 import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 
 /*
  * Test ensures that type that aggregate all basic (primitive/collection/maps/arrays)
@@ -191,6 +192,27 @@ class BasicTypesSerializationTest {
         val inp = KeyValueInput(Parser(StringReader("\"$durationString\"")))
         val other = inp.decodeSerializableValue(Duration.serializer())
         assertEquals(Duration.parseIsoString(durationString), other)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun testEncodeInstant() {
+        val sb = StringBuilder()
+        val out = KeyValueOutput(sb)
+
+        val instant = Instant.parse("2020-12-09T09:16:56.000124Z")
+        out.encodeSerializableValue(Instant.serializer(), instant)
+
+        assertEquals("\"${instant}\"", sb.toString())
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun testDecodeInstant() {
+        val instantString = "2020-12-09T09:16:56.000124Z"
+        val inp = KeyValueInput(Parser(StringReader("\"$instantString\"")))
+        val other = inp.decodeSerializableValue(Instant.serializer())
+        assertEquals(Instant.parse(instantString), other)
     }
 
     @Test

--- a/core/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/BasicTypesSerializationTest.kt
@@ -12,8 +12,6 @@ import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 import kotlinx.serialization.modules.*
 import kotlin.test.*
 import kotlin.time.Duration
-import kotlin.time.Instant
-import kotlin.time.ExperimentalTime
 
 /*
  * Test ensures that type that aggregate all basic (primitive/collection/maps/arrays)
@@ -192,27 +190,6 @@ class BasicTypesSerializationTest {
         val inp = KeyValueInput(Parser(StringReader("\"$durationString\"")))
         val other = inp.decodeSerializableValue(Duration.serializer())
         assertEquals(Duration.parseIsoString(durationString), other)
-    }
-
-    @OptIn(ExperimentalTime::class)
-    @Test
-    fun testEncodeInstant() {
-        val sb = StringBuilder()
-        val out = KeyValueOutput(sb)
-
-        val instant = Instant.parse("2020-12-09T09:16:56.000124Z")
-        out.encodeSerializableValue(Instant.serializer(), instant)
-
-        assertEquals("\"${instant}\"", sb.toString())
-    }
-
-    @OptIn(ExperimentalTime::class)
-    @Test
-    fun testDecodeInstant() {
-        val instantString = "2020-12-09T09:16:56.000124Z"
-        val inp = KeyValueInput(Parser(StringReader("\"$instantString\"")))
-        val other = inp.decodeSerializableValue(Instant.serializer())
-        assertEquals(Instant.parse(instantString), other)
     }
 
     @Test

--- a/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
@@ -81,7 +81,8 @@ private val KClass<*>.isInterface: Boolean
         return js.asDynamic().`$metadata$`?.kind == "interface"
     }
 
-@OptIn(ExperimentalUnsignedTypes::class, ExperimentalUuidApi::class, ExperimentalSerializationApi::class)
+@OptIn(ExperimentalUnsignedTypes::class, ExperimentalUuidApi::class, ExperimentalSerializationApi::class,
+    ExperimentalTime::class)
 internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = mapOf(
     String::class to String.serializer(),
     Char::class to Char.serializer(),
@@ -111,5 +112,6 @@ internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = mapOf(
     Unit::class to Unit.serializer(),
     Nothing::class to NothingSerializer(),
     Duration::class to Duration.serializer(),
+    Instant::class to Instant.serializer(),
     Uuid::class to Uuid.serializer()
 )

--- a/core/jvmMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/jvmMain/src/kotlinx/serialization/internal/Platform.kt
@@ -201,6 +201,9 @@ internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = buildMap {
     }
     @OptIn(ExperimentalUuidApi::class)
     loadSafe { put(Uuid::class, Uuid.serializer()) }
+
+    @OptIn(ExperimentalTime::class)
+    loadSafe { put(Instant::class, Instant.serializer()) }
 }
 
 // Reference classes in [block] ignoring any exceptions related to class loading

--- a/core/nativeMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/nativeMain/src/kotlinx/serialization/internal/Platform.kt
@@ -75,7 +75,8 @@ private fun <T> arrayOfAnyNulls(size: Int): Array<T> = arrayOfNulls<Any>(size) a
 
 internal actual fun isReferenceArray(rootClass: KClass<Any>): Boolean = rootClass == Array::class
 
-@OptIn(ExperimentalUnsignedTypes::class, ExperimentalUuidApi::class, ExperimentalSerializationApi::class)
+@OptIn(ExperimentalUnsignedTypes::class, ExperimentalUuidApi::class, ExperimentalSerializationApi::class,
+    ExperimentalTime::class)
 internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = mapOf(
     String::class to String.serializer(),
     Char::class to Char.serializer(),
@@ -105,5 +106,6 @@ internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = mapOf(
     Unit::class to Unit.serializer(),
     Nothing::class to NothingSerializer(),
     Duration::class to Duration.serializer(),
+    Instant::class to Instant.serializer(),
     Uuid::class to Uuid.serializer()
 )

--- a/core/wasmMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/wasmMain/src/kotlinx/serialization/internal/Platform.kt
@@ -65,7 +65,8 @@ internal actual fun <T : Any, E : T?> ArrayList<E>.toNativeArrayImpl(eClass: KCl
 
 internal actual fun isReferenceArray(rootClass: KClass<Any>): Boolean = rootClass == Array::class
 
-@OptIn(ExperimentalUnsignedTypes::class, ExperimentalUuidApi::class, ExperimentalSerializationApi::class)
+@OptIn(ExperimentalUnsignedTypes::class, ExperimentalUuidApi::class, ExperimentalSerializationApi::class,
+    ExperimentalTime::class)
 internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = mapOf(
     String::class to String.serializer(),
     Char::class to Char.serializer(),
@@ -95,5 +96,6 @@ internal actual fun initBuiltins(): Map<KClass<*>, KSerializer<*>> = mapOf(
     Unit::class to Unit.serializer(),
     Nothing::class to NothingSerializer(),
     Duration::class to Duration.serializer(),
+    Instant::class to Instant.serializer(),
     Uuid::class to Uuid.serializer()
 )

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.builtins.*
+import kotlin.time.*
+import kotlin.test.*
+
+@OptIn(ExperimentalTime::class)
+class InstantSerializationTest {
+    private fun iso8601Serialization(serializer: KSerializer<Instant>) {
+        for ((instant, json) in listOf(
+            Pair(Instant.fromEpochSeconds(1607505416, 124000),
+                "\"2020-12-09T09:16:56.000124Z\""),
+            Pair(Instant.fromEpochSeconds(-1607505416, -124000),
+                "\"1919-01-23T14:43:03.999876Z\""),
+            Pair(Instant.fromEpochSeconds(987654321, 123456789),
+                "\"2001-04-19T04:25:21.123456789Z\""),
+            Pair(Instant.fromEpochSeconds(987654321, 0),
+                "\"2001-04-19T04:25:21Z\""),
+        )) {
+            assertEquals(json, Json.encodeToString(serializer, instant))
+            assertEquals(instant, Json.decodeFromString(serializer, json))
+        }
+    }
+
+    private fun componentSerialization(serializer: KSerializer<Instant>) {
+        for ((instant, json) in listOf(
+            Pair(Instant.fromEpochSeconds(1607505416, 124000),
+                "{\"epochSeconds\":1607505416,\"nanosecondsOfSecond\":124000}"),
+            Pair(Instant.fromEpochSeconds(-1607505416, -124000),
+                "{\"epochSeconds\":-1607505417,\"nanosecondsOfSecond\":999876000}"),
+            Pair(Instant.fromEpochSeconds(987654321, 123456789),
+                "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":123456789}"),
+            Pair(Instant.fromEpochSeconds(987654321, 0),
+                "{\"epochSeconds\":987654321}"),
+        )) {
+            assertEquals(json, Json.encodeToString(serializer, instant))
+            assertEquals(instant, Json.decodeFromString(serializer, json))
+        }
+        // check that having a `"nanosecondsOfSecond": 0` field doesn't break deserialization
+        assertEquals(Instant.fromEpochSeconds(987654321, 0),
+            Json.decodeFromString(serializer,
+                "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":0}"))
+        // "epochSeconds" should always be present
+        assertFailsWith<SerializationException> { Json.decodeFromString(serializer, "{}") }
+        assertFailsWith<SerializationException> { Json.decodeFromString(serializer, "{\"nanosecondsOfSecond\":3}") }
+    }
+
+    @Test
+    fun testIso8601Serialization() {
+        iso8601Serialization(Instant.serializer())
+    }
+
+    @Test
+    fun testComponentSerialization() {
+        componentSerialization(InstantComponentSerializer)
+    }
+
+    @Test
+    fun testDefaultSerializers() {
+        // should be the same as the ISO 8601
+        iso8601Serialization(Json.serializersModule.serializer())
+    }
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
@@ -26,6 +26,14 @@ class InstantSerializationTest: JsonTestBase() {
         )) {
             assertJsonFormAndRestored(serializer, instant, json)
         }
+        for ((instant, json) in listOf(
+            Pair(Instant.fromEpochSeconds(987654321, 123456789),
+                "\"2001-04-19T07:55:21.123456789+03:30\""),
+            Pair(Instant.fromEpochSeconds(987654321, 123456789),
+                "\"2001-04-19T00:55:21.123456789-03:30\""),
+        )) {
+            assertRestoredFromJsonForm(serializer, json, instant)
+        }
     }
 
     private fun componentSerialization(serializer: KSerializer<Instant>) {

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
@@ -9,9 +9,10 @@ import kotlinx.serialization.json.*
 import kotlinx.serialization.builtins.*
 import kotlin.time.*
 import kotlin.test.*
+import kotlin.reflect.typeOf
 
 @OptIn(ExperimentalTime::class)
-class InstantSerializationTest {
+class InstantSerializationTest: JsonTestBase() {
     private fun iso8601Serialization(serializer: KSerializer<Instant>) {
         for ((instant, json) in listOf(
             Pair(Instant.fromEpochSeconds(1607505416, 124000),
@@ -23,8 +24,7 @@ class InstantSerializationTest {
             Pair(Instant.fromEpochSeconds(987654321, 0),
                 "\"2001-04-19T04:25:21Z\""),
         )) {
-            assertEquals(json, Json.encodeToString(serializer, instant))
-            assertEquals(instant, Json.decodeFromString(serializer, json))
+            assertJsonFormAndRestored(serializer, instant, json)
         }
     }
 
@@ -39,8 +39,7 @@ class InstantSerializationTest {
             Pair(Instant.fromEpochSeconds(987654321, 0),
                 "{\"epochSeconds\":987654321}"),
         )) {
-            assertEquals(json, Json.encodeToString(serializer, instant))
-            assertEquals(instant, Json.decodeFromString(serializer, json))
+            assertJsonFormAndRestored(serializer, instant, json)
         }
         // check that having a `"nanosecondsOfSecond": 0` field doesn't break deserialization
         assertEquals(Instant.fromEpochSeconds(987654321, 0),
@@ -64,6 +63,8 @@ class InstantSerializationTest {
     @Test
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
-        iso8601Serialization(Json.serializersModule.serializer())
+        @Suppress("UNCHECKED_CAST")
+        iso8601Serialization(serializer(typeOf<Instant>()) as KSerializer<Instant>)
+        // iso8601Serialization(serializer())  TODO: uncomment when the compiler adds KT-75759
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
@@ -45,14 +45,21 @@ class InstantSerializationTest: JsonTestBase() {
             Pair(Instant.fromEpochSeconds(987654321, 123456789),
                 "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":123456789}"),
             Pair(Instant.fromEpochSeconds(987654321, 0),
-                "{\"epochSeconds\":987654321}"),
+                "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":0}"),
         )) {
             assertJsonFormAndRestored(serializer, instant, json)
         }
-        // check that having a `"nanosecondsOfSecond": 0` field doesn't break deserialization
+        // by default, `nanosecondsOfSecond` is optional
+        assertJsonFormAndRestored(serializer, Instant.fromEpochSeconds(987654321, 0),
+            "{\"epochSeconds\":987654321}", Json { })
+        // having a `"nanosecondsOfSecond": 0` field doesn't break deserialization
         assertEquals(Instant.fromEpochSeconds(987654321, 0),
             Json.decodeFromString(serializer,
                 "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":0}"))
+        // as does not having a `"nanosecondsOfSecond"` field if `encodeDefaults` is true
+        assertEquals(Instant.fromEpochSeconds(987654321, 0),
+            default.decodeFromString(serializer,
+                "{\"epochSeconds\":987654321}"))
         // "epochSeconds" should always be present
         assertFailsWith<SerializationException> { Json.decodeFromString(serializer, "{}") }
         assertFailsWith<SerializationException> { Json.decodeFromString(serializer, "{\"nanosecondsOfSecond\":3}") }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/InstantSerializationTest.kt
@@ -56,6 +56,9 @@ class InstantSerializationTest: JsonTestBase() {
         assertEquals(Instant.fromEpochSeconds(987654321, 0),
             Json.decodeFromString(serializer,
                 "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":0}"))
+        // with `default`, `nanosecondsOfSecond` is non-optional
+        assertJsonFormAndRestored(serializer, Instant.fromEpochSeconds(987654321, 0),
+            "{\"epochSeconds\":987654321,\"nanosecondsOfSecond\":0}")
         // as does not having a `"nanosecondsOfSecond"` field if `encodeDefaults` is true
         assertEquals(Instant.fromEpochSeconds(987654321, 0),
             default.decodeFromString(serializer,

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonTestBase.kt
@@ -190,4 +190,15 @@ abstract class JsonTestBase {
             assertTrue("Failed with streaming = $jsonTestingMode\n\tsource value =$data\n\tdeserialized value=$deserialized") { check(data, deserialized) }
         }
     }
+
+    internal fun <T> assertRestoredFromJsonForm(
+        serializer: KSerializer<T>,
+        jsonForm: String,
+        expected: T,
+    ) {
+        parametrizedTest { jsonTestingMode ->
+            val deserialized: T = Json.decodeFromString(serializer, jsonForm, jsonTestingMode)
+            assertEquals(expected, deserialized, "Failed with streaming = $jsonTestingMode")
+        }
+    }
 }


### PR DESCRIPTION
Can be merged after moving to Kotlin 2.1.20, which introduces
kotlin.time.Instant.

kotlinx.datetime.Instant entered the stdlib as kotlin.time.Instant,
and so kotlinx.serialization takes over its serializers.
See https://github.com/Kotlin/KEEP/pull/387