### PR TITLE
Fix protobuf oneof default values

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -22,6 +22,7 @@ stable, these are currently experimental features of Kotlin Serialization.
   * [Integer types](#integer-types)
   * [Lists as repeated fields](#lists-as-repeated-fields)
   * [Packed fields](#packed-fields)
+  * [Default values](#default-values)
   * [Oneof field (experimental)](#oneof-field-experimental)
     * [Usage](#usage)
     * [Alternative](#alternative)
@@ -537,6 +538,29 @@ Per the standard packed fields can only be used on primitive numeric types. The 
 
 Per the [format description](https://developers.google.com/protocol-buffers/docs/encoding#packed) the parser ignores
 the annotation, but rather reads list in either packed or repeated format.
+
+### Default values
+
+In Protocol Buffers, fields have implicit default values when they are not present in the encoded data.
+According to the [proto2 default value specification](https://protobuf.dev/programming-guides/proto2/#default), 
+these default values are type-specific:
+
+| Code type               | Recommanded default value                                           | Acceptable default value                                            |
+| ----------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Int, Long, Uint, Ulong  | 0                                                                   |                                                                     |
+| Float, Double           | 0.0                                                                 |                                                                     |
+| String                  | ""                                                                  |                                                                     |
+| ByteArray               | empty                                                               |                                                                     |
+| Boolean                 | false                                                               |                                                                     |
+| Enum                    | Enum instance stands for 0                                          | `null`                                                              |
+| Array, Map              | Empty or `null`                                                     |                                                                     |
+| Optional Messages       | null                                                                | Default instance with all fields assigned with valid default values |
+| Required Messages       | Default instance with all fields assigned with valid default values |                                                                     |
+| Field with `@ProtoOneOf`| Always use `null` as default                                        |                                                                     |
+
+Protocol Buffers uses a compact binary encoding where fields set to their type's default value are completely omitted from the wire format. This is a fundamental design principle for efficiency. When decoding, if a field is missing from the binary data, the decoder automatically assigns the type's default value.
+
+If you use a custom default value in Kotlin (e.g., `val timeout: Int = 30` instead of `0`), you create a mismatch between Kotlin's expectations and ProtoBuf's behavior. The encoder will include the field in the output when the value equals your custom default (since `30 != 0`), but if that field is missing from data encoded elsewhere, the decoder will assign `0` (the type default), not `30`. This creates data inconsistency and unpredictable behavior.
 
 ### Oneof field (experimental)
 

--- a/docs/serialization-guide.md
+++ b/docs/serialization-guide.md
@@ -160,6 +160,7 @@ Once the project is set up, we can start serializing some classes.
   * <a name='integer-types'></a>[Integer types](formats.md#integer-types)
   * <a name='lists-as-repeated-fields'></a>[Lists as repeated fields](formats.md#lists-as-repeated-fields)
   * <a name='packed-fields'></a>[Packed fields](formats.md#packed-fields)
+  * <a name='default-values'></a>[Default values](formats.md#default-values)
   * <a name='oneof-field-experimental'></a>[Oneof field (experimental)](formats.md#oneof-field-experimental)
     * <a name='usage'></a>[Usage](formats.md#usage)
     * <a name='alternative'></a>[Alternative](formats.md#alternative)

--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/internal/ProtobufEncoding.kt
@@ -253,6 +253,12 @@ private class OneOfElementEncoder(
             "Implementation of oneOf type ${descriptor.serialName} should have @ProtoNumber annotation"
         }
     }
+
+    // For oneof fields, we must always encode the element even if it contains default values,
+    // because the oneof semantics require knowing which case was selected.
+    // Otherwise, decoding an empty byte array would incorrectly select the default variant defined in the message class.
+    // An element with default values will be encoded as {TAG}00 for 0-length content.
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = true
 }
 
 private class MapRepeatedEncoder(

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -756,10 +756,10 @@ class ProtobufOneOfTest {
     @Serializable
     class EmptyBox {
         override fun equals(other: Any?): Boolean =
-            this === other || javaClass == other?.javaClass
+            this === other || (other != null && this::class == other::class)
 
         override fun hashCode(): Int =
-            javaClass.hashCode()
+            this::class.hashCode()
     }
 
     @Test

--- a/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
+++ b/formats/protobuf/commonTest/src/kotlinx/serialization/protobuf/ProtobufOneOfTest.kt
@@ -716,4 +716,123 @@ class ProtobufOneOfTest {
             ProtoBuf.decodeFromHexString<Outer>("082a")
         }
     }
+
+    @Serializable
+    data class MessageWithOneOf(
+        @ProtoOneOf val ofValue: OfValue?,
+        @ProtoNumber(100) val name: String = "",
+    ) {
+        @Serializable
+        sealed interface OfValue {
+            @Serializable
+            data class StringValue(
+                @ProtoNumber(1) val value: String = "",
+            ) : OfValue
+
+            @Serializable
+            data class IntValue(
+                @ProtoNumber(2) val value: Int = 0,
+            ) : OfValue
+
+            @Serializable
+            data class EmptyValue(
+                @ProtoNumber(3) val value: EmptyBox = EmptyBox(),
+            ) : OfValue
+
+            @Serializable
+            @JvmInline
+            value class InlineIntValue(
+                @ProtoNumber(4) val value: Int = 0,
+            ) : OfValue
+
+            @Serializable
+            @JvmInline
+            value class InlineStringValue(
+                @ProtoNumber(5) val value: String = "",
+            ) : OfValue
+        }
+    }
+
+    @Serializable
+    class EmptyBox {
+        override fun equals(other: Any?): Boolean =
+            this === other || javaClass == other?.javaClass
+
+        override fun hashCode(): Int =
+            javaClass.hashCode()
+    }
+
+    @Test
+    fun testOneOfWithDefaultValues() {
+        // Test with null (no value set) - only name field is encoded
+        val messageWithNull = MessageWithOneOf(null, "test")
+        val hexNull = ProtoBuf.encodeToHexString(messageWithNull)
+        /**
+         * 100:LEN {"test"}
+         */
+        assertEquals("a2060474657374", hexNull)
+        val decodedNull = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexNull)
+        assertEquals(null, decodedNull.ofValue)
+        assertEquals("test", decodedNull.name)
+
+        // Test with non-default value - should work
+        val messageWithNonDefault = MessageWithOneOf(MessageWithOneOf.OfValue.IntValue(42))
+        val hexNonDefault = ProtoBuf.encodeToHexString(messageWithNonDefault)
+        /**
+         * 2:VARINT 42
+         */
+        assertEquals("102a", hexNonDefault)
+        val decodedNonDefault = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexNonDefault)
+        assertEquals(MessageWithOneOf.OfValue.IntValue(42), decodedNonDefault.ofValue)
+
+        // Test with default int value (0) - should preserve the type
+        val messageWithDefaultInt = MessageWithOneOf(MessageWithOneOf.OfValue.IntValue(0))
+        val hexDefaultInt = ProtoBuf.encodeToHexString(messageWithDefaultInt)
+        /**
+         * 2:VARINT 0
+         */
+        assertEquals("1000", hexDefaultInt)
+        val decodedDefaultInt = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexDefaultInt)
+        assertEquals(MessageWithOneOf.OfValue.IntValue(0), decodedDefaultInt.ofValue)
+
+        // Test with default string value ("") - should preserve the type
+        val messageWithDefaultString = MessageWithOneOf(MessageWithOneOf.OfValue.StringValue(""))
+        val hexDefaultString = ProtoBuf.encodeToHexString(messageWithDefaultString)
+        /**
+         * 1:LEN {""}
+         */
+        assertEquals("0a00", hexDefaultString)
+        val decodedDefaultString = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexDefaultString)
+        assertEquals(MessageWithOneOf.OfValue.StringValue(""), decodedDefaultString.ofValue)
+
+        // Test with empty class - should preserve the type
+        val messageWithEmpty = MessageWithOneOf(MessageWithOneOf.OfValue.EmptyValue(EmptyBox()))
+        val hexEmpty = ProtoBuf.encodeToHexString(messageWithEmpty)
+        /**
+         * 3:LEN {}
+         */
+        assertEquals("1a00", hexEmpty)
+        val decodedEmpty = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexEmpty)
+        assertEquals(MessageWithOneOf.OfValue.EmptyValue(EmptyBox()), decodedEmpty.ofValue)
+
+        // Test with inline value class - default int (0)
+        val messageWithInlineInt = MessageWithOneOf(MessageWithOneOf.OfValue.InlineIntValue(0))
+        val hexInlineInt = ProtoBuf.encodeToHexString(messageWithInlineInt)
+        /**
+         * 4:VARINT 0
+         */
+        assertEquals("2000", hexInlineInt)
+        val decodedInlineInt = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexInlineInt)
+        assertEquals(MessageWithOneOf.OfValue.InlineIntValue(0), decodedInlineInt.ofValue)
+
+        // Test with inline value class - default string ("")
+        val messageWithInlineString = MessageWithOneOf(MessageWithOneOf.OfValue.InlineStringValue(""))
+        val hexInlineString = ProtoBuf.encodeToHexString(messageWithInlineString)
+        /**
+         * 5:LEN {""}
+         */
+        assertEquals("2a00", hexInlineString)
+        val decodedInlineString = ProtoBuf.decodeFromHexString<MessageWithOneOf>(hexInlineString)
+        assertEquals(MessageWithOneOf.OfValue.InlineStringValue(""), decodedInlineString.ofValue)
+    }
 }


### PR DESCRIPTION
Override `shouldEncodeElementDefault` in `OneOfElementEncoder` to always return true. This ensures oneof fields are encoded even when they contain default values.

According to protobuf oneof semantics, the selected case must always be identifiable. So a tag with field number is always needed for one of field.

Fixes https://github.com/Kotlin/kotlinx.serialization/issues/3144

And I found that code sample in the issue shows some misusing of default values in proto messages. So I add an extra section in docs for it.