### PR TITLE
Update JsonPath tests:

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/JsonPathTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/JsonPathTest.kt
@@ -5,7 +5,6 @@
 package kotlinx.serialization
 
 import kotlinx.serialization.json.*
-import kotlinx.serialization.test.*
 import kotlin.test.*
 
 class JsonPathTest : JsonTestBase() {
@@ -36,8 +35,7 @@ class JsonPathTest : JsonTestBase() {
     fun testUnknownKeyIsProperlyReported() {
         expectPath("$.i") { Json.decodeFromString<Outer>("""{"a":42, "i":{"foo":42}""") }
         expectPath("$") { Json.decodeFromString<Outer>("""{"x":{}, "a": 42}""") }
-        // The only place we have misattribution in
-        // Json.decodeFromString<Outer>("""{"a":42, "x":{}}""")
+        expectPath("$") { Json.decodeFromString<Outer>("""{"a":42, "x":{}}""") }
     }
 
     @Test
@@ -117,9 +115,8 @@ class JsonPathTest : JsonTestBase() {
         data class DoubleNesting(val f: Sealed, val f2: Sealed) : Sealed()
     }
 
-    // TODO use non-array polymorphism when https://github.com/Kotlin/kotlinx.serialization/issues/1839 is fixed
     @Test
-    fun testHugeNestingToCheckResize() = jvmOnly {
+    fun testHugeNestingToCheckResize() {
         val json = Json { useArrayPolymorphism = true }
         var outer = Sealed.Nesting(Sealed.Box("value"))
         repeat(100) {
@@ -135,8 +132,8 @@ class JsonPathTest : JsonTestBase() {
     }
 
     @Test
-    fun testDoubleNesting() = jvmOnly {
-        val json = Json { useArrayPolymorphism = true }
+    fun testDoubleNestingNoArrayPoly() {
+        val json = Json { useArrayPolymorphism = false }
         var outer1 = Sealed.Nesting(Sealed.Box("correct"))
         repeat(64) {
             outer1 = Sealed.Nesting(outer1)
@@ -153,7 +150,7 @@ class JsonPathTest : JsonTestBase() {
         assertEquals(value, json.decodeFromString(Sealed.serializer(), str))
 
         val malformed = str.replace("\"incorrect\"", "42")
-        val expectedPath = "$.value.f2" + ".value.f".repeat(34) + ".value.s"
+        val expectedPath = "$.f2" + ".f".repeat(34) + ".s"
         expectPath(expectedPath) { json.decodeFromString(Sealed.serializer(), malformed) }
     }
 


### PR DESCRIPTION
- Uncomment test that was fixed by some other PR
- Remove jvmOnly clause, because tests are working on other platforms too
- Add test with useArrayPolymorphism=false