### PR TITLE
Skip discriminator entries when decoding inline-map sealed children

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/sealed/SealedInterfacesInlineMapChildTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/sealed/SealedInterfacesInlineMapChildTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.features.sealed
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonTestBase
+import kotlin.jvm.JvmInline
+import kotlin.test.Test
+
+class SealedInterfacesInlineMapChildTest : JsonTestBase() {
+
+    @Serializable
+    sealed interface Parent {
+
+        @JvmInline
+        @Serializable
+        @SerialName("child")
+        value class Child(val value: Map<Int, String>) : Parent
+    }
+
+    @Test
+    fun encodesDecodesInlineMapChildWithClassDiscriminator() {
+        val value = Parent.Child(mapOf(1 to "one", 2 to "two"))
+        assertJsonFormAndRestored(
+            Parent.serializer(),
+            value,
+            """{"type":"child","1":"one","2":"two"}"""
+        )
+    }
+}

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -101,6 +101,9 @@ internal open class StreamingJsonDecoder(
         lexer.path.pushDescriptor(descriptor)
         lexer.consumeNextToken(newMode.begin)
         checkLeadingComma()
+        if (newMode == WriteMode.MAP) {
+            skipMapDiscriminator()
+        }
         return when (newMode) {
             // In fact resets current index that these modes rely on
             WriteMode.LIST, WriteMode.MAP, WriteMode.POLY_OBJ -> StreamingJsonDecoder(
@@ -150,6 +153,18 @@ internal open class StreamingJsonDecoder(
     private fun checkLeadingComma() {
         if (lexer.peekNextToken() == TC_COMMA) {
             lexer.fail("Unexpected leading comma")
+        }
+    }
+
+    // Skip the discriminator when entering MAP mode. decodeMapIndex can't skip
+    // it like decodeObjectIndex because we delegate the actual key decoding to
+    // serializers, and decodeObjectIndex only needs to care about string keys.
+    private fun skipMapDiscriminator() {
+        if (discriminatorHolder?.discriminatorToSkip == null) return
+        if (discriminatorHolder.trySkip(decodeStringKey())) {
+            lexer.consumeNextToken(COLON)
+            lexer.skipElement(configuration.isLenient)
+            val _ = lexer.tryConsumeComma()
         }
     }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -63,7 +63,7 @@ private sealed class AbstractJsonTreeDecoder(
             StructureKind.LIST, is PolymorphicKind -> JsonTreeListDecoder(json, cast(currentObject, descriptor))
             StructureKind.MAP -> json.selectMapMode(
                 descriptor,
-                { JsonTreeMapDecoder(json, cast(currentObject, descriptor)) },
+                { JsonTreeMapDecoder(json, cast(currentObject, descriptor), polymorphicDiscriminator) },
                 { JsonTreeListDecoder(json, cast(currentObject, descriptor)) }
             )
             else -> JsonTreeDecoder(json, cast(currentObject, descriptor), polymorphicDiscriminator)
@@ -303,8 +303,16 @@ private open class JsonTreeDecoder(
     }
 }
 
-private class JsonTreeMapDecoder(json: Json, override val value: JsonObject) : JsonTreeDecoder(json, value) {
-    private val keys = value.keys.toList()
+private class JsonTreeMapDecoder(
+    json: Json,
+    override val value: JsonObject,
+    polymorphicDiscriminator: String? = null
+) : JsonTreeDecoder(json, value, polymorphicDiscriminator) {
+    private val keys = if (polymorphicDiscriminator != null) {
+        value.keys.filter { it != polymorphicDiscriminator }
+    } else {
+        value.keys.toList()
+    }
     private val size: Int = keys.size * 2
     private var position = -1
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -121,6 +121,9 @@ private sealed class AbstractJsonTreeEncoder(
         return if (currentTagOrNull != null) {
             if (polymorphicDiscriminator != null) polymorphicSerialName = descriptor.serialName
             super.encodeInline(descriptor)
+        } else if (polymorphicDiscriminator != null) {
+            polymorphicSerialName = descriptor.serialName
+            this
         } else {
             JsonPrimitiveEncoder(json, nodeConsumer).encodeInline(descriptor)
         }


### PR DESCRIPTION
Fixes #3172

Streaming JSON decoding is missing an edge-case where:

- an object is decoded in MAP mode
- the object contains a polymorphic discriminator

I believe the only case this can happen is when you have a value class, wrapping `Map<K, V>`, in a sealed hierarchy. If we're in this case, skip the discriminator entry and proceed to decode the object as a Map.

Tree decoding doesn't handle the discriminator either; skip it by filtering it out of `keys`.

There's an ancillary issue the test revealed: encoding the value class with JsonTreeEncoder is missing the discriminator entirely, probably because we don't set a tag for `Map` values. Added similar handling for the case where we have a discriminator but no tag, and return `this` decoder so that we encode the wrapped value without dealing with tags.