### PR TITLE
[KUP] Disable opt-in Kotlin compiler warnings

### DIFF
--- a/buildSrc/src/main/kotlin/global-compiler-options.gradle.kts
+++ b/buildSrc/src/main/kotlin/global-compiler-options.gradle.kts
@@ -33,15 +33,7 @@ tasks.withType(KotlinCompilationTask::class).configureEach {
                 null -> true // Werror is enabled by default
                 else -> throw GradleException("Invalid kotlin_Werror_override value. Use 'enable' or 'disable'")
             }
-
             allWarningsAsErrors = werrorEnabled
-            // Add extra compiler options when -Werror is disabled
-            if (!werrorEnabled) {
-                freeCompilerArgs.addAll(
-                    "-Wextra",
-                    "-Xuse-fir-experimental-checkers"
-                )
-            }
         }
     }
 }


### PR DESCRIPTION
It was decided to deprecate and phase out the concept (see KT-77721).