### PR TITLE
Bump Kotlin to 2.1.20

### DIFF
--- a/buildSrc/src/main/kotlin/animalsniffer-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/animalsniffer-conventions.gradle.kts
@@ -28,7 +28,10 @@ plugins.withId("org.jetbrains.kotlin.multiplatform") {
 
 afterEvaluate { // Can be applied only when the project is evaluated
     extensions.configure<AnimalSnifferExtension> {
-        sourceSets = listOf(this@afterEvaluate.sourceSets["main"])
+        sourceSets = listOfNotNull(
+            this@afterEvaluate.sourceSets.findByName("jvmMain"),
+            this@afterEvaluate.sourceSets.findByName("main")
+        )
 
         val annotationValue = when(name) {
             "kotlinx-serialization-core" -> "kotlinx.serialization.internal.SuppressAnimalSniffer"

--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -21,8 +21,6 @@ kotlin {
     explicitApi()
 
     jvm {
-        @Suppress("DEPRECATION") // Migrate on Kotlin 2.1.20 update
-        withJava()
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget = JvmTarget.JVM_1_8

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 #
 
 group=org.jetbrains.kotlinx
-version=1.8.0-SNAPSHOT
+version=1.8.1-SNAPSHOT
 jdk_toolchain_version=11
 
 # This version takes precedence if 'bootstrap' property passed to project

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.0"
+kotlin = "2.1.20"
 kover = "0.8.2"
 dokka = "2.0.0-Beta"
 knit = "0.5.0"

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -48,9 +48,7 @@ kotlin {
     wasmWasi {
         nodejs()
     }
-    jvm {
-        withJava()
-    }
+    jvm()
     macosX64()
     macosArm64()
     linuxX64()

--- a/integration-test/gradle.properties
+++ b/integration-test/gradle.properties
@@ -2,8 +2,8 @@
 # Copyright 2017-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
 #
 
-mainKotlinVersion=2.1.0
-mainLibVersion=1.8.0-SNAPSHOT
+mainKotlinVersion=2.1.20
+mainLibVersion=1.8.1-SNAPSHOT
 
 kotlin.code.style=official
 


### PR DESCRIPTION
Fix incorrect configuration of animalSniffer: now, for MPP projects, `main` source set does not exist and `jvmMain` should be used instead.