### PR TITLE
Suppress `REDUNDANT_ELSE_IN_WHEN` in `ProtobufTaggedEncoder.encodeNull()`

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufTaggedEncoder.kt
@@ -36,6 +36,7 @@ internal abstract class ProtobufTaggedEncoder : ProtobufTaggedBase(), Encoder, C
 
     public final override fun encodeNull() {
         if (nullableMode != NullableMode.ACCEPTABLE) {
+            @Suppress("REDUNDANT_ELSE_IN_WHEN")
             val message = when (nullableMode) {
                 NullableMode.OPTIONAL -> "'null' is not supported for optional properties in ProtoBuf"
                 NullableMode.COLLECTION -> "'null' is not supported as the value of collection types in ProtoBuf"


### PR DESCRIPTION
A cherry-pick to `dev` for [pull/2987](https://github.com/Kotlin/kotlinx.serialization/pull/2987).
