### PR TITLE
Remove obsolete -Xjvm-default argument.

### DIFF
--- a/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/source-sets-conventions.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget = JvmTarget.JVM_1_8
-            freeCompilerArgs.addAll("-Xjdk-release=1.8", "-Xjvm-default=all-compatibility")
+            freeCompilerArgs.addAll("-Xjdk-release=1.8")
         }
     }
     jvmToolchain(jdkToolchainVersion)

--- a/formats/hocon/build.gradle.kts
+++ b/formats/hocon/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
             languageVersion = KotlinVersion.fromVersion(overriddenLanguageVersion!!)
             freeCompilerArgs.add("-Xsuppress-version-warnings")
         }
-        freeCompilerArgs.addAll("-Xjdk-release=1.8", "-Xjvm-default=all-compatibility")
+        freeCompilerArgs.addAll("-Xjdk-release=1.8")
     }
 
     sourceSets.all {


### PR DESCRIPTION
Since Kotlin 2.2, all-compatibility is the default mode.