### PR TITLE
CBOR: update RFC number and corresponding links

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -40,7 +40,7 @@ stable, these are currently experimental features of Kotlin Serialization.
 
 ## CBOR (experimental) 
 
-[CBOR][RFC 7049] is one of the standard compact binary
+[CBOR][RFC 8949] is one of the standard compact binary
 encodings for JSON, so it supports a subset of [JSON features](json.md) and
 is generally very similar to JSON in use, but produces binary data.
 
@@ -157,7 +157,7 @@ BF                                      # map(*)
 
 ### Byte arrays and CBOR data types
 
-Per the [RFC 7049 Major Types] section, CBOR supports the following data types:
+Per the [RFC 8949 Major Types] section, CBOR supports the following data types:
 
 - Major type 0: an unsigned integer
 - Major type 1: a negative integer
@@ -1607,9 +1607,9 @@ This chapter concludes [Kotlin Serialization Guide](serialization-guide.md).
                                      
 
 <!-- references -->
-[RFC 7049]: https://tools.ietf.org/html/rfc7049
+[RFC 8949]: https://tools.ietf.org/html/rfc8949
 [IoT]: https://en.wikipedia.org/wiki/Internet_of_things
-[RFC 7049 Major Types]: https://tools.ietf.org/html/rfc7049#section-2.1
+[RFC 8949 Major Types]: https://tools.ietf.org/html/rfc8949#section-3.1
 
 <!-- Java references -->
 [java.io.DataOutput]: https://docs.oracle.com/javase/8/docs/api/java/io/DataOutput.html

--- a/dokka/moduledoc.md
+++ b/dokka/moduledoc.md
@@ -14,7 +14,7 @@ Extensions for kotlinx.serialization.json.Json for integration with the [kotlinx
 Currently experimental.
 
 # Module kotlinx-serialization-cbor
-Concise Binary Object Representation (CBOR) format implementation, as per [RFC 7049](https://tools.ietf.org/html/rfc7049).
+Concise Binary Object Representation (CBOR) format implementation, as per [RFC 8949](https://tools.ietf.org/html/rfc8949).
 
 # Module kotlinx-serialization-hocon
 Allows deserialization of `Config` object from popular [lightbend/config](https://github.com/lightbend/config) library 
@@ -66,4 +66,4 @@ Experimental generator of ProtoBuf schema from Kotlin classes.
 Properties serialization format implementation that represents the input data as a plain map of properties.
 
 # Package kotlinx.serialization.cbor
-Concise Binary Object Representation (CBOR) format implementation, as per [RFC 7049](https://tools.ietf.org/html/rfc7049).
+Concise Binary Object Representation (CBOR) format implementation, as per [RFC 8949](https://tools.ietf.org/html/rfc8949).

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/ByteString.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/ByteString.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.*
  * )
  * ```
  *
- * See [RFC 7049 2.1. Major Types](https://tools.ietf.org/html/rfc7049#section-2.1).
+ * See [RFC 8949 3.1. Major Types](https://tools.ietf.org/html/rfc8949#section-3.1).
  */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.modules.*
 
 /**
  * Implements [encoding][encodeToByteArray] and [decoding][decodeFromByteArray] classes to/from bytes
- * using [CBOR](https://tools.ietf.org/html/rfc7049) specification.
+ * using [CBOR](https://tools.ietf.org/html/rfc8949) specification.
  * It is typically used by constructing an application-specific instance, with configured behaviour, and,
  * if necessary, registered custom serializers (in [SerializersModule] provided by [serializersModule] constructor parameter).
  *

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -481,7 +481,7 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
     /**
      * Determines if [curByte] represents an indefinite length CBOR item.
      *
-     * Per [RFC 7049: 2.2. Indefinite Lengths for Some Major Types](https://tools.ietf.org/html/rfc7049#section-2.2):
+     * Per [RFC 8949: 3.2. Indefinite Lengths for Some Major Types](https://tools.ietf.org/html/rfc8949#section-3.2):
      * > Four CBOR items (arrays, maps, byte strings, and text strings) can be encoded with an indefinite length
      */
     private fun isIndefinite(): Boolean {
@@ -576,7 +576,7 @@ private val normalizeBaseBits = SINGLE_PRECISION_NORMALIZE_BASE.toBits()
 
 
 /*
- * For details about half-precision floating-point numbers see https://tools.ietf.org/html/rfc7049#appendix-D
+ * For details about half-precision floating-point numbers see https://tools.ietf.org/html/rfc8949#name-half-precision
  */
 private fun floatFromHalfBits(bits: Short): Float {
     val intBits = bits.toInt()


### PR DESCRIPTION
[RFC 8949](https://www.rfc-editor.org/rfc/rfc8949) obsoleted [RFC 7049](https://www.rfc-editor.org/rfc/rfc7049) some time ago. 
Yet our documentation refers to 7049 instead of 8949.

This change updates the RFC number and replaces links to point to recent RFC.