### PR TITLE
CBOR: Relax value range check when decoding numbers

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -584,12 +584,10 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
         return when (majorType) {
             HEADER_BYTE_STRING, HEADER_STRING, HEADER_ARRAY
                 -> readUnsignedIntegerIgnoringMajorType { "${majorType.majorTypeName} length" }
-                .asSizedElementLength(majorType)
-
+                    .asSizedElementLength(majorType)
             HEADER_MAP
                 -> readUnsignedIntegerIgnoringMajorType { "map length" }
-                .asSizedElementLength(majorType, Int.MAX_VALUE / 2) * 2
-
+                    .asSizedElementLength(majorType, Int.MAX_VALUE / 2) * 2
             else -> when (additionalInformation) {
                 24 -> 1
                 25 -> 2

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -129,17 +129,17 @@ internal open class CborReader(override val cbor: Cbor, protected val parser: Cb
 
     override fun decodeBoolean() = parser.nextBoolean(tags)
 
-    override fun decodeByte() = parser.nextNumberWithinRange(
-        tags, Byte.MIN_VALUE.toLong(), Byte.MAX_VALUE.toLong(), "Byte"
+    override fun decodeByte() = parser.nextNumberWithMaxWidth(
+        tags, Byte.SIZE_BITS, "Byte"
     ).toByte()
-    override fun decodeShort() = parser.nextNumberWithinRange(
-        tags, Short.MIN_VALUE.toLong(), Short.MAX_VALUE.toLong(), "Short"
+    override fun decodeShort() = parser.nextNumberWithMaxWidth(
+        tags, Short.SIZE_BITS, "Short"
     ).toShort()
-    override fun decodeChar() = parser.nextNumberWithinRange(
-        tags, Char.MIN_VALUE.code.toLong(), Char.MAX_VALUE.code.toLong(), "Char"
+    override fun decodeChar() = parser.nextNumberWithMaxWidth(
+        tags, Char.SIZE_BITS, "Char"
     ).toInt().toChar()
-    override fun decodeInt() = parser.nextNumberWithinRange(
-        tags, Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong(), "Int"
+    override fun decodeInt() = parser.nextNumberWithMaxWidth(
+        tags, Int.SIZE_BITS, "Int"
     ).toInt()
     override fun decodeLong() = parser.nextNumber(tags)
 
@@ -353,11 +353,18 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
         }
     }
 
-    internal fun nextNumberWithinRange(tags: ULongArray?, from: Long, to: Long, type: String): Long {
+    internal fun nextNumberWithMaxWidth(tags: ULongArray?, widthBits: Int, type: String): Long {
         val number = nextNumber(tags)
-        if (number !in from..to) {
-            throw CborDecodingException("Decoded number $number is not within the range for type $type ([$from..$to])")
+        val msb = number.shr(widthBits)
+        // A number's value will fit into widthBits if:
+        // 1) (64 - widthBits) most significant bits are all zeros (the value is positive and fits into widthBits)
+        // 2) (64 - widthBits) most significant bits are all ones and
+        //    bit # (widthBits - 1) is also one (the value is negative and fits into widthBits,
+        //    truncation of the MSBs won't truncate the value itself)
+        if ((msb != 0L && msb != -1L) || (msb == -1L && number.shr(widthBits - 1) != -1L)) {
+            throw CborDecodingException("Decoded number $number could not be represented as $type without loss")
         }
+
         return number
     }
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -129,18 +129,23 @@ internal open class CborReader(override val cbor: Cbor, protected val parser: Cb
 
     override fun decodeBoolean() = parser.nextBoolean(tags)
 
-    override fun decodeByte() = parser.nextNumberWithMaxWidth(
-        tags, Byte.SIZE_BITS, "Byte"
+    override fun decodeByte() = parser.nextNumberWithinRange(
+        tags, Byte.MIN_VALUE.toLong(), Byte.MAX_VALUE.toLong(), UByte.MAX_VALUE.toLong(), "Byte"
     ).toByte()
-    override fun decodeShort() = parser.nextNumberWithMaxWidth(
-        tags, Short.SIZE_BITS, "Short"
+
+    override fun decodeShort() = parser.nextNumberWithinRange(
+        tags, Short.MIN_VALUE.toLong(), Short.MAX_VALUE.toLong(), UShort.MAX_VALUE.toLong(), "Short"
     ).toShort()
-    override fun decodeChar() = parser.nextNumberWithMaxWidth(
-        tags, Char.SIZE_BITS, "Char"
+
+    override fun decodeChar() = parser.nextNumberWithinRange(
+        tags, Char.MIN_VALUE.code.toLong(), Char.MAX_VALUE.code.toLong(),
+        /* no unsigned type for Char */ -1, "Char"
     ).toInt().toChar()
-    override fun decodeInt() = parser.nextNumberWithMaxWidth(
-        tags, Int.SIZE_BITS, "Int"
+
+    override fun decodeInt() = parser.nextNumberWithinRange(
+        tags, Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong(), UInt.MAX_VALUE.toLong(), "Int"
     ).toInt()
+
     override fun decodeLong() = parser.nextNumber(tags)
 
     override fun decodeNull() = parser.nextNull(tags)
@@ -353,18 +358,22 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
         }
     }
 
-    internal fun nextNumberWithMaxWidth(tags: ULongArray?, widthBits: Int, type: String): Long {
+    internal fun nextNumberWithinRange(
+        tags: ULongArray?,
+        from: Long,
+        to: Long,
+        unsignedUpperBound: Long,
+        type: String,
+    ): Long {
         val number = nextNumber(tags)
-        val msb = number.shr(widthBits)
-        // A number's value will fit into widthBits if:
-        // 1) (64 - widthBits) most significant bits are all zeros (the value is positive and fits into widthBits)
-        // 2) (64 - widthBits) most significant bits are all ones and
-        //    bit # (widthBits - 1) is also one (the value is negative and fits into widthBits,
-        //    truncation of the MSBs won't truncate the value itself)
-        if ((msb != 0L && msb != -1L) || (msb == -1L && number.shr(widthBits - 1) != -1L)) {
-            throw CborDecodingException("Decoded number $number could not be represented as $type without loss")
+        if (number !in from..to && number !in 0..unsignedUpperBound) {
+            throw CborDecodingException(buildString {
+                append("Decoded number $number is not within the range for type $type ([$from..$to])")
+                if (unsignedUpperBound >= 0) {
+                    append(", nor it is within the range for U$type ([0..$unsignedUpperBound])")
+                }
+            })
         }
-
         return number
     }
 
@@ -575,10 +584,12 @@ internal class CborParser(private val input: ByteArrayInput, private val verifyO
         return when (majorType) {
             HEADER_BYTE_STRING, HEADER_STRING, HEADER_ARRAY
                 -> readUnsignedIntegerIgnoringMajorType { "${majorType.majorTypeName} length" }
-                    .asSizedElementLength(majorType)
+                .asSizedElementLength(majorType)
+
             HEADER_MAP
                 -> readUnsignedIntegerIgnoringMajorType { "map length" }
-                    .asSizedElementLength(majorType, Int.MAX_VALUE / 2) * 2
+                .asSizedElementLength(majorType, Int.MAX_VALUE / 2) * 2
+
             else -> when (additionalInformation) {
                 24 -> 1
                 25 -> 2

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
@@ -612,26 +612,42 @@ class CborDecoderTest {
         val singleByteValue = "BF6176182AFF"
         //       39: two-byte int \   / -16162
         val twoByteValue = "BF6176393F21FF"
-        //       19: two-byte int \   / C0DE
+        //                       19: two-byte int \   / C0DE
         val twoByteValueWithShortOverflow = "BF617619C0DEFF"
+        //                       19: two-byte int \   / 01DE
+        val twoByteValueSlightlyOutOfByte = "BF61761901DEFF"
+        //                    38: negative single-byte int \   / 80
+        val negativeTwoByteValueSlightlyOutOfByte = "BF61763880FF"
         //       1A: four-byte int \  / 0BADC0DE
         val fourByteValue = "BF61761A0BADC0DEFF"
+        //                         1A: four-byte int \  / 0001CODE
+        val fourByteValueSlightlyOutOfShort = "BF61761A0001C0DEFF"
+        //                         39: two-byte negative int \  / 8000
+        val negativeFourByteValueSlightlyOutOfShort = "BF6176398000FF"
         //       1B: eight-byte int \  / 0BADC0DE15BAD000
         val eightByteValue = "BF61761B0BADC0DE15BAD000FF"
 
         assertEquals(0x2A, Cbor.decodeFromHexString<IntHolder>(singleByteValue).v)
         assertEquals(0xC0DE, Cbor.decodeFromHexString<IntHolder>(twoByteValueWithShortOverflow).v)
         assertEquals(0xBADC0DE, Cbor.decodeFromHexString<IntHolder>(fourByteValue).v)
+        assertEquals(0x1C0DE,Cbor.decodeFromHexString<IntHolder>(fourByteValueSlightlyOutOfShort).v)
+        assertEquals(-32769,Cbor.decodeFromHexString<IntHolder>(negativeFourByteValueSlightlyOutOfShort).v)
         assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<IntHolder>(eightByteValue) }
 
         assertEquals(0x2A, Cbor.decodeFromHexString<ShortHolder>(singleByteValue).v)
         assertEquals(0xC0DE.toShort(), Cbor.decodeFromHexString<ShortHolder>(twoByteValue).v)
-        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ShortHolder>(twoByteValueWithShortOverflow) }
+        assertEquals(0xC0DE.toShort(), Cbor.decodeFromHexString<ShortHolder>(twoByteValueWithShortOverflow).v)
         assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ShortHolder>(fourByteValue) }
+        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ShortHolder>(fourByteValueSlightlyOutOfShort) }
+        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ShortHolder>(negativeFourByteValueSlightlyOutOfShort) }
         assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ShortHolder>(eightByteValue) }
 
         assertEquals(0x2A, Cbor.decodeFromHexString<ByteHolder>(singleByteValue).v)
         assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(twoByteValue) }
+        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(twoByteValueSlightlyOutOfByte) }
+        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(fourByteValueSlightlyOutOfShort) }
+        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(negativeTwoByteValueSlightlyOutOfByte) }
+        assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(negativeFourByteValueSlightlyOutOfShort) }
         assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(fourByteValue) }
         assertFailsWith<CborDecodingException> { Cbor.decodeFromHexString<ByteHolder>(eightByteValue) }
     }
@@ -708,5 +724,16 @@ class CborDecoderTest {
         assertFailsWith<CborDecodingException> {
             Cbor.decodeFromHexString<BytesHolder>(paddedInput)
         }
+    }
+
+    @Test
+    fun testEncodeUnsignedValuesFromPositiveInteger() {
+        assertEquals(200U.toUByte(), Cbor.decodeFromHexString<UByte>("18C8"))
+        checkDecodingException<UByte>("197D00", "Decoded number 32000 could not be represented as Byte without loss")
+        assertEquals(32000U.toUShort(), Cbor.decodeFromHexString<UShort>("197D00"))
+        checkDecodingException<UShort>("1A80000000", "Decoded number 2147483648 could not be represented as Short without loss")
+        assertEquals(2147483648U, Cbor.decodeFromHexString<UInt>("1A80000000"))
+        checkDecodingException<UInt>("1B8000000000000000", "Decoded number -9223372036854775808 could not be represented as Int without loss")
+        assertEquals(9223372036854775808UL, Cbor.decodeFromHexString<ULong>("1B8000000000000000"))
     }
 }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
@@ -729,11 +729,13 @@ class CborDecoderTest {
     @Test
     fun testEncodeUnsignedValuesFromPositiveInteger() {
         assertEquals(200U.toUByte(), Cbor.decodeFromHexString<UByte>("18C8"))
-        checkDecodingException<UByte>("197D00", "Decoded number 32000 could not be represented as Byte without loss")
+        checkDecodingException<UByte>("197D00", "Decoded number 32000 is not within the range for type Byte ([-128..127]), nor it is within the range for UByte ([0..255])")
         assertEquals(32000U.toUShort(), Cbor.decodeFromHexString<UShort>("197D00"))
-        checkDecodingException<UShort>("1A80000000", "Decoded number 2147483648 could not be represented as Short without loss")
+        assertEquals(32000.toChar(), Cbor.decodeFromHexString<Char>("197D00"))
+        checkDecodingException<Char>("1A80000000", "Decoded number 2147483648 is not within the range for type Char ([0..65535])")
+        checkDecodingException<UShort>("1A80000000", "Decoded number 2147483648 is not within the range for type Short ([-32768..32767]), nor it is within the range for UShort ([0..65535])")
         assertEquals(2147483648U, Cbor.decodeFromHexString<UInt>("1A80000000"))
-        checkDecodingException<UInt>("1B8000000000000000", "Decoded number -9223372036854775808 could not be represented as Int without loss")
+        checkDecodingException<UInt>("1B8000000000000000", "Decoded number -9223372036854775808 is not within the range for type Int ([-2147483648..2147483647]), nor it is within the range for UInt ([0..4294967295])")
         assertEquals(9223372036854775808UL, Cbor.decodeFromHexString<ULong>("1B8000000000000000"))
     }
 }


### PR DESCRIPTION
A commit e334d1c introduced a strict value range check when decoding integer values. The main intention was to prevent misinterpreting a parsed CBOR document due to integer overflow or truncation. However, the overflow check is too strict and prevent decoding unsigned Kotlin numbers from some unsigned CBOR integers. For now, we should relax the check to verify only that there will be no truncation.

Closes #3143