### PR TITLE
RFC: Allow disabling coercion between JSON primitives

### DIFF
--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -658,6 +658,8 @@ public class JsonBuilder internal constructor(json: Json) {
      */
     public var useArrayPolymorphism: Boolean = json.configuration.useArrayPolymorphism
 
+    public var allowPrimitiveCoercion: Boolean = json.configuration.allowPrimitiveCoercion
+
     /**
      * Module with contextual and polymorphic serializers to be used in the resulting [Json] instance.
      *
@@ -695,7 +697,8 @@ public class JsonBuilder internal constructor(json: Json) {
             allowStructuredMapKeys, prettyPrint, explicitNulls, prettyPrintIndent,
             coerceInputValues, useArrayPolymorphism,
             classDiscriminator, allowSpecialFloatingPointValues, useAlternativeNames,
-            namingStrategy, decodeEnumsCaseInsensitive, allowTrailingComma, allowComments, classDiscriminatorMode
+            namingStrategy, decodeEnumsCaseInsensitive, allowTrailingComma, allowComments, classDiscriminatorMode,
+            allowPrimitiveCoercion
         )
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -45,6 +45,8 @@ public class JsonConfiguration @OptIn(ExperimentalSerializationApi::class) inter
         level = DeprecationLevel.ERROR
     )
     public var classDiscriminatorMode: ClassDiscriminatorMode = ClassDiscriminatorMode.POLYMORPHIC,
+    @ExperimentalSerializationApi
+    public val allowPrimitiveCoercion: Boolean = true,
 ) {
 
     /** @suppress Dokka **/

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -85,6 +85,9 @@ private sealed class AbstractJsonTreeDecoder(
 
     private inline fun <T : Any> getPrimitiveValue(tag: String, primitiveName: String, convert: JsonPrimitive.() -> T?): T {
         val literal = cast<JsonPrimitive>(currentElement(tag), primitiveName, tag)
+        if (!json.configuration.allowPrimitiveCoercion && literal.isString) {
+            unparsedPrimitive(literal, primitiveName, tag)
+        }
         try {
             return literal.convert() ?: unparsedPrimitive(literal, primitiveName, tag)
         } catch (e: IllegalArgumentException) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
@@ -438,14 +438,18 @@ internal abstract class AbstractJsonLexer {
     }
 
     // Allows consuming unquoted string
-    fun consumeStringLenient(): String {
+    fun consumeStringLenient(): String =
+        consumeOther(allowQuoted = true)
+
+    fun consumeOther(allowQuoted: Boolean): String {
+        // TODO this string peeking stuff might break things...
         if (peekedString != null) {
             return takePeeked()
         }
         var current = skipWhitespaces()
         if (current >= source.length || current == -1) fail("EOF", current)
         val token = charToTokenClass(source[current])
-        if (token == TC_STRING) {
+        if (allowQuoted && token == TC_STRING) {
             return consumeString()
         }
 
@@ -587,7 +591,10 @@ internal abstract class AbstractJsonLexer {
         throw JsonDecodingException(position, message + " at path: " + path.getPath() + hintMessage, source)
     }
 
-    fun consumeNumericLiteral(): Long {
+    fun consumeNumericLiteral(): Long =
+        consumeNumericLiteral(coercePrimitives = true)
+
+    fun consumeNumericLiteral(coercePrimitives: Boolean): Long {
         /*
          * This is an optimized (~40% for numbers) version of consumeString().toLong()
          * that doesn't allocate and also doesn't support any radix but 10
@@ -595,7 +602,7 @@ internal abstract class AbstractJsonLexer {
         var current = skipWhitespaces()
         current = prefetchOrEof(current)
         if (current >= source.length || current == -1) fail("EOF")
-        val hasQuotation = if (source[current] == STRING) {
+        val hasQuotation = if (coercePrimitives && source[current] == STRING) {
             // Check it again
             // not sure if should call ensureHaveChars() because threshold is far greater than chars count in MAX_LONG
             if (++current == source.length) fail("EOF")


### PR DESCRIPTION
Currently, and independent of the `isLenient` option, the JSON decoders will coerce Strings to other primitiv types, allowing e.g. `"true"` to be decoded as `Boolean`. We are currently transitioning from a very strict decoder setup based on Jackson over to kotlinx serialization for some of the nicer kotlin-specific functionality and the lack of reflection.

This PR is currently meant as an RFC to gauge if this is something that would be accepted upstream. As such there are some caveats:

* There are no additional tests, however the existing tests show that the default behavior is unchanged.
* No documentation has been written for the new functionality.
* There are some TODO's which will require closer inspection for a final implementation and some dedicated tests.
* The new option should probably be marked as `@ExperimentalSerializationApi`, but it is not currently.

I would obviously add those things, if there is a chance this would be pulled.

The implementation is rather simple: Introduce a boolean option and in and around the lexer prevent the use of quoted strings, where they wouldn't be necessary unless coercion is wanted. In some places the necessary functionality was already in place as separate methods (decodeBoolean vs decodeBooleanLenient), in others I was able to add minimal changes, usually as part of existing checks around string quotes. I tried to keep the interfaces stable.

Related issues:

* https://github.com/Kotlin/kotlinx.serialization/issues/1042
* https://github.com/Kotlin/kotlinx.serialization/issues/2696
