### PR TITLE
Stabilize @EncodeDefault annotation and its modes.

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -199,12 +199,10 @@ public annotation class Transient
  */
 @MustBeDocumented
 @Target(AnnotationTarget.PROPERTY)
-@ExperimentalSerializationApi
 public annotation class EncodeDefault(val mode: Mode = Mode.ALWAYS) {
     /**
      * Strategy for the [EncodeDefault] annotation.
      */
-    @ExperimentalSerializationApi
     public enum class Mode {
         /**
          * Configures serializer to always encode the property, even if its value is equal to its default.

--- a/docs/basic-serialization.md
+++ b/docs/basic-serialization.md
@@ -448,9 +448,13 @@ See JSON's [Encoding defaults](json.md#encoding-defaults) section on how this be
 Additionally, this behavior can be controlled without taking format settings into account.
 For that purposes, [EncodeDefault] annotation can be used:
 
+<!--- INCLUDE
+import kotlinx.serialization.EncodeDefault.Mode.NEVER
+-->
+
+
 ```kotlin
 @Serializable
-@OptIn(ExperimentalSerializationApi::class) // EncodeDefault is an experimental annotation for now
 data class Project(
     val name: String,
     @EncodeDefault val language: String = "Kotlin"
@@ -461,12 +465,10 @@ This annotation instructs the framework to always serialize property, regardless
 It's also possible to tweak it into the opposite behavior using [EncodeDefault.Mode] parameter:
 
 ```kotlin
-
 @Serializable
-@OptIn(ExperimentalSerializationApi::class) // EncodeDefault is an experimental annotation for now
 data class User(
     val name: String,
-    @EncodeDefault(EncodeDefault.Mode.NEVER) val projects: List<Project> = emptyList()
+    @EncodeDefault(NEVER) val projects: List<Project> = emptyList()
 )
 
 fun main() {

--- a/guide/example/example-classes-10.kt
+++ b/guide/example/example-classes-10.kt
@@ -4,19 +4,18 @@ package example.exampleClasses10
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 
+import kotlinx.serialization.EncodeDefault.Mode.NEVER
+
 @Serializable
-@OptIn(ExperimentalSerializationApi::class) // EncodeDefault is an experimental annotation for now
 data class Project(
     val name: String,
     @EncodeDefault val language: String = "Kotlin"
 )
 
-
 @Serializable
-@OptIn(ExperimentalSerializationApi::class) // EncodeDefault is an experimental annotation for now
 data class User(
     val name: String,
-    @EncodeDefault(EncodeDefault.Mode.NEVER) val projects: List<Project> = emptyList()
+    @EncodeDefault(NEVER) val projects: List<Project> = emptyList()
 )
 
 fun main() {


### PR DESCRIPTION
It is widely popular and de-facto is a stable API.