### PR TITLE
🍒 Rename KClass<*>.isInterface helper in the JS part

### DIFF
--- a/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
+++ b/core/jsMain/src/kotlinx/serialization/internal/Platform.kt
@@ -23,7 +23,7 @@ internal actual fun <T : Any> KClass<T>.compiledSerializerImpl(): KSerializer<T>
         else this.js.asDynamic().Companion?.serializer()
         ) as? KSerializer<T>
 
-internal actual fun <T: Any> KClass<T>.isInterface(): Boolean = isInterface
+internal actual fun <T: Any> KClass<T>.isInterface(): Boolean = isInterfaceHack
 
 internal actual fun <T> createCache(factory: (KClass<*>) -> KSerializer<T>?): SerializerCache<T> {
     return object: SerializerCache<T> {
@@ -70,8 +70,10 @@ internal actual fun isReferenceArray(rootClass: KClass<Any>): Boolean = rootClas
  * WARNING: may be broken in arbitrary time in the future without notice
  *
  * Should be eventually replaced with compiler intrinsics
+ *
+ * TODO: Remove this when KT-78581 lands into a 2.2.20 release
  */
-private val KClass<*>.isInterface: Boolean
+private val KClass<*>.isInterfaceHack: Boolean
     get(): Boolean {
         // .js throws an exception for Nothing
         if (this === Nothing::class) return false


### PR DESCRIPTION
This is a cherry-pick of #3027 into the `kotlin-community/k1/dev` branch.