### PR TITLE
Fixed ProGuard rules for obfuscation to work correctly

### DIFF
--- a/rules/common.pro
+++ b/rules/common.pro
@@ -2,7 +2,15 @@
 # This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
 -if @kotlinx.serialization.Serializable class **
 -keepclassmembers class <1> {
-    static <1>$Companion Companion;
+    static <1>$* Companion;
+}
+
+# Keep names for named companion object from obfuscation
+# Names of a class and of a field are important in lookup of named companion in runtime
+-keepnames @kotlinx.serialization.internal.NamedCompanion class *
+-if @kotlinx.serialization.internal.NamedCompanion class *
+-keepclassmembernames class * {
+    static <1> *;
 }
 
 # Keep `serializer()` on companion objects (both default and named) of serializable classes.


### PR DESCRIPTION
The current rules only apply if the companion class is called `Companion`. If obfuscation is triggered, the rule does not work and the static `Companion` field is not kept, which breaks the lookup of a companion.

A rule has also been added that preserves the named companion class name and field, as they must match to correctly search for the named companion in runtime.

Fixes #2976