### PR TITLE
Fix formatting in Encoder kdoc

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/encoding/Encoding.kt
+++ b/core/commonMain/src/kotlinx/serialization/encoding/Encoding.kt
@@ -83,7 +83,7 @@ import kotlinx.serialization.modules.*
  * ```
  *
  * This serializer does not know anything about the underlying storage and will work with any properly-implemented encoder.
- * JSON, for example, writes an opening bracket `{` during the `beginStructure` call, writes 'stringValue` key along
+ * JSON, for example, writes an opening bracket `{` during the `beginStructure` call, writes `stringValue` key along
  * with its value in `encodeStringElement` and writes the closing bracket `}` during the `endStructure`.
  * XML would do roughly the same, but with different separators and structures, while ProtoBuf
  * machinery could be completely different.


### PR DESCRIPTION
Add a missing backtick

Before:
<img width="678" height="117" alt="image" src="https://github.com/user-attachments/assets/663fcc11-dfcc-41f1-b323-e7d2a97d26d5" />
