### PR TITLE
Suppress the deprecation warning on a reference to Kotlin 2.0 language version

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -175,6 +175,7 @@ object Java9Modularity {
 
             val taskKotlinLanguageVersion = compilerOptions.languageVersion.orElse(KotlinVersion.DEFAULT)
             @OptIn(InternalKotlinGradlePluginApi::class)
+            @Suppress("DEPRECATION")
             if (taskKotlinLanguageVersion.get() < KotlinVersion.KOTLIN_2_0) {
                 // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
                 @Suppress("INVISIBLE_MEMBER")


### PR DESCRIPTION
See [KT-76136](https://youtrack.jetbrains.com/issue/KT-76136)