### PR TITLE
Add @JsonExtraKeys for capturing unknown JSON keys

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/JsonExtraKeysBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/JsonExtraKeysBenchmark.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package kotlinx.benchmarks.json
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(2)
+open class JsonExtraKeysBenchmark {
+
+    @Serializable
+    class Plain(
+        val i1: Int, val i2: Int, val i3: Int, val i4: Int, val i5: Int,
+        val i6: Int, val i7: Int, val i8: Int, val i9: Int, val i10: Int
+    )
+
+    @Serializable
+    class WithMapBucket(
+        val i1: Int, val i2: Int, val i3: Int, val i4: Int, val i5: Int,
+        val i6: Int, val i7: Int, val i8: Int, val i9: Int, val i10: Int,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    class WithObjectBucket(
+        val i1: Int, val i2: Int, val i3: Int, val i4: Int, val i5: Int,
+        val i6: Int, val i7: Int, val i8: Int, val i9: Int, val i10: Int,
+        @JsonExtraKeys val extras: JsonObject = JsonObject(emptyMap())
+    )
+
+    private val noExtrasInput = """{"i1":1,"i2":1,"i3":1,"i4":1,"i5":1,"i6":1,"i7":1,"i8":1,"i9":1,"i10":1}"""
+    private val extrasInput =
+        """{"i1":1,"i2":1,"i3":1,"i4":1,"i5":1,"i6":1,"i7":1,"i8":1,"i9":1,"i10":1,"e1":2,"e2":2,"e3":2}"""
+
+    private val json = Json // useExtraKeys = false by default
+    private val extraKeysJson = Json { useExtraKeys = true }
+    private val ignoringJson = Json { ignoreUnknownKeys = true }
+
+    private val mapValue = extraKeysJson.decodeFromString(WithMapBucket.serializer(), extrasInput)
+    private val objectValue = extraKeysJson.decodeFromString(WithObjectBucket.serializer(), extrasInput)
+    private val plainValue = json.decodeFromString(Plain.serializer(), noExtrasInput)
+
+    // Baseline with the default configuration (useExtraKeys = false). Compare
+    // against the same benchmark on master to detect hot-path regressions from
+    // the feature's mere existence in the code.
+    @Benchmark
+    fun decodePlain() = json.decodeFromString(Plain.serializer(), noExtrasInput)
+
+    @Benchmark
+    fun encodePlain() = json.encodeToString(Plain.serializer(), plainValue)
+
+    // Flag enabled, but the class declares no bucket: the per-object cost of
+    // the enabled feature for classes that do not use it.
+    @Benchmark
+    fun decodePlainExtraKeysOn() = extraKeysJson.decodeFromString(Plain.serializer(), noExtrasInput)
+
+    @Benchmark
+    fun encodePlainExtraKeysOn() = extraKeysJson.encodeToString(Plain.serializer(), plainValue)
+
+    // Bucket declared, input contains no unknown keys: the price of declaring
+    // a bucket on the happy path.
+    @Benchmark
+    fun decodeMapBucketNoExtras() = extraKeysJson.decodeFromString(WithMapBucket.serializer(), noExtrasInput)
+
+    @Benchmark
+    fun decodeObjectBucketNoExtras() = extraKeysJson.decodeFromString(WithObjectBucket.serializer(), noExtrasInput)
+
+    // Today's alternative: unknown keys silently dropped.
+    @Benchmark
+    fun decodeIgnoringExtras() = ignoringJson.decodeFromString(Plain.serializer(), extrasInput)
+
+    // Capture cost with 3 unknown keys.
+    @Benchmark
+    fun decodeMapBucketExtras() = extraKeysJson.decodeFromString(WithMapBucket.serializer(), extrasInput)
+
+    @Benchmark
+    fun decodeObjectBucketExtras() = extraKeysJson.decodeFromString(WithObjectBucket.serializer(), extrasInput)
+
+    // Write-back cost: 3 captured entries validated and appended after the
+    // regular properties.
+    @Benchmark
+    fun encodeMapBucketExtras() = extraKeysJson.encodeToString(WithMapBucket.serializer(), mapValue)
+
+    @Benchmark
+    fun encodeObjectBucketExtras() = extraKeysJson.encodeToString(WithObjectBucket.serializer(), objectValue)
+}

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TwitterFeedBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TwitterFeedBenchmark.kt
@@ -24,6 +24,8 @@ open class TwitterFeedBenchmark {
     private val twitter = Json.decodeFromString(MacroTwitterFeed.serializer(), input)
 
     private val jsonNoAltNames = Json { useAlternativeNames = false }
+    @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+    private val jsonExtraKeys = Json { useExtraKeys = true }
     private val jsonIgnoreUnknwn = Json { ignoreUnknownKeys = true }
     private val jsonIgnoreUnknwnNoAltNames = Json { ignoreUnknownKeys = true; useAlternativeNames = false }
     private val jsonNamingStrategy = Json { namingStrategy = JsonNamingStrategy.SnakeCase }
@@ -46,6 +48,14 @@ open class TwitterFeedBenchmark {
 
     @Benchmark
     fun encodeTwitter() = Json.encodeToString(MacroTwitterFeed.serializer(), twitter)
+
+    // Enabled state of the useExtraKeys flag on a macro payload; the default
+    // (disabled) state is measured by decodeTwitter/encodeTwitter.
+    @Benchmark
+    fun decodeTwitterWithExtraKeys() = jsonExtraKeys.decodeFromString(MacroTwitterFeed.serializer(), input)
+
+    @Benchmark
+    fun encodeTwitterWithExtraKeys() = jsonExtraKeys.encodeToString(MacroTwitterFeed.serializer(), twitter)
 
     @Benchmark
     fun decodeMicroTwitter() = jsonIgnoreUnknwn.decodeFromString(MicroTwitterFeed.serializer(), input)

--- a/docs/json.md
+++ b/docs/json.md
@@ -41,6 +41,7 @@ In this chapter, we'll walk through features of [JSON](https://www.json.org/json
   * [Extending the behavior of the plugin generated serializer](#extending-the-behavior-of-the-plugin-generated-serializer)
   * [Under the hood (experimental)](#under-the-hood-experimental)
   * [Maintaining custom JSON attributes](#maintaining-custom-json-attributes)
+  * [Preserving unknown keys (experimental)](#preserving-unknown-keys-experimental)
 
 <!--- END -->
 
@@ -162,6 +163,8 @@ It decodes the object despite the fact that the `Project` class doesn't have the
 ```text
 Project(name=kotlinx.serialization)
 ```
+
+If you need to keep the unknown keys instead of dropping them, see [Preserving unknown keys (experimental)](#preserving-unknown-keys-experimental).
 
 <!--- TEST -->
 
@@ -1514,6 +1517,56 @@ UnknownProject(name=example, details={"type":"unknown","maintainer":"Unknown","l
 
 <!--- TEST -->
 
+### Preserving unknown keys (experimental)
+
+Instead of writing such a serializer by hand, you can ask the plugin-generated serializer to collect unknown keys for you.
+Mark a property of type [JsonObject] with the [JsonExtraKeys] annotation and enable the [useExtraKeys][JsonBuilder.useExtraKeys]
+flag on the [Json] instance:
+
+```kotlin
+@OptIn(ExperimentalSerializationApi::class) // useExtraKeys is an experimental setting for now
+val format = Json { useExtraKeys = true }
+
+@OptIn(ExperimentalSerializationApi::class) // JsonExtraKeys is an experimental annotation for now
+@Serializable
+data class Project(
+    val name: String,
+    @JsonExtraKeys val details: JsonObject = JsonObject(emptyMap())
+)
+
+fun main() {
+    val project = format.decodeFromString<Project>("""{"type":"unknown","name":"example","maintainer":"Unknown","license":"Apache 2.0"}""")
+    println(project)
+    println(format.encodeToString(project))
+}
+```
+
+> You can get the full code [here](../guide/example/example-json-33.kt).
+
+Every key that does not match a declared property of `Project` ends up in `details`. Encoding writes them back
+after the regular properties, so the JSON survives a decode and encode round trip:
+
+```text
+Project(name=example, details={"type":"unknown","maintainer":"Unknown","license":"Apache 2.0"})
+{"name":"example","type":"unknown","maintainer":"Unknown","license":"Apache 2.0"}
+```
+
+A few rules apply:
+
+* Only one property per class can be annotated, and it must be of type [JsonObject] or `Map<String, JsonElement>`.
+Give it a default value so that the property is optional when the input has no unknown keys.
+* [JsonExtraKeys] takes precedence over [ignoreUnknownKeys][JsonBuilder.ignoreUnknownKeys] and [JsonIgnoreUnknownKeys]:
+unknown keys are captured rather than ignored or rejected.
+* Keys matched through [JsonNames] or a [JsonNamingStrategy] are not unknown and are not captured.
+The class discriminator used for polymorphism is not captured either.
+* If the captured object contains a key that a declared property would be written under, encoding throws
+a `SerializationException` instead of producing duplicate keys.
+
+The flag is disabled by default because resolving the annotation adds a small cost to encoding and decoding of every class,
+including classes that do not use [JsonExtraKeys]. Without the flag, the annotated property behaves as a regular one.
+
+<!--- TEST -->
+
 ---
 
 The next chapter covers [Alternative and custom formats (experimental)](formats.md).
@@ -1598,5 +1651,7 @@ The next chapter covers [Alternative and custom formats (experimental)](formats.
 [JsonDecoder.json]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-decoder/json.html
 [JsonEncoder.json]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-encoder/json.html
 [Json.encodeToJsonElement]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/encode-to-json-element.html
+[JsonExtraKeys]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-extra-keys/index.html
+[JsonBuilder.useExtraKeys]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-builder/use-extra-keys.html
 
 <!--- END -->

--- a/docs/serialization-guide.md
+++ b/docs/serialization-guide.md
@@ -143,6 +143,7 @@ Once the project is set up, we can start serializing some classes.
   * <a name='extending-the-behavior-of-the-plugin-generated-serializer'></a>[Extending the behavior of the plugin generated serializer](json.md#extending-the-behavior-of-the-plugin-generated-serializer)
   * <a name='under-the-hood-experimental'></a>[Under the hood (experimental)](json.md#under-the-hood-experimental)
   * <a name='maintaining-custom-json-attributes'></a>[Maintaining custom JSON attributes](json.md#maintaining-custom-json-attributes)
+  * <a name='preserving-unknown-keys-experimental'></a>[Preserving unknown keys (experimental)](json.md#preserving-unknown-keys-experimental)
 <!--- END -->
 
 **Chapter 6.** [Alternative and custom formats (experimental)](formats.md)

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.test.checkSerializationException
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class JsonExtraKeysTest : JsonTestBase() {
+
+    @Serializable
+    data class Basic(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    data class NonOptionalBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, JsonElement>
+    )
+
+    @Serializable
+    data class WithNullable(
+        val a: Int,
+        val b: String? = null,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    data class WithAlias(
+        val a: Int,
+        @JsonNames("b_alias") val b: String,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    data class WithNaming(
+        val someValue: Int,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    @JsonIgnoreUnknownKeys
+    data class IgnoresUnknown(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    sealed class Base
+
+    @Serializable
+    @SerialName("derived")
+    data class Derived(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    ) : Base()
+
+    @Serializable
+    data class Wrapper(val base: Base)
+
+    @Serializable
+    data class BadBucket(
+        val a: Int,
+        @JsonNames("extras_alias")
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    data class TwoSiblings(val first: Basic, val second: Basic)
+
+    @Serializable
+    data class RecursiveNode(
+        val value: Int,
+        val child: RecursiveNode? = null,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
+    data class OuterWithNestedPoly(
+        val base: Base,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Test
+    fun testBasicCapture() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"a":1,"b":"text","c":[1,2],"d":{"x":true},"e":null}"""
+        val result = json.decodeFromString<Basic>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(JsonPrimitive("text"), result.extras["b"])
+        assertEquals(JsonArray(listOf(JsonPrimitive(1), JsonPrimitive(2))), result.extras["c"])
+        assertEquals(JsonObject(mapOf("x" to JsonPrimitive(true))), result.extras["d"])
+        assertEquals(JsonNull, result.extras["e"])
+
+        val roundTrip = json.encodeToString(result, mode)
+        val result2 = json.decodeFromString<Basic>(roundTrip, mode)
+        assertEquals(result, result2)
+    }
+
+    @Test
+    fun testCaptureWinsOverIgnoreUnknownKeys() = parametrizedTest { mode ->
+        val json = Json(default) { ignoreUnknownKeys = true; encodeDefaults = true }
+        val input = """{"a":1,"unknown":42}"""
+        val result = json.decodeFromString<Basic>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(JsonPrimitive(42), result.extras["unknown"])
+    }
+
+    @Test
+    fun testCaptureWinsOverAnnotation() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"a":1,"unknown":42}"""
+        val result = json.decodeFromString<IgnoresUnknown>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(JsonPrimitive(42), result.extras["unknown"])
+    }
+
+    @Test
+    fun testJsonNamesInteraction() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"a":1,"b_alias":"value","unknown":42}"""
+        val result = json.decodeFromString<WithAlias>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals("value", result.b)
+        assertEquals(JsonPrimitive(42), result.extras["unknown"])
+    }
+
+    @Test
+    fun testNamingStrategy() = parametrizedTest { mode ->
+        val json = Json(default) { namingStrategy = JsonNamingStrategy.SnakeCase; encodeDefaults = true }
+        val input = """{"some_value":1,"some_other":42}"""
+        val result = json.decodeFromString<WithNaming>(input, mode)
+        assertEquals(1, result.someValue)
+        assertEquals(JsonPrimitive(42), result.extras["some_other"])
+    }
+
+    @Test
+    fun testRejectJsonNamesOnBucket() {
+        val json = Json(default) { encodeDefaults = true }
+        assertFailsWith<SerializationException> {
+            json.decodeFromString<BadBucket>("""{"a":1}""")
+        }
+    }
+
+    @Test
+    fun testExplicitNullsFalse() = parametrizedTest { mode ->
+        val json = Json(default) { explicitNulls = false; encodeDefaults = true }
+        val input = """{"a":1,"unknown":42}"""
+        val result = json.decodeFromString<WithNullable>(input, mode)
+        assertEquals(1, result.a)
+        assertNull(result.b)
+        assertEquals(JsonPrimitive(42), result.extras["unknown"])
+    }
+
+    @Test
+    fun testDiscriminatorExcluded() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"base":{"type":"derived","a":1,"unknown":42}}"""
+        val result = json.decodeFromString<Wrapper>(input, mode)
+        val derived = result.base as Derived
+        assertEquals(1, derived.a)
+        assertEquals(JsonPrimitive(42), derived.extras["unknown"])
+        assertNull(derived.extras["type"])
+    }
+
+    @Test
+    fun testBucketOwnNameCaptured() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"a":1,"extras":42}"""
+        val result = json.decodeFromString<Basic>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(JsonPrimitive(42), result.extras["extras"])
+    }
+
+    @Test
+    fun testEncodeCollisionDeclaredName() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val data = Basic(a = 1, extras = mapOf("a" to JsonPrimitive(2)))
+        checkSerializationException({
+            json.encodeToString(data, mode)
+        }) { msg ->
+            assertContains(msg, "conflicts with a declared property name")
+        }
+    }
+
+    @Test
+    fun testEncodeCollisionDiscriminator() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val data: Base = Derived(a = 1, extras = mapOf("type" to JsonPrimitive("foo")))
+        checkSerializationException({
+            json.encodeToString(Base.serializer(), data, mode)
+        }) { msg ->
+            assertContains(msg, "conflicts with the active class discriminator")
+        }
+    }
+
+    @Test
+    fun testNonOptionalBucketNoExtras() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"a":1}"""
+        val result = json.decodeFromString<NonOptionalBucket>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(emptyMap(), result.extras)
+    }
+
+    @Test
+    fun testNamingStrategyEncodeCollision() = parametrizedTest { mode ->
+        val json = Json(default) { namingStrategy = JsonNamingStrategy.SnakeCase; encodeDefaults = true }
+        val data = WithNaming(someValue = 1, extras = mapOf("some_value" to JsonPrimitive(2)))
+        checkSerializationException({
+            json.encodeToString(data, mode)
+        }) { msg ->
+            assertContains(msg, "conflicts with a declared property name")
+        }
+    }
+
+    @Test
+    fun testSiblingSameTypeBuckets() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"first":{"a":1,"x":10},"second":{"a":2,"y":20}}"""
+        val result = json.decodeFromString<TwoSiblings>(input, mode)
+        assertEquals(1, result.first.a)
+        assertEquals(JsonPrimitive(10), result.first.extras["x"])
+        assertEquals(2, result.second.a)
+        assertEquals(JsonPrimitive(20), result.second.extras["y"])
+    }
+
+    @Test
+    fun testNestedSameDescriptorDecode() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val input = """{"value":1,"child":{"value":2,"inner":"in"},"outer":"out"}"""
+        val result = json.decodeFromString<RecursiveNode>(input, mode)
+        assertEquals(1, result.value)
+        assertEquals(JsonPrimitive("in"), result.child?.extras?.get("inner"))
+        assertEquals(JsonPrimitive("out"), result.extras["outer"])
+    }
+
+    @Test
+    fun testEncodeCollisionAliasName() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val data = WithAlias(a = 1, b = "value", extras = mapOf("b_alias" to JsonPrimitive("conflict")))
+        checkSerializationException({
+            json.encodeToString(data, mode)
+        }) { msg ->
+            assertContains(msg, "conflicts with a declared property name")
+        }
+    }
+
+    @Test
+    fun testOuterBucketAfterNestedPolymorphic() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val data = OuterWithNestedPoly(base = Derived(a = 1), extras = mapOf("type" to JsonPrimitive("foo")))
+        // "type" is the discriminator of Derived, but OuterWithNestedPoly is not polymorphic,
+        // so its extras may legally contain "type".
+        val serialized = json.encodeToString(data, mode)
+        val deserialized = json.decodeFromString<OuterWithNestedPoly>(serialized, mode)
+        assertEquals(JsonPrimitive("foo"), deserialized.extras["type"])
+    }
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
@@ -17,6 +17,9 @@ import kotlin.test.assertNull
 
 class JsonExtraKeysTest : JsonTestBase() {
 
+    // @JsonExtraKeys processing is off by default and must be enabled explicitly.
+    private val extraJson = Json(default) { useExtraKeys = true }
+
     @Serializable
     data class Basic(
         val a: Int,
@@ -80,6 +83,16 @@ class JsonExtraKeysTest : JsonTestBase() {
     data class TwoSiblings(val first: Basic, val second: Basic)
 
     @Serializable
+    data class PlainChild(val x: Int)
+
+    @Serializable
+    data class BucketWithPlainChild(
+        val a: Int,
+        val child: PlainChild,
+        @JsonExtraKeys val extras: Map<String, JsonElement> = emptyMap()
+    )
+
+    @Serializable
     data class RecursiveNode(
         val value: Int,
         val child: RecursiveNode? = null,
@@ -94,7 +107,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testBasicCapture() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"a":1,"b":"text","c":[1,2],"d":{"x":true},"e":null}"""
         val result = json.decodeFromString<Basic>(input, mode)
         assertEquals(1, result.a)
@@ -112,7 +125,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testCaptureWinsOverIgnoreUnknownKeys() = parametrizedTest { mode ->
-        val json = Json(default) { ignoreUnknownKeys = true; encodeDefaults = true }
+        val json = Json(extraJson) { ignoreUnknownKeys = true; encodeDefaults = true }
         val input = """{"a":1,"unknown":42}"""
         val result = json.decodeFromString<Basic>(input, mode)
         assertEquals(1, result.a)
@@ -121,7 +134,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testCaptureWinsOverAnnotation() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"a":1,"unknown":42}"""
         val result = json.decodeFromString<IgnoresUnknown>(input, mode)
         assertEquals(1, result.a)
@@ -130,7 +143,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testJsonNamesInteraction() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"a":1,"b_alias":"value","unknown":42}"""
         val result = json.decodeFromString<WithAlias>(input, mode)
         assertEquals(1, result.a)
@@ -140,7 +153,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testNamingStrategy() = parametrizedTest { mode ->
-        val json = Json(default) { namingStrategy = JsonNamingStrategy.SnakeCase; encodeDefaults = true }
+        val json = Json(extraJson) { namingStrategy = JsonNamingStrategy.SnakeCase; encodeDefaults = true }
         val input = """{"some_value":1,"some_other":42}"""
         val result = json.decodeFromString<WithNaming>(input, mode)
         assertEquals(1, result.someValue)
@@ -149,7 +162,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testRejectJsonNamesOnBucket() {
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         assertFailsWith<SerializationException> {
             json.decodeFromString<BadBucket>("""{"a":1}""")
         }
@@ -157,7 +170,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testExplicitNullsFalse() = parametrizedTest { mode ->
-        val json = Json(default) { explicitNulls = false; encodeDefaults = true }
+        val json = Json(extraJson) { explicitNulls = false; encodeDefaults = true }
         val input = """{"a":1,"unknown":42}"""
         val result = json.decodeFromString<WithNullable>(input, mode)
         assertEquals(1, result.a)
@@ -167,7 +180,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testDiscriminatorExcluded() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"base":{"type":"derived","a":1,"unknown":42}}"""
         val result = json.decodeFromString<Wrapper>(input, mode)
         val derived = result.base as Derived
@@ -178,7 +191,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testBucketOwnNameCaptured() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"a":1,"extras":42}"""
         val result = json.decodeFromString<Basic>(input, mode)
         assertEquals(1, result.a)
@@ -192,14 +205,14 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testEncodeWritesExtrasLast() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val data = Basic(a = 1, extras = mapOf("z" to JsonPrimitive(2), "y" to JsonPrimitive(3)))
         assertEquals("""{"a":1,"z":2,"y":3}""", json.encodeToString(data, mode))
     }
 
     @Test
     fun testEncodeCollisionDeclaredName() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val data = Basic(a = 1, extras = mapOf("a" to JsonPrimitive(2)))
         checkSerializationException({
             json.encodeToString(data, mode)
@@ -210,7 +223,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testEncodeCollisionDiscriminator() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val data: Base = Derived(a = 1, extras = mapOf("type" to JsonPrimitive("foo")))
         checkSerializationException({
             json.encodeToString(Base.serializer(), data, mode)
@@ -221,7 +234,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testEncodeCollisionAliasName() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val data = WithAlias(a = 1, b = "value", extras = mapOf("b_alias" to JsonPrimitive("conflict")))
         checkSerializationException({
             json.encodeToString(data, mode)
@@ -232,7 +245,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testNonOptionalBucketNoExtras() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"a":1}"""
         val result = json.decodeFromString<NonOptionalBucket>(input, mode)
         assertEquals(1, result.a)
@@ -241,7 +254,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testNamingStrategyEncodeCollision() = parametrizedTest { mode ->
-        val json = Json(default) { namingStrategy = JsonNamingStrategy.SnakeCase; encodeDefaults = true }
+        val json = Json(extraJson) { namingStrategy = JsonNamingStrategy.SnakeCase; encodeDefaults = true }
         val data = WithNaming(someValue = 1, extras = mapOf("some_value" to JsonPrimitive(2)))
         checkSerializationException({
             json.encodeToString(data, mode)
@@ -252,7 +265,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testSiblingSameTypeBuckets() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"first":{"a":1,"x":10},"second":{"a":2,"y":20}}"""
         val result = json.decodeFromString<TwoSiblings>(input, mode)
         assertEquals(1, result.first.a)
@@ -262,8 +275,21 @@ class JsonExtraKeysTest : JsonTestBase() {
     }
 
     @Test
+    fun testCaptureSurvivesNestedPlainObject() = parametrizedTest { mode ->
+        val json = Json(extraJson) { encodeDefaults = true }
+        // Keys captured before a nested bucket-less object must survive the
+        // nested object's endStructure (decoder instance reuse).
+        val input = """{"u1":1,"a":1,"child":{"x":2},"u2":2}"""
+        val result = json.decodeFromString<BucketWithPlainChild>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(PlainChild(2), result.child)
+        assertEquals(JsonPrimitive(1), result.extras["u1"])
+        assertEquals(JsonPrimitive(2), result.extras["u2"])
+    }
+
+    @Test
     fun testNestedSameDescriptorDecode() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         val input = """{"value":1,"child":{"value":2,"inner":"in"},"outer":"out"}"""
         val result = json.decodeFromString<RecursiveNode>(input, mode)
         assertEquals(1, result.value)
@@ -273,7 +299,7 @@ class JsonExtraKeysTest : JsonTestBase() {
 
     @Test
     fun testOuterBucketAfterNestedPolymorphic() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
+        val json = Json(extraJson) { encodeDefaults = true }
         // "type" is the discriminator of Derived, but OuterWithNestedPoly is not polymorphic,
         // so a top-level "type" key is a regular unknown key and lands in the outer bucket.
         // On encode, the nested Derived's discriminator must not be misattributed
@@ -315,28 +341,59 @@ class JsonExtraKeysTest : JsonTestBase() {
     @Test
     fun testJsonObjectTypedBucket() = parametrizedTest { mode ->
         val input = """{"a":1,"x":10,"y":"s"}"""
-        val result = default.decodeFromString<ObjectBucket>(input, mode)
+        val result = extraJson.decodeFromString<ObjectBucket>(input, mode)
         assertEquals(1, result.a)
         assertEquals(JsonPrimitive(10), result.extras["x"])
         assertEquals(JsonPrimitive("s"), result.extras["y"])
-        assertEquals(input, default.encodeToString(result, mode))
+        assertEquals(input, extraJson.encodeToString(result, mode))
     }
 
     @Test
     fun testRoundTripEmptyObjectBucket() = parametrizedTest { mode ->
         val input = """{"a":1}"""
-        val result = default.decodeFromString<ObjectBucket>(input, mode)
+        val result = extraJson.decodeFromString<ObjectBucket>(input, mode)
         assertEquals(1, result.a)
         assertEquals(JsonObject(emptyMap()), result.extras)
-        val roundTrip = default.encodeToString(result, mode)
-        assertEquals(result, default.decodeFromString<ObjectBucket>(roundTrip, mode))
+        val roundTrip = extraJson.encodeToString(result, mode)
+        assertEquals(result, extraJson.decodeFromString<ObjectBucket>(roundTrip, mode))
     }
 
     @Test
     fun testRejectTypedValues() {
         assertFailsWith<SerializationException> {
-            default.decodeFromString<IntBucket>("""{"a":1}""")
+            extraJson.decodeFromString<IntBucket>("""{"a":1}""")
         }
+    }
+
+    @Test
+    fun testFlagOffAnnotationIgnored() = parametrizedTest { mode ->
+        val json = Json(extraJson) { useExtraKeys = false; encodeDefaults = true }
+        // The bucket behaves as a regular property: read from and written
+        // under its own name, no capture.
+        val input = """{"a":1,"extras":{"x":10}}"""
+        val result = json.decodeFromString<Basic>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(JsonPrimitive(10), result.extras["x"])
+        assertEquals(input, json.encodeToString(result, mode))
+    }
+
+    @Test
+    fun testFlagOffUnknownKeysRejected() = parametrizedTest { mode ->
+        val json = Json(extraJson) { useExtraKeys = false }
+        // Without capture, unknown keys fall back to default handling.
+        assertFailsWith<SerializationException> {
+            json.decodeFromString<Basic>("""{"a":1,"unknown":42}""", mode)
+        }
+    }
+
+    @Test
+    fun testFlagOffValidationSkipped() = parametrizedTest { mode ->
+        // With the flag off, even invalid bucket declarations are usable as
+        // plain properties — validation never runs.
+        val json = Json(extraJson) { useExtraKeys = false }
+        val result = json.decodeFromString<IntBucket>("""{"a":1,"extras":{"x":10}}""", mode)
+        assertEquals(1, result.a)
+        assertEquals(10, result.extras["x"])
     }
 
     @Test
@@ -344,7 +401,7 @@ class JsonExtraKeysTest : JsonTestBase() {
         // Inline value class wrapping String has STRING kind but a different
         // runtime type — the strict identity check rejects it.
         assertFailsWith<SerializationException> {
-            default.decodeFromString<InlineKeyBucket>("""{"a":1}""")
+            extraJson.decodeFromString<InlineKeyBucket>("""{"a":1}""")
         }
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
@@ -4,10 +4,20 @@
 
 package kotlinx.serialization.json
 
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.test.checkSerializationException
+import kotlin.jvm.JvmInline
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -265,5 +275,190 @@ class JsonExtraKeysTest : JsonTestBase() {
         val serialized = json.encodeToString(data, mode)
         val deserialized = json.decodeFromString<OuterWithNestedPoly>(serialized, mode)
         assertEquals(JsonPrimitive("foo"), deserialized.extras["type"])
+    }
+
+    // ---- bucket value types other than JsonElement ----
+
+    @Serializable
+    data class IntBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, Int> = emptyMap()
+    )
+
+    @Serializable
+    data class Inner(val name: String, val count: Int)
+
+    @Serializable
+    data class ClassBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, Inner> = emptyMap()
+    )
+
+    @Serializable
+    sealed class Shape
+
+    @Serializable
+    @SerialName("circle")
+    data class Circle(val radius: Double) : Shape()
+
+    @Serializable
+    @SerialName("square")
+    data class Square(val side: Double) : Shape()
+
+    @Serializable
+    data class ShapeBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, Shape> = emptyMap()
+    )
+
+    // Polymorphic outer with a bucket whose value type's property name collides
+    // with the outer's class discriminator ("type"). Inner's "type" field must
+    // be written inside the inner object — not be flagged as a bucket-key
+    // collision against the outer discriminator.
+    @Serializable
+    sealed class PolyOuter
+
+    @Serializable
+    data class ValueWithTypeProperty(val type: String, val payload: String)
+
+    @Serializable
+    @SerialName("polyOuter")
+    data class PolyOuterImpl(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, ValueWithTypeProperty> = emptyMap()
+    ) : PolyOuter()
+
+    // Contextual value type — resolution at encode/decode time via SerializersModule.
+    data class ExternalValue(val text: String)
+
+    private object ExternalValueSerializer : KSerializer<ExternalValue> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("ExternalValue", PrimitiveKind.STRING)
+        override fun serialize(encoder: Encoder, value: ExternalValue) =
+            encoder.encodeString(value.text)
+        override fun deserialize(decoder: Decoder): ExternalValue =
+            ExternalValue(decoder.decodeString())
+    }
+
+    @Serializable
+    data class ContextualBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<String, @Contextual ExternalValue> = emptyMap()
+    )
+
+    // Inline String key — must be rejected by the strict identity check
+    // because the encode path casts each entry key to String.
+    @JvmInline
+    @Serializable
+    value class WrappedKey(val raw: String)
+
+    @Serializable
+    data class InlineKeyBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: Map<WrappedKey, Int> = emptyMap()
+    )
+
+    @Test
+    fun testRoundTripMapStringInt() = parametrizedTest { mode ->
+        val input = """{"a":1,"x":10,"y":20}"""
+        val result = default.decodeFromString<IntBucket>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(10, result.extras["x"])
+        assertEquals(20, result.extras["y"])
+        val roundTrip = default.encodeToString(result, mode)
+        assertEquals(result, default.decodeFromString<IntBucket>(roundTrip, mode))
+    }
+
+    @Test
+    fun testRoundTripMapStringDataClass() = parametrizedTest { mode ->
+        val input = """{"a":1,"foo":{"name":"hello","count":3},"bar":{"name":"world","count":7}}"""
+        val result = default.decodeFromString<ClassBucket>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(Inner("hello", 3), result.extras["foo"])
+        assertEquals(Inner("world", 7), result.extras["bar"])
+        val roundTrip = default.encodeToString(result, mode)
+        assertEquals(result, default.decodeFromString<ClassBucket>(roundTrip, mode))
+    }
+
+    @Test
+    fun testRoundTripEmptyIntBucket() = parametrizedTest { mode ->
+        val input = """{"a":1}"""
+        val result = default.decodeFromString<IntBucket>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(emptyMap(), result.extras)
+        // Empty bucket: encode should not emit anything for `extras`.
+        val roundTrip = default.encodeToString(result, mode)
+        assertEquals(result, default.decodeFromString<IntBucket>(roundTrip, mode))
+    }
+
+    @Test
+    fun testTypeMismatchInBucketValueReportsError() = parametrizedTest { mode ->
+        val input = """{"a":1,"x":"not-an-int"}"""
+        assertFailsWith<SerializationException> {
+            default.decodeFromString<IntBucket>(input, mode)
+        }
+    }
+
+    @Test
+    fun testRoundTripMapStringPolymorphic() = parametrizedTest { mode ->
+        val data = ShapeBucket(
+            a = 1,
+            extras = mapOf(
+                "shape1" to Circle(radius = 2.5),
+                "shape2" to Square(side = 4.0)
+            )
+        )
+        val serialized = default.encodeToString(data, mode)
+        val restored = default.decodeFromString<ShapeBucket>(serialized, mode)
+        assertEquals(data, restored)
+    }
+
+    @Test
+    fun testInnerValuePropertyNamesDoNotClashWithOuterDiscriminator() = parametrizedTest { mode ->
+        // PolyOuterImpl's discriminator at outer level is "type". Inner value
+        // ValueWithTypeProperty also has a property named "type" — that lives
+        // inside the inner object's braces and must NOT be misinterpreted as
+        // a bucket-key collision.
+        val data: PolyOuter = PolyOuterImpl(
+            a = 1,
+            extras = mapOf("foo" to ValueWithTypeProperty(type = "X", payload = "Y"))
+        )
+        val serialized = default.encodeToString(PolyOuter.serializer(), data, mode)
+        val restored = default.decodeFromString(PolyOuter.serializer(), serialized, mode)
+        assertEquals(data, restored)
+    }
+
+    @Test
+    fun testRoundTripContextualValue() = parametrizedTest { mode ->
+        val json = Json(default) {
+            serializersModule = SerializersModule {
+                contextual(ExternalValue::class, ExternalValueSerializer)
+            }
+        }
+        val data = ContextualBucket(a = 1, extras = mapOf("foo" to ExternalValue("hello")))
+        val serialized = json.encodeToString(data, mode)
+        val restored = json.decodeFromString<ContextualBucket>(serialized, mode)
+        assertEquals(data, restored)
+    }
+
+    @Test
+    fun testCaptureWinsOverIgnoreUnknownKeysForIntBucket() = parametrizedTest { mode ->
+        // Capture wins over ignoreUnknownKeys = true for typed buckets,
+        // parity with the JsonElement case.
+        val json = Json(default) { ignoreUnknownKeys = true }
+        val input = """{"a":1,"x":42}"""
+        val result = json.decodeFromString<IntBucket>(input, mode)
+        assertEquals(1, result.a)
+        assertEquals(42, result.extras["x"])
+    }
+
+    @Test
+    fun testRejectInlineStringKey() {
+        // Inline value class wrapping String has STRING kind but a different
+        // runtime type — the strict identity check rejects it to avoid
+        // runtime cast failures in the encode wrapper.
+        assertFailsWith<SerializationException> {
+            default.decodeFromString<InlineKeyBucket>("""{"a":1}""")
+        }
     }
 }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
@@ -4,18 +4,9 @@
 
 package kotlinx.serialization.json
 
-import kotlinx.serialization.Contextual
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.test.checkSerializationException
 import kotlin.jvm.JvmInline
 import kotlin.test.Test
@@ -112,9 +103,11 @@ class JsonExtraKeysTest : JsonTestBase() {
         assertEquals(JsonObject(mapOf("x" to JsonPrimitive(true))), result.extras["d"])
         assertEquals(JsonNull, result.extras["e"])
 
-        val roundTrip = json.encodeToString(result, mode)
-        val result2 = json.decodeFromString<Basic>(roundTrip, mode)
-        assertEquals(result, result2)
+        // Write-back: captured entries are emitted after regular properties,
+        // reproducing the original document exactly.
+        val encoded = json.encodeToString(result, mode)
+        assertEquals(input, encoded)
+        assertEquals(result, json.decodeFromString<Basic>(encoded, mode))
     }
 
     @Test
@@ -190,6 +183,18 @@ class JsonExtraKeysTest : JsonTestBase() {
         val result = json.decodeFromString<Basic>(input, mode)
         assertEquals(1, result.a)
         assertEquals(JsonPrimitive(42), result.extras["extras"])
+        // The bucket's own property name is never written by encode, so a
+        // captured key equal to it is not a collision and round-trips exactly.
+        val encoded = json.encodeToString(result, mode)
+        assertEquals(input, encoded)
+        assertEquals(result, json.decodeFromString<Basic>(encoded, mode))
+    }
+
+    @Test
+    fun testEncodeWritesExtrasLast() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val data = Basic(a = 1, extras = mapOf("z" to JsonPrimitive(2), "y" to JsonPrimitive(3)))
+        assertEquals("""{"a":1,"z":2,"y":3}""", json.encodeToString(data, mode))
     }
 
     @Test
@@ -210,7 +215,18 @@ class JsonExtraKeysTest : JsonTestBase() {
         checkSerializationException({
             json.encodeToString(Base.serializer(), data, mode)
         }) { msg ->
-            assertContains(msg, "conflicts with the active class discriminator")
+            assertContains(msg, "conflicts with the class discriminator")
+        }
+    }
+
+    @Test
+    fun testEncodeCollisionAliasName() = parametrizedTest { mode ->
+        val json = Json(default) { encodeDefaults = true }
+        val data = WithAlias(a = 1, b = "value", extras = mapOf("b_alias" to JsonPrimitive("conflict")))
+        checkSerializationException({
+            json.encodeToString(data, mode)
+        }) { msg ->
+            assertContains(msg, "conflicts with a declared property name")
         }
     }
 
@@ -256,98 +272,36 @@ class JsonExtraKeysTest : JsonTestBase() {
     }
 
     @Test
-    fun testEncodeCollisionAliasName() = parametrizedTest { mode ->
-        val json = Json(default) { encodeDefaults = true }
-        val data = WithAlias(a = 1, b = "value", extras = mapOf("b_alias" to JsonPrimitive("conflict")))
-        checkSerializationException({
-            json.encodeToString(data, mode)
-        }) { msg ->
-            assertContains(msg, "conflicts with a declared property name")
-        }
-    }
-
-    @Test
     fun testOuterBucketAfterNestedPolymorphic() = parametrizedTest { mode ->
         val json = Json(default) { encodeDefaults = true }
-        val data = OuterWithNestedPoly(base = Derived(a = 1), extras = mapOf("type" to JsonPrimitive("foo")))
         // "type" is the discriminator of Derived, but OuterWithNestedPoly is not polymorphic,
-        // so its extras may legally contain "type".
-        val serialized = json.encodeToString(data, mode)
-        val deserialized = json.decodeFromString<OuterWithNestedPoly>(serialized, mode)
-        assertEquals(JsonPrimitive("foo"), deserialized.extras["type"])
+        // so a top-level "type" key is a regular unknown key and lands in the outer bucket.
+        // On encode, the nested Derived's discriminator must not be misattributed
+        // to the outer object's bucket validation.
+        val input = """{"base":{"type":"derived","a":1},"type":"foo"}"""
+        val result = json.decodeFromString<OuterWithNestedPoly>(input, mode)
+        assertEquals(Derived(a = 1), result.base)
+        assertEquals(JsonPrimitive("foo"), result.extras["type"])
+        assertEquals(input, json.encodeToString(result, mode))
     }
 
-    // ---- bucket value types other than JsonElement ----
+    // ---- JsonObject-typed bucket and rejected declarations ----
 
+    @Serializable
+    data class ObjectBucket(
+        val a: Int,
+        @JsonExtraKeys val extras: JsonObject = JsonObject(emptyMap())
+    )
+
+    // Typed values are not supported: the bucket must hold raw JsonElements.
     @Serializable
     data class IntBucket(
         val a: Int,
         @JsonExtraKeys val extras: Map<String, Int> = emptyMap()
     )
 
-    @Serializable
-    data class Inner(val name: String, val count: Int)
-
-    @Serializable
-    data class ClassBucket(
-        val a: Int,
-        @JsonExtraKeys val extras: Map<String, Inner> = emptyMap()
-    )
-
-    @Serializable
-    sealed class Shape
-
-    @Serializable
-    @SerialName("circle")
-    data class Circle(val radius: Double) : Shape()
-
-    @Serializable
-    @SerialName("square")
-    data class Square(val side: Double) : Shape()
-
-    @Serializable
-    data class ShapeBucket(
-        val a: Int,
-        @JsonExtraKeys val extras: Map<String, Shape> = emptyMap()
-    )
-
-    // Polymorphic outer with a bucket whose value type's property name collides
-    // with the outer's class discriminator ("type"). Inner's "type" field must
-    // be written inside the inner object — not be flagged as a bucket-key
-    // collision against the outer discriminator.
-    @Serializable
-    sealed class PolyOuter
-
-    @Serializable
-    data class ValueWithTypeProperty(val type: String, val payload: String)
-
-    @Serializable
-    @SerialName("polyOuter")
-    data class PolyOuterImpl(
-        val a: Int,
-        @JsonExtraKeys val extras: Map<String, ValueWithTypeProperty> = emptyMap()
-    ) : PolyOuter()
-
-    // Contextual value type — resolution at encode/decode time via SerializersModule.
-    data class ExternalValue(val text: String)
-
-    private object ExternalValueSerializer : KSerializer<ExternalValue> {
-        override val descriptor: SerialDescriptor =
-            PrimitiveSerialDescriptor("ExternalValue", PrimitiveKind.STRING)
-        override fun serialize(encoder: Encoder, value: ExternalValue) =
-            encoder.encodeString(value.text)
-        override fun deserialize(decoder: Decoder): ExternalValue =
-            ExternalValue(decoder.decodeString())
-    }
-
-    @Serializable
-    data class ContextualBucket(
-        val a: Int,
-        @JsonExtraKeys val extras: Map<String, @Contextual ExternalValue> = emptyMap()
-    )
-
-    // Inline String key — must be rejected by the strict identity check
-    // because the encode path casts each entry key to String.
+    // Inline String key — rejected by the strict identity check: bucket keys
+    // must be plain String.
     @JvmInline
     @Serializable
     value class WrappedKey(val raw: String)
@@ -355,108 +309,40 @@ class JsonExtraKeysTest : JsonTestBase() {
     @Serializable
     data class InlineKeyBucket(
         val a: Int,
-        @JsonExtraKeys val extras: Map<WrappedKey, Int> = emptyMap()
+        @JsonExtraKeys val extras: Map<WrappedKey, JsonElement> = emptyMap()
     )
 
     @Test
-    fun testRoundTripMapStringInt() = parametrizedTest { mode ->
-        val input = """{"a":1,"x":10,"y":20}"""
-        val result = default.decodeFromString<IntBucket>(input, mode)
+    fun testJsonObjectTypedBucket() = parametrizedTest { mode ->
+        val input = """{"a":1,"x":10,"y":"s"}"""
+        val result = default.decodeFromString<ObjectBucket>(input, mode)
         assertEquals(1, result.a)
-        assertEquals(10, result.extras["x"])
-        assertEquals(20, result.extras["y"])
-        val roundTrip = default.encodeToString(result, mode)
-        assertEquals(result, default.decodeFromString<IntBucket>(roundTrip, mode))
+        assertEquals(JsonPrimitive(10), result.extras["x"])
+        assertEquals(JsonPrimitive("s"), result.extras["y"])
+        assertEquals(input, default.encodeToString(result, mode))
     }
 
     @Test
-    fun testRoundTripMapStringDataClass() = parametrizedTest { mode ->
-        val input = """{"a":1,"foo":{"name":"hello","count":3},"bar":{"name":"world","count":7}}"""
-        val result = default.decodeFromString<ClassBucket>(input, mode)
-        assertEquals(1, result.a)
-        assertEquals(Inner("hello", 3), result.extras["foo"])
-        assertEquals(Inner("world", 7), result.extras["bar"])
-        val roundTrip = default.encodeToString(result, mode)
-        assertEquals(result, default.decodeFromString<ClassBucket>(roundTrip, mode))
-    }
-
-    @Test
-    fun testRoundTripEmptyIntBucket() = parametrizedTest { mode ->
+    fun testRoundTripEmptyObjectBucket() = parametrizedTest { mode ->
         val input = """{"a":1}"""
-        val result = default.decodeFromString<IntBucket>(input, mode)
+        val result = default.decodeFromString<ObjectBucket>(input, mode)
         assertEquals(1, result.a)
-        assertEquals(emptyMap(), result.extras)
-        // Empty bucket: encode should not emit anything for `extras`.
+        assertEquals(JsonObject(emptyMap()), result.extras)
         val roundTrip = default.encodeToString(result, mode)
-        assertEquals(result, default.decodeFromString<IntBucket>(roundTrip, mode))
+        assertEquals(result, default.decodeFromString<ObjectBucket>(roundTrip, mode))
     }
 
     @Test
-    fun testTypeMismatchInBucketValueReportsError() = parametrizedTest { mode ->
-        val input = """{"a":1,"x":"not-an-int"}"""
+    fun testRejectTypedValues() {
         assertFailsWith<SerializationException> {
-            default.decodeFromString<IntBucket>(input, mode)
+            default.decodeFromString<IntBucket>("""{"a":1}""")
         }
-    }
-
-    @Test
-    fun testRoundTripMapStringPolymorphic() = parametrizedTest { mode ->
-        val data = ShapeBucket(
-            a = 1,
-            extras = mapOf(
-                "shape1" to Circle(radius = 2.5),
-                "shape2" to Square(side = 4.0)
-            )
-        )
-        val serialized = default.encodeToString(data, mode)
-        val restored = default.decodeFromString<ShapeBucket>(serialized, mode)
-        assertEquals(data, restored)
-    }
-
-    @Test
-    fun testInnerValuePropertyNamesDoNotClashWithOuterDiscriminator() = parametrizedTest { mode ->
-        // PolyOuterImpl's discriminator at outer level is "type". Inner value
-        // ValueWithTypeProperty also has a property named "type" — that lives
-        // inside the inner object's braces and must NOT be misinterpreted as
-        // a bucket-key collision.
-        val data: PolyOuter = PolyOuterImpl(
-            a = 1,
-            extras = mapOf("foo" to ValueWithTypeProperty(type = "X", payload = "Y"))
-        )
-        val serialized = default.encodeToString(PolyOuter.serializer(), data, mode)
-        val restored = default.decodeFromString(PolyOuter.serializer(), serialized, mode)
-        assertEquals(data, restored)
-    }
-
-    @Test
-    fun testRoundTripContextualValue() = parametrizedTest { mode ->
-        val json = Json(default) {
-            serializersModule = SerializersModule {
-                contextual(ExternalValue::class, ExternalValueSerializer)
-            }
-        }
-        val data = ContextualBucket(a = 1, extras = mapOf("foo" to ExternalValue("hello")))
-        val serialized = json.encodeToString(data, mode)
-        val restored = json.decodeFromString<ContextualBucket>(serialized, mode)
-        assertEquals(data, restored)
-    }
-
-    @Test
-    fun testCaptureWinsOverIgnoreUnknownKeysForIntBucket() = parametrizedTest { mode ->
-        // Capture wins over ignoreUnknownKeys = true for typed buckets,
-        // parity with the JsonElement case.
-        val json = Json(default) { ignoreUnknownKeys = true }
-        val input = """{"a":1,"x":42}"""
-        val result = json.decodeFromString<IntBucket>(input, mode)
-        assertEquals(1, result.a)
-        assertEquals(42, result.extras["x"])
     }
 
     @Test
     fun testRejectInlineStringKey() {
         // Inline value class wrapping String has STRING kind but a different
-        // runtime type — the strict identity check rejects it to avoid
-        // runtime cast failures in the encode wrapper.
+        // runtime type — the strict identity check rejects it.
         assertFailsWith<SerializationException> {
             default.decodeFromString<InlineKeyBucket>("""{"a":1}""")
         }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonExtraKeysTest.kt
@@ -326,8 +326,8 @@ class JsonExtraKeysTest : JsonTestBase() {
         @JsonExtraKeys val extras: Map<String, Int> = emptyMap()
     )
 
-    // Inline String key — rejected by the strict identity check: bucket keys
-    // must be plain String.
+    // Inline String key: rejected by the strict identity check because bucket
+    // keys must be plain String.
     @JvmInline
     @Serializable
     value class WrappedKey(val raw: String)
@@ -389,7 +389,7 @@ class JsonExtraKeysTest : JsonTestBase() {
     @Test
     fun testFlagOffValidationSkipped() = parametrizedTest { mode ->
         // With the flag off, even invalid bucket declarations are usable as
-        // plain properties — validation never runs.
+        // plain properties, because validation never runs.
         val json = Json(extraJson) { useExtraKeys = false }
         val result = json.decodeFromString<IntBucket>("""{"a":1,"extras":{"x":10}}""", mode)
         assertEquals(1, result.a)
@@ -399,7 +399,7 @@ class JsonExtraKeysTest : JsonTestBase() {
     @Test
     fun testRejectInlineStringKey() {
         // Inline value class wrapping String has STRING kind but a different
-        // runtime type — the strict identity check rejects it.
+        // runtime type, so the strict identity check rejects it.
         assertFailsWith<SerializationException> {
             extraJson.decodeFromString<InlineKeyBucket>("""{"a":1}""")
         }

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -294,6 +294,13 @@ public final synthetic class kotlinx/serialization/json/JsonIgnoreUnknownKeys$Im
 	public fun <init> ()V
 }
 
+public abstract interface annotation class kotlinx/serialization/json/JsonExtraKeys : java/lang/annotation/Annotation {
+}
+
+public final synthetic class kotlinx/serialization/json/JsonExtraKeys$Impl : kotlinx/serialization/json/JsonExtraKeys {
+	public fun <init> ()V
+}
+
 public final class kotlinx/serialization/json/JsonKt {
 	public static final fun Json (Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;)Lkotlinx/serialization/json/Json;
 	public static synthetic fun Json$default (Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/serialization/json/Json;

--- a/formats/json/api/kotlinx-serialization-json.api
+++ b/formats/json/api/kotlinx-serialization-json.api
@@ -112,6 +112,7 @@ public final class kotlinx/serialization/json/JsonBuilder {
 	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public final fun getUseAlternativeNames ()Z
 	public final fun getUseArrayPolymorphism ()Z
+	public final fun getUseExtraKeys ()Z
 	public final fun isLenient ()Z
 	public final fun setAllowComments (Z)V
 	public final fun setAllowSpecialFloatingPointValues (Z)V
@@ -132,6 +133,7 @@ public final class kotlinx/serialization/json/JsonBuilder {
 	public final fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
 	public final fun setUseAlternativeNames (Z)V
 	public final fun setUseArrayPolymorphism (Z)V
+	public final fun setUseExtraKeys (Z)V
 }
 
 public abstract interface annotation class kotlinx/serialization/json/JsonClassDiscriminator : java/lang/annotation/Annotation {
@@ -162,6 +164,7 @@ public final class kotlinx/serialization/json/JsonConfiguration {
 	public final fun getPrettyPrintIndent ()Ljava/lang/String;
 	public final fun getUseAlternativeNames ()Z
 	public final fun getUseArrayPolymorphism ()Z
+	public final fun getUseExtraKeys ()Z
 	public final fun isLenient ()Z
 	public final fun setClassDiscriminatorMode (Lkotlinx/serialization/json/ClassDiscriminatorMode;)V
 	public final fun setExceptionsWithDebugInfo (Z)V
@@ -287,17 +290,17 @@ public abstract class kotlinx/serialization/json/JsonException : kotlinx/seriali
 	public abstract fun getShortMessage ()Ljava/lang/String;
 }
 
-public abstract interface annotation class kotlinx/serialization/json/JsonIgnoreUnknownKeys : java/lang/annotation/Annotation {
-}
-
-public final synthetic class kotlinx/serialization/json/JsonIgnoreUnknownKeys$Impl : kotlinx/serialization/json/JsonIgnoreUnknownKeys {
-	public fun <init> ()V
-}
-
 public abstract interface annotation class kotlinx/serialization/json/JsonExtraKeys : java/lang/annotation/Annotation {
 }
 
 public final synthetic class kotlinx/serialization/json/JsonExtraKeys$Impl : kotlinx/serialization/json/JsonExtraKeys {
+	public fun <init> ()V
+}
+
+public abstract interface annotation class kotlinx/serialization/json/JsonIgnoreUnknownKeys : java/lang/annotation/Annotation {
+}
+
+public final synthetic class kotlinx/serialization/json/JsonIgnoreUnknownKeys$Impl : kotlinx/serialization/json/JsonIgnoreUnknownKeys {
 	public fun <init> ()V
 }
 

--- a/formats/json/api/kotlinx-serialization-json.klib.api
+++ b/formats/json/api/kotlinx-serialization-json.klib.api
@@ -24,12 +24,12 @@ open annotation class kotlinx.serialization.json/JsonClassDiscriminator : kotlin
         final fun <get-discriminator>(): kotlin/String // kotlinx.serialization.json/JsonClassDiscriminator.discriminator.<get-discriminator>|<get-discriminator>(){}[0]
 }
 
-open annotation class kotlinx.serialization.json/JsonIgnoreUnknownKeys : kotlin/Annotation { // kotlinx.serialization.json/JsonIgnoreUnknownKeys|null[0]
-    constructor <init>() // kotlinx.serialization.json/JsonIgnoreUnknownKeys.<init>|<init>(){}[0]
-}
-
 open annotation class kotlinx.serialization.json/JsonExtraKeys : kotlin/Annotation { // kotlinx.serialization.json/JsonExtraKeys|null[0]
     constructor <init>() // kotlinx.serialization.json/JsonExtraKeys.<init>|<init>(){}[0]
+}
+
+open annotation class kotlinx.serialization.json/JsonIgnoreUnknownKeys : kotlin/Annotation { // kotlinx.serialization.json/JsonIgnoreUnknownKeys|null[0]
+    constructor <init>() // kotlinx.serialization.json/JsonIgnoreUnknownKeys.<init>|<init>(){}[0]
 }
 
 open annotation class kotlinx.serialization.json/JsonNames : kotlin/Annotation { // kotlinx.serialization.json/JsonNames|null[0]
@@ -221,6 +221,9 @@ final class kotlinx.serialization.json/JsonBuilder { // kotlinx.serialization.js
     final var useArrayPolymorphism // kotlinx.serialization.json/JsonBuilder.useArrayPolymorphism|{}useArrayPolymorphism[0]
         final fun <get-useArrayPolymorphism>(): kotlin/Boolean // kotlinx.serialization.json/JsonBuilder.useArrayPolymorphism.<get-useArrayPolymorphism>|<get-useArrayPolymorphism>(){}[0]
         final fun <set-useArrayPolymorphism>(kotlin/Boolean) // kotlinx.serialization.json/JsonBuilder.useArrayPolymorphism.<set-useArrayPolymorphism>|<set-useArrayPolymorphism>(kotlin.Boolean){}[0]
+    final var useExtraKeys // kotlinx.serialization.json/JsonBuilder.useExtraKeys|{}useExtraKeys[0]
+        final fun <get-useExtraKeys>(): kotlin/Boolean // kotlinx.serialization.json/JsonBuilder.useExtraKeys.<get-useExtraKeys>|<get-useExtraKeys>(){}[0]
+        final fun <set-useExtraKeys>(kotlin/Boolean) // kotlinx.serialization.json/JsonBuilder.useExtraKeys.<set-useExtraKeys>|<set-useExtraKeys>(kotlin.Boolean){}[0]
 }
 
 final class kotlinx.serialization.json/JsonConfiguration { // kotlinx.serialization.json/JsonConfiguration|null[0]
@@ -256,6 +259,8 @@ final class kotlinx.serialization.json/JsonConfiguration { // kotlinx.serializat
         final fun <get-useAlternativeNames>(): kotlin/Boolean // kotlinx.serialization.json/JsonConfiguration.useAlternativeNames.<get-useAlternativeNames>|<get-useAlternativeNames>(){}[0]
     final val useArrayPolymorphism // kotlinx.serialization.json/JsonConfiguration.useArrayPolymorphism|{}useArrayPolymorphism[0]
         final fun <get-useArrayPolymorphism>(): kotlin/Boolean // kotlinx.serialization.json/JsonConfiguration.useArrayPolymorphism.<get-useArrayPolymorphism>|<get-useArrayPolymorphism>(){}[0]
+    final val useExtraKeys // kotlinx.serialization.json/JsonConfiguration.useExtraKeys|{}useExtraKeys[0]
+        final fun <get-useExtraKeys>(): kotlin/Boolean // kotlinx.serialization.json/JsonConfiguration.useExtraKeys.<get-useExtraKeys>|<get-useExtraKeys>(){}[0]
 
     final var classDiscriminatorMode // kotlinx.serialization.json/JsonConfiguration.classDiscriminatorMode|{}classDiscriminatorMode[0]
         final fun <get-classDiscriminatorMode>(): kotlinx.serialization.json/ClassDiscriminatorMode // kotlinx.serialization.json/JsonConfiguration.classDiscriminatorMode.<get-classDiscriminatorMode>|<get-classDiscriminatorMode>(){}[0]

--- a/formats/json/api/kotlinx-serialization-json.klib.api
+++ b/formats/json/api/kotlinx-serialization-json.klib.api
@@ -28,6 +28,10 @@ open annotation class kotlinx.serialization.json/JsonIgnoreUnknownKeys : kotlin/
     constructor <init>() // kotlinx.serialization.json/JsonIgnoreUnknownKeys.<init>|<init>(){}[0]
 }
 
+open annotation class kotlinx.serialization.json/JsonExtraKeys : kotlin/Annotation { // kotlinx.serialization.json/JsonExtraKeys|null[0]
+    constructor <init>() // kotlinx.serialization.json/JsonExtraKeys.<init>|<init>(){}[0]
+}
+
 open annotation class kotlinx.serialization.json/JsonNames : kotlin/Annotation { // kotlinx.serialization.json/JsonNames|null[0]
     constructor <init>(kotlin/Array<out kotlin/String>...) // kotlinx.serialization.json/JsonNames.<init>|<init>(kotlin.Array<out|kotlin.String>...){}[0]
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -554,6 +554,22 @@ public class JsonBuilder internal constructor(json: Json) {
     public var useAlternativeNames: Boolean = json.configuration.useAlternativeNames
 
     /**
+     * Specifies whether Json instance makes use of the [JsonExtraKeys] annotation.
+     *
+     * When disabled (the default), properties annotated with [JsonExtraKeys] are
+     * treated as regular properties: unknown keys are not captured (they are handled
+     * according to [ignoreUnknownKeys]), and the annotated property is read from and
+     * written under its own name.
+     *
+     * The flag is disabled by default because resolving the annotation adds a small
+     * per-object cost to decoding and encoding of all classes, including ones that
+     * do not use [JsonExtraKeys].
+     * `false` by default.
+     */
+    @ExperimentalSerializationApi
+    public var useExtraKeys: Boolean = json.configuration.useExtraKeys
+
+    /**
      * Specifies [JsonNamingStrategy] that should be used for all properties in classes for serialization and deserialization.
      *
      * `null` by default.
@@ -720,7 +736,7 @@ public class JsonBuilder internal constructor(json: Json) {
             coerceInputValues, useArrayPolymorphism,
             classDiscriminator, allowSpecialFloatingPointValues, useAlternativeNames,
             namingStrategy, decodeEnumsCaseInsensitive, allowTrailingComma, allowComments, classDiscriminatorMode,
-            exceptionsWithDebugInfo
+            exceptionsWithDebugInfo, useExtraKeys
         )
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
@@ -110,7 +110,12 @@ public annotation class JsonIgnoreUnknownKeys
  * Marks a property as the bucket that captures every JSON object key that
  * does not match any declared property of the enclosing class.
  *
- * The annotated property must be of type `Map<String, JsonElement>`.
+ * The annotated property must be of type `Map<String, V>`, where `V` is any
+ * `@Serializable` type or a contextually serializable type (resolved via the
+ * active [SerializersModule][kotlinx.serialization.modules.SerializersModule]).
+ * `V` can be a [JsonElement] (lossless capture), a primitive, an enum, a
+ * `@Serializable` class, or a polymorphic / sealed hierarchy.
+ *
  * Unknown keys are still resolved through [JsonNames] aliases and the active
  * [JsonNamingStrategy] first; only keys that remain unmatched after that
  * resolution are placed into the bucket. The class discriminator used during
@@ -126,23 +131,38 @@ public annotation class JsonIgnoreUnknownKeys
  * [JsonIgnoreUnknownKeys]: when this annotation is present on a property,
  * unknown keys are always captured rather than silently dropped or rejected.
  *
- * Example:
+ * Example with a typed value class:
  * ```
+ * @Serializable
+ * data class Response(val status: Int, val body: String)
+ *
  * @Serializable
  * data class Responses(
  *     val default: Response,
- *     @JsonExtraKeys val statuses: Map<String, JsonElement> = emptyMap()
+ *     @JsonExtraKeys val statuses: Map<String, Response> = emptyMap()
  * )
  *
- * val json = Json.decodeFromString<Responses>(
+ * val parsed = Json.decodeFromString<Responses>(
  *     """{"default": {...}, "200": {...}, "404": {...}}"""
  * )
- * // json.statuses == { "200" -> {...}, "404" -> {...} }
+ * // parsed.statuses == { "200" -> Response(...), "404" -> Response(...) }
  * ```
+ *
+ * Use `Map<String, JsonElement>` if the bucket's value shapes are heterogeneous
+ * or unknown ahead of time.
  *
  * Constraints validated lazily on first use, raising [SerializationException]:
  *  - at most one property per class may be annotated with [JsonExtraKeys];
- *  - the annotated property must be of type `Map<String, JsonElement>`.
+ *  - the annotated property must be of kind `Map<String, V>` and the key
+ *    serializer must be the standard [String] serializer (inline value classes
+ *    wrapping `String` are not accepted as the key type);
+ *  - the property must not also carry a [JsonNames] annotation.
+ *
+ * The bucket type must be the standard `kotlinx.serialization` `Map` serializer
+ * (the one synthesised by the compiler plugin or returned by `MapSerializer`).
+ * A hand-rolled `KSerializer<Map<String, V>>` that does not follow the
+ * alternating key/value index protocol is not supported and may fail at encode
+ * time.
  *
  * It is recommended to give the annotated property a default value of
  * `emptyMap()` so that it is optional in the input.

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
@@ -110,62 +110,50 @@ public annotation class JsonIgnoreUnknownKeys
  * Marks a property as the bucket that captures every JSON object key that
  * does not match any declared property of the enclosing class.
  *
- * The annotated property must be of type `Map<String, V>`, where `V` is any
- * `@Serializable` type or a contextually serializable type (resolved via the
- * active [SerializersModule][kotlinx.serialization.modules.SerializersModule]).
- * `V` can be a [JsonElement] (lossless capture), a primitive, an enum, a
- * `@Serializable` class, or a polymorphic / sealed hierarchy.
+ * The annotated property must be of type [JsonObject] or `Map<String, JsonElement>`.
+ * Captured values are stored losslessly as [JsonElement]s; apply
+ * [Json.decodeFromJsonElement] to individual entries if typed access is needed.
  *
  * Unknown keys are still resolved through [JsonNames] aliases and the active
  * [JsonNamingStrategy] first; only keys that remain unmatched after that
  * resolution are placed into the bucket. The class discriminator used during
  * polymorphic decoding is also excluded from the bucket.
  *
- * On encoding, entries of the map are emitted as direct sibling key/value
- * pairs of the enclosing JSON object — i.e. the map's own JSON property name
- * is suppressed. A [SerializationException] is thrown if any of the bucket's
- * keys clash with a declared property name (after naming strategy / [JsonNames]
- * resolution) or with the active class discriminator.
+ * On encoding, the entries of the bucket are written back as members of the
+ * enclosing JSON object, after all regular properties; the bucket's own
+ * property name is not written. This makes `encode(decode(input))` preserve
+ * the captured keys. If the bucket was manipulated to contain a key that a
+ * declared property (or the class discriminator) would be written under —
+ * i.e. a key that decoding would *not* capture into the bucket —
+ * a [SerializationException] is thrown to prevent duplicate keys in the output.
  *
  * Capturing takes precedence over both [JsonBuilder.ignoreUnknownKeys] and
  * [JsonIgnoreUnknownKeys]: when this annotation is present on a property,
  * unknown keys are always captured rather than silently dropped or rejected.
  *
- * Example with a typed value class:
+ * Example:
  * ```
  * @Serializable
- * data class Response(val status: Int, val body: String)
- *
- * @Serializable
- * data class Responses(
- *     val default: Response,
- *     @JsonExtraKeys val statuses: Map<String, Response> = emptyMap()
+ * data class Project(
+ *     val name: String,
+ *     @JsonExtraKeys val extras: JsonObject = JsonObject(emptyMap())
  * )
  *
- * val parsed = Json.decodeFromString<Responses>(
- *     """{"default": {...}, "200": {...}, "404": {...}}"""
+ * val parsed = Json.decodeFromString<Project>(
+ *     """{"name":"kotlinx.serialization","stars":9000,"forks":500}"""
  * )
- * // parsed.statuses == { "200" -> Response(...), "404" -> Response(...) }
+ * // parsed.extras == {"stars": 9000, "forks": 500}
+ * // Json.encodeToString(parsed) reproduces the original JSON
  * ```
- *
- * Use `Map<String, JsonElement>` if the bucket's value shapes are heterogeneous
- * or unknown ahead of time.
  *
  * Constraints validated lazily on first use, raising [SerializationException]:
  *  - at most one property per class may be annotated with [JsonExtraKeys];
- *  - the annotated property must be of kind `Map<String, V>` and the key
- *    serializer must be the standard [String] serializer (inline value classes
- *    wrapping `String` are not accepted as the key type);
+ *  - the annotated property must be of type [JsonObject] or `Map<String, JsonElement>`
+ *    (with exactly the standard [String] and [JsonElement] serializers);
  *  - the property must not also carry a [JsonNames] annotation.
  *
- * The bucket type must be the standard `kotlinx.serialization` `Map` serializer
- * (the one synthesised by the compiler plugin or returned by `MapSerializer`).
- * A hand-rolled `KSerializer<Map<String, V>>` that does not follow the
- * alternating key/value index protocol is not supported and may fail at encode
- * time.
- *
  * It is recommended to give the annotated property a default value of
- * `emptyMap()` so that it is optional in the input.
+ * `JsonObject(emptyMap())` (or `emptyMap()`) so that it is optional in the input.
  *
  * @see JsonIgnoreUnknownKeys
  * @see JsonBuilder.ignoreUnknownKeys

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
@@ -131,6 +131,10 @@ public annotation class JsonIgnoreUnknownKeys
  * [JsonIgnoreUnknownKeys]: when this annotation is present on a property,
  * unknown keys are always captured rather than silently dropped or rejected.
  *
+ * Processing of this annotation must be enabled with the
+ * [JsonBuilder.useExtraKeys] flag (`false` by default); without it, the
+ * annotated property behaves as a regular property.
+ *
  * Example:
  * ```
  * @Serializable
@@ -139,11 +143,12 @@ public annotation class JsonIgnoreUnknownKeys
  *     @JsonExtraKeys val extras: JsonObject = JsonObject(emptyMap())
  * )
  *
- * val parsed = Json.decodeFromString<Project>(
+ * val json = Json { useExtraKeys = true }
+ * val parsed = json.decodeFromString<Project>(
  *     """{"name":"kotlinx.serialization","stars":9000,"forks":500}"""
  * )
  * // parsed.extras == {"stars": 9000, "forks": 500}
- * // Json.encodeToString(parsed) reproduces the original JSON
+ * // json.encodeToString(parsed) reproduces the original JSON
  * ```
  *
  * Constraints validated lazily on first use, raising [SerializationException]:

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
@@ -123,9 +123,10 @@ public annotation class JsonIgnoreUnknownKeys
  * enclosing JSON object, after all regular properties; the bucket's own
  * property name is not written. This makes `encode(decode(input))` preserve
  * the captured keys. If the bucket was manipulated to contain a key that a
- * declared property (or the class discriminator) would be written under —
- * i.e. a key that decoding would *not* capture into the bucket —
+ * declared property (or the class discriminator) would be written under,
  * a [SerializationException] is thrown to prevent duplicate keys in the output.
+ * In other words, the bucket may only contain keys that decoding would have
+ * captured into it.
  *
  * Capturing takes precedence over both [JsonBuilder.ignoreUnknownKeys] and
  * [JsonIgnoreUnknownKeys]: when this annotation is present on a property,

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt
@@ -105,3 +105,52 @@ public annotation class JsonClassDiscriminator(val discriminator: String)
 @SerialInfo
 @Target(AnnotationTarget.CLASS)
 public annotation class JsonIgnoreUnknownKeys
+
+/**
+ * Marks a property as the bucket that captures every JSON object key that
+ * does not match any declared property of the enclosing class.
+ *
+ * The annotated property must be of type `Map<String, JsonElement>`.
+ * Unknown keys are still resolved through [JsonNames] aliases and the active
+ * [JsonNamingStrategy] first; only keys that remain unmatched after that
+ * resolution are placed into the bucket. The class discriminator used during
+ * polymorphic decoding is also excluded from the bucket.
+ *
+ * On encoding, entries of the map are emitted as direct sibling key/value
+ * pairs of the enclosing JSON object — i.e. the map's own JSON property name
+ * is suppressed. A [SerializationException] is thrown if any of the bucket's
+ * keys clash with a declared property name (after naming strategy / [JsonNames]
+ * resolution) or with the active class discriminator.
+ *
+ * Capturing takes precedence over both [JsonBuilder.ignoreUnknownKeys] and
+ * [JsonIgnoreUnknownKeys]: when this annotation is present on a property,
+ * unknown keys are always captured rather than silently dropped or rejected.
+ *
+ * Example:
+ * ```
+ * @Serializable
+ * data class Responses(
+ *     val default: Response,
+ *     @JsonExtraKeys val statuses: Map<String, JsonElement> = emptyMap()
+ * )
+ *
+ * val json = Json.decodeFromString<Responses>(
+ *     """{"default": {...}, "200": {...}, "404": {...}}"""
+ * )
+ * // json.statuses == { "200" -> {...}, "404" -> {...} }
+ * ```
+ *
+ * Constraints validated lazily on first use, raising [SerializationException]:
+ *  - at most one property per class may be annotated with [JsonExtraKeys];
+ *  - the annotated property must be of type `Map<String, JsonElement>`.
+ *
+ * It is recommended to give the annotated property a default value of
+ * `emptyMap()` so that it is optional in the input.
+ *
+ * @see JsonIgnoreUnknownKeys
+ * @see JsonBuilder.ignoreUnknownKeys
+ */
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+@ExperimentalSerializationApi
+public annotation class JsonExtraKeys

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -43,6 +43,8 @@ public class JsonConfiguration @OptIn(ExperimentalSerializationApi::class) inter
 
     @ExperimentalSerializationApi
     public var exceptionsWithDebugInfo: Boolean = true,
+    @ExperimentalSerializationApi
+    public val useExtraKeys: Boolean = false,
 ) {
 
     /** @suppress Dokka **/
@@ -53,7 +55,8 @@ public class JsonConfiguration @OptIn(ExperimentalSerializationApi::class) inter
                 "prettyPrintIndent='$prettyPrintIndent', coerceInputValues=$coerceInputValues, useArrayPolymorphism=$useArrayPolymorphism, " +
                 "classDiscriminator='$classDiscriminator', allowSpecialFloatingPointValues=$allowSpecialFloatingPointValues, " +
                 "useAlternativeNames=$useAlternativeNames, namingStrategy=$namingStrategy, decodeEnumsCaseInsensitive=$decodeEnumsCaseInsensitive, " +
-                "allowTrailingComma=$allowTrailingComma, allowComments=$allowComments, classDiscriminatorMode=$classDiscriminatorMode, exceptionsWithDebugInfo=$exceptionsWithDebugInfo)"
+                "allowTrailingComma=$allowTrailingComma, allowComments=$allowComments, classDiscriminatorMode=$classDiscriminatorMode, " +
+                "exceptionsWithDebugInfo=$exceptionsWithDebugInfo, useExtraKeys=$useExtraKeys)"
     }
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -164,3 +164,67 @@ internal inline fun Json.tryCoerceValue(
 
 internal fun SerialDescriptor.ignoreUnknownKeys(json: Json): Boolean =
     json.configuration.ignoreUnknownKeys || annotations.any { it is JsonIgnoreUnknownKeys }
+
+internal val JsonExtraKeysIndexKey = DescriptorSchemaCache.Key<Int>()
+
+/**
+ * Returns the element index of the property annotated with [JsonExtraKeys],
+ * or -1 if no such property exists in this descriptor.
+ *
+ * Validates on first computation and throws [SerializationException] if:
+ *  - more than one property is annotated with [JsonExtraKeys];
+ *  - the annotated property is not of type `Map<String, JsonElement>`.
+ *
+ * The result is memoised in the per-[Json] [DescriptorSchemaCache].
+ */
+internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int =
+    json.schemaCache.getOrPut(this, JsonExtraKeysIndexKey) {
+        computeJsonExtraKeysIndex()
+    }
+
+private fun SerialDescriptor.computeJsonExtraKeysIndex(): Int {
+    var foundIndex = -1
+    var duplicates: MutableList<String>? = null
+    for (i in 0 until elementsCount) {
+        if (getElementAnnotations(i).any { it is JsonExtraKeys }) {
+            if (foundIndex == -1) {
+                foundIndex = i
+            } else {
+                val list = duplicates ?: mutableListOf(getElementName(foundIndex)).also { duplicates = it }
+                list.add(getElementName(i))
+            }
+        }
+    }
+    duplicates?.let {
+        throw SerializationException(
+            "Class '$serialName' has more than one property annotated with @JsonExtraKeys: " +
+                it.joinToString(", ") { name -> "'$name'" } +
+                ". At most one such property is allowed per class."
+        )
+    }
+    if (foundIndex == -1) return -1
+    validateJsonExtraKeysProperty(foundIndex)
+    return foundIndex
+}
+
+private fun SerialDescriptor.validateJsonExtraKeysProperty(index: Int) {
+    val propertyName = getElementName(index)
+    val elementDescriptor = getElementDescriptor(index)
+    val rejection = "Property '$propertyName' of '$serialName' is annotated with @JsonExtraKeys " +
+        "but its type is not 'Map<String, JsonElement>'"
+    if (elementDescriptor.kind != StructureKind.MAP) {
+        throw SerializationException("$rejection (kind is ${elementDescriptor.kind}).")
+    }
+    val keyDescriptor = elementDescriptor.getElementDescriptor(0)
+    if (keyDescriptor.kind != PrimitiveKind.STRING) {
+        throw SerializationException(
+            "$rejection: map key type must be String but was '${keyDescriptor.serialName}'."
+        )
+    }
+    val valueDescriptor = elementDescriptor.getElementDescriptor(1)
+    if (valueDescriptor != JsonElementSerializer.descriptor) {
+        throw SerializationException(
+            "$rejection: map value type must be JsonElement but was '${valueDescriptor.serialName}'."
+        )
+    }
+}

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -189,9 +189,9 @@ internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int {
         // Some partially-customized descriptors (e.g. created via the @Serializer
         // companion shortcut) have a broken hashCode() that throws an
         // index-out-of-bounds exception when the schema cache hashes them.
-        // Unlike useAlternativeNames — which touches hashCode only on the
-        // unknown-key slow path and documents `useAlternativeNames = false` as
-        // the remedy — this lookup runs eagerly for every class descriptor, so
+        // useAlternativeNames touches hashCode only on the unknown-key slow
+        // path and documents `useAlternativeNames = false` as the remedy. This
+        // lookup instead runs eagerly for every class descriptor, so
         // without this fallback the mere presence of such a descriptor would
         // break on upgrade even when @JsonExtraKeys is not used at all
         // (see JsonCustomSerializersTest). Fall back to uncached computation.
@@ -267,7 +267,7 @@ internal val JsonExtraKeysCollisionNamesKey = DescriptorSchemaCache.Key<Set<Stri
  * Names that a [JsonExtraKeys] bucket is not allowed to contain when written
  * back during encoding: every JSON name that decoding would resolve to a
  * declared property (serial names, [JsonNames] aliases and naming-strategy
- * forms) — except names resolving to the bucket itself, which decoding
+ * forms), except names resolving to the bucket itself, which decoding
  * captures into the bucket and which therefore round-trip safely.
  *
  * Memoised in the per-[Json] [DescriptorSchemaCache].

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -79,6 +79,21 @@ internal fun SerialDescriptor.getJsonEncodedNames(json: Json): Set<String> {
     return if (strategy == null) jsonCachedSerialNames() else serializationNamesIndices(json, strategy).toSet()
 }
 
+// All JSON names that decode would resolve to a declared property, including @JsonNames aliases
+internal fun SerialDescriptor.getJsonDecodingNames(json: Json): Set<String> {
+    val strategy = namingStrategy(json)
+    return if (strategy == null && !json.configuration.useAlternativeNames) {
+        jsonCachedSerialNames()
+    } else {
+        val result = mutableSetOf<String>()
+        if (strategy == null) {
+            result.addAll(jsonCachedSerialNames())
+        }
+        result.addAll(json.deserializationNamesMap(this).keys)
+        result
+    }
+}
+
 internal fun SerialDescriptor.namingStrategy(json: Json) =
     if (kind == StructureKind.CLASS) json.configuration.namingStrategy else null
 
@@ -178,7 +193,13 @@ internal val JsonExtraKeysIndexKey = DescriptorSchemaCache.Key<Int>()
  * The result is memoised in the per-[Json] [DescriptorSchemaCache].
  */
 internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int =
-    json.schemaCache.getOrPut(this, JsonExtraKeysIndexKey) {
+    try {
+        json.schemaCache.getOrPut(this, JsonExtraKeysIndexKey) {
+            computeJsonExtraKeysIndex()
+        }
+    } catch (e: ArrayIndexOutOfBoundsException) {
+        // Defensive fallback for hand-rolled descriptors (e.g. external @Serializer)
+        // whose hashCode() crashes due to mismatched childSerializers array.
         computeJsonExtraKeysIndex()
     }
 
@@ -190,8 +211,12 @@ private fun SerialDescriptor.computeJsonExtraKeysIndex(): Int {
             if (foundIndex == -1) {
                 foundIndex = i
             } else {
-                val list = duplicates ?: mutableListOf(getElementName(foundIndex)).also { duplicates = it }
-                list.add(getElementName(i))
+                val list = duplicates
+                if (list == null) {
+                    duplicates = mutableListOf(getElementName(foundIndex), getElementName(i))
+                } else {
+                    list.add(getElementName(i))
+                }
             }
         }
     }
@@ -222,9 +247,19 @@ private fun SerialDescriptor.validateJsonExtraKeysProperty(index: Int) {
         )
     }
     val valueDescriptor = elementDescriptor.getElementDescriptor(1)
+    // Strict identity check: we deliberately reject custom JsonElement
+    // serializers because the streaming decoder synthesises a JsonObject
+    // and feeds it to the standard JsonElementSerializer (see ARCHITECTURE.md §8.3).
+    // Loosening this requires also routing the user's serializer through
+    // the synthetic decode path.
     if (valueDescriptor != JsonElementSerializer.descriptor) {
         throw SerializationException(
             "$rejection: map value type must be JsonElement but was '${valueDescriptor.serialName}'."
+        )
+    }
+    if (getElementAnnotations(index).any { it is JsonNames }) {
+        throw SerializationException(
+            "$rejection: @JsonNames is not allowed on a @JsonExtraKeys property."
         )
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -197,9 +197,11 @@ internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int =
         json.schemaCache.getOrPut(this, JsonExtraKeysIndexKey) {
             computeJsonExtraKeysIndex()
         }
-    } catch (e: ArrayIndexOutOfBoundsException) {
-        // Defensive fallback for hand-rolled descriptors (e.g. external @Serializer)
-        // whose hashCode() crashes due to mismatched childSerializers array.
+    } catch (_: ArrayIndexOutOfBoundsException) {
+        // Some partially-customized descriptors (e.g. created via the @Serializer
+        // companion shortcut) have a broken hashCode() that throws AIOOBE.
+        // The library already documents this limitation around `useAlternativeNames`
+        // (see JsonCustomSerializersTest.kt). Fall back to uncached computation.
         computeJsonExtraKeysIndex()
     }
 
@@ -249,7 +251,7 @@ private fun SerialDescriptor.validateJsonExtraKeysProperty(index: Int) {
     val valueDescriptor = elementDescriptor.getElementDescriptor(1)
     // Strict identity check: we deliberately reject custom JsonElement
     // serializers because the streaming decoder synthesises a JsonObject
-    // and feeds it to the standard JsonElementSerializer (see ARCHITECTURE.md §8.3).
+    // and feeds it to the standard JsonElementSerializer.
     // Loosening this requires also routing the user's serializer through
     // the synthetic decode path.
     if (valueDescriptor != JsonElementSerializer.descriptor) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -80,21 +80,6 @@ internal fun SerialDescriptor.getJsonEncodedNames(json: Json): Set<String> {
     return if (strategy == null) jsonCachedSerialNames() else serializationNamesIndices(json, strategy).toSet()
 }
 
-// All JSON names that decode would resolve to a declared property, including @JsonNames aliases
-internal fun SerialDescriptor.getJsonDecodingNames(json: Json): Set<String> {
-    val strategy = namingStrategy(json)
-    return if (strategy == null && !json.configuration.useAlternativeNames) {
-        jsonCachedSerialNames()
-    } else {
-        val result = mutableSetOf<String>()
-        if (strategy == null) {
-            result.addAll(jsonCachedSerialNames())
-        }
-        result.addAll(json.deserializationNamesMap(this).keys)
-        result
-    }
-}
-
 internal fun SerialDescriptor.namingStrategy(json: Json) =
     if (kind == StructureKind.CLASS) json.configuration.namingStrategy else null
 
@@ -189,7 +174,7 @@ internal val JsonExtraKeysIndexKey = DescriptorSchemaCache.Key<Int>()
  *
  * Validates on first computation and throws [SerializationException] if:
  *  - more than one property is annotated with [JsonExtraKeys];
- *  - the annotated property is not of type `Map<String, V>` (string-keyed map).
+ *  - the annotated property is not of type `JsonObject` / `Map<String, JsonElement>`.
  *
  * The result is memoised in the per-[Json] [DescriptorSchemaCache].
  */
@@ -242,18 +227,24 @@ private fun SerialDescriptor.validateJsonExtraKeysProperty(index: Int) {
     val propertyName = getElementName(index)
     val elementDescriptor = getElementDescriptor(index)
     val rejection = "Property '$propertyName' of '$serialName' is annotated with @JsonExtraKeys " +
-        "but its type is not 'Map<String, V>'"
+        "but its type is not 'JsonObject' or 'Map<String, JsonElement>'"
     if (elementDescriptor.kind != StructureKind.MAP) {
         throw SerializationException("$rejection (kind is ${elementDescriptor.kind}).")
     }
-    val keyDescriptor = elementDescriptor.getElementDescriptor(0)
-    // Strict identity check: the encode path iterates entries and casts each key
-    // to String. Inline value classes wrapping String have STRING kind but a
-    // different runtime type, so we reject anything but the standard String
-    // serializer's descriptor.
-    if (keyDescriptor !== String.serializer().descriptor) {
+    // Strict identity checks: bucket keys are JSON object member names and
+    // values must be opaque JsonElements. Both JsonObject's descriptor and the
+    // one produced by MapSerializer(String.serializer(), JsonElement.serializer())
+    // delegate to the same element descriptors, so identity comparison accepts
+    // exactly the two supported declarations and nothing else (e.g. inline
+    // value classes wrapping String, or typed/nullable values).
+    if (elementDescriptor.getElementDescriptor(0) !== String.serializer().descriptor) {
         throw SerializationException(
-            "$rejection: map key type must be String but was '${keyDescriptor.serialName}'."
+            "$rejection: map key type must be String but was '${elementDescriptor.getElementDescriptor(0).serialName}'."
+        )
+    }
+    if (elementDescriptor.getElementDescriptor(1) !== JsonElementSerializer.descriptor) {
+        throw SerializationException(
+            "$rejection: map value type must be JsonElement but was '${elementDescriptor.getElementDescriptor(1).serialName}'."
         )
     }
     if (getElementAnnotations(index).any { it is JsonNames }) {
@@ -262,3 +253,34 @@ private fun SerialDescriptor.validateJsonExtraKeysProperty(index: Int) {
         )
     }
 }
+
+internal val JsonExtraKeysCollisionNamesKey = DescriptorSchemaCache.Key<Set<String>>()
+
+/**
+ * Names that a [JsonExtraKeys] bucket is not allowed to contain when written
+ * back during encoding: every JSON name that decoding would resolve to a
+ * declared property (serial names, [JsonNames] aliases and naming-strategy
+ * forms) — except names resolving to the bucket itself, which decoding
+ * captures into the bucket and which therefore round-trip safely.
+ *
+ * Memoised in the per-[Json] [DescriptorSchemaCache].
+ */
+internal fun SerialDescriptor.jsonExtraKeysCollisionNames(json: Json, bucketIndex: Int): Set<String> =
+    json.schemaCache.getOrPut(this, JsonExtraKeysCollisionNamesKey) {
+        // Mirrors the name-resolution rules of decoding: serial names are
+        // recognized only without a naming strategy, and @JsonNames aliases
+        // (from deserializationNamesMap) only when useAlternativeNames is on.
+        val strategy = namingStrategy(json)
+        val result = mutableSetOf<String>()
+        if (strategy == null) {
+            for (i in 0 until elementsCount) {
+                if (i != bucketIndex) result.add(getElementName(i))
+            }
+        }
+        if (strategy != null || json.configuration.useAlternativeNames) {
+            for ((name, index) in json.deserializationNamesMap(this)) {
+                if (index != bucketIndex) result.add(name)
+            }
+        }
+        result
+    }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -170,7 +170,8 @@ internal val JsonExtraKeysIndexKey = DescriptorSchemaCache.Key<Int>()
 
 /**
  * Returns the element index of the property annotated with [JsonExtraKeys],
- * or -1 if no such property exists in this descriptor.
+ * or -1 if no such property exists in this descriptor or the feature is
+ * disabled via [JsonBuilder.useExtraKeys].
  *
  * Validates on first computation and throws [SerializationException] if:
  *  - more than one property is annotated with [JsonExtraKeys];
@@ -178,21 +179,27 @@ internal val JsonExtraKeysIndexKey = DescriptorSchemaCache.Key<Int>()
  *
  * The result is memoised in the per-[Json] [DescriptorSchemaCache].
  */
-internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int =
-    try {
+internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int {
+    if (!json.configuration.useExtraKeys) return -1
+    return try {
         json.schemaCache.getOrPut(this, JsonExtraKeysIndexKey) {
             computeJsonExtraKeysIndex()
         }
     } catch (_: IndexOutOfBoundsException) {
         // Some partially-customized descriptors (e.g. created via the @Serializer
         // companion shortcut) have a broken hashCode() that throws an
-        // index-out-of-bounds exception. The library already documents this
-        // limitation around `useAlternativeNames` (see JsonCustomSerializersTest.kt).
-        // Fall back to uncached computation. We catch the parent type so the
-        // catch is portable across JVM (where the JDK throws AIOOBE) and
-        // Kotlin/Native (where AIOOBE is a deprecated alias for IOOBE).
+        // index-out-of-bounds exception when the schema cache hashes them.
+        // Unlike useAlternativeNames — which touches hashCode only on the
+        // unknown-key slow path and documents `useAlternativeNames = false` as
+        // the remedy — this lookup runs eagerly for every class descriptor, so
+        // without this fallback the mere presence of such a descriptor would
+        // break on upgrade even when @JsonExtraKeys is not used at all
+        // (see JsonCustomSerializersTest). Fall back to uncached computation.
+        // The parent exception type is caught for portability: the JDK throws
+        // AIOOBE, while on Kotlin/Native AIOOBE is a deprecated alias of IOOBE.
         computeJsonExtraKeysIndex()
     }
+}
 
 private fun SerialDescriptor.computeJsonExtraKeysIndex(): Int {
     var foundIndex = -1

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -6,6 +6,7 @@
 package kotlinx.serialization.json.internal
 
 import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.internal.jsonCachedSerialNames
@@ -188,7 +189,7 @@ internal val JsonExtraKeysIndexKey = DescriptorSchemaCache.Key<Int>()
  *
  * Validates on first computation and throws [SerializationException] if:
  *  - more than one property is annotated with [JsonExtraKeys];
- *  - the annotated property is not of type `Map<String, JsonElement>`.
+ *  - the annotated property is not of type `Map<String, V>` (string-keyed map).
  *
  * The result is memoised in the per-[Json] [DescriptorSchemaCache].
  */
@@ -197,11 +198,14 @@ internal fun SerialDescriptor.jsonExtraKeysIndex(json: Json): Int =
         json.schemaCache.getOrPut(this, JsonExtraKeysIndexKey) {
             computeJsonExtraKeysIndex()
         }
-    } catch (_: ArrayIndexOutOfBoundsException) {
+    } catch (_: IndexOutOfBoundsException) {
         // Some partially-customized descriptors (e.g. created via the @Serializer
-        // companion shortcut) have a broken hashCode() that throws AIOOBE.
-        // The library already documents this limitation around `useAlternativeNames`
-        // (see JsonCustomSerializersTest.kt). Fall back to uncached computation.
+        // companion shortcut) have a broken hashCode() that throws an
+        // index-out-of-bounds exception. The library already documents this
+        // limitation around `useAlternativeNames` (see JsonCustomSerializersTest.kt).
+        // Fall back to uncached computation. We catch the parent type so the
+        // catch is portable across JVM (where the JDK throws AIOOBE) and
+        // Kotlin/Native (where AIOOBE is a deprecated alias for IOOBE).
         computeJsonExtraKeysIndex()
     }
 
@@ -238,25 +242,18 @@ private fun SerialDescriptor.validateJsonExtraKeysProperty(index: Int) {
     val propertyName = getElementName(index)
     val elementDescriptor = getElementDescriptor(index)
     val rejection = "Property '$propertyName' of '$serialName' is annotated with @JsonExtraKeys " +
-        "but its type is not 'Map<String, JsonElement>'"
+        "but its type is not 'Map<String, V>'"
     if (elementDescriptor.kind != StructureKind.MAP) {
         throw SerializationException("$rejection (kind is ${elementDescriptor.kind}).")
     }
     val keyDescriptor = elementDescriptor.getElementDescriptor(0)
-    if (keyDescriptor.kind != PrimitiveKind.STRING) {
+    // Strict identity check: the encode path iterates entries and casts each key
+    // to String. Inline value classes wrapping String have STRING kind but a
+    // different runtime type, so we reject anything but the standard String
+    // serializer's descriptor.
+    if (keyDescriptor !== String.serializer().descriptor) {
         throw SerializationException(
             "$rejection: map key type must be String but was '${keyDescriptor.serialName}'."
-        )
-    }
-    val valueDescriptor = elementDescriptor.getElementDescriptor(1)
-    // Strict identity check: we deliberately reject custom JsonElement
-    // serializers because the streaming decoder synthesises a JsonObject
-    // and feeds it to the standard JsonElementSerializer.
-    // Loosening this requires also routing the user's serializer through
-    // the synthetic decode path.
-    if (valueDescriptor != JsonElementSerializer.descriptor) {
-        throw SerializationException(
-            "$rejection: map value type must be JsonElement but was '${valueDescriptor.serialName}'."
         )
     }
     if (getElementAnnotations(index).any { it is JsonNames }) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -291,6 +291,9 @@ internal open class StreamingJsonDecoder(
         // Dispatch once per element-index request: classes without a
         // @JsonExtraKeys bucket (the overwhelming majority) run a loop that is
         // identical to the pre-feature code and carry no bucket bookkeeping.
+        // The flag check is inlined here so the disabled path branches straight
+        // into the no-bucket loop without calling into the cache machinery.
+        if (!configuration.useExtraKeys) return decodeObjectIndexNoBucket(descriptor)
         val extraKeysIndex = extraKeysIndexFor(descriptor)
         if (extraKeysIndex == -1) return decodeObjectIndexNoBucket(descriptor)
         return decodeObjectIndexWithBucket(descriptor, extraKeysIndex)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -178,7 +178,7 @@ internal open class StreamingJsonDecoder(
         // The stack is null in the common case (no @JsonExtraKeys was ever seen).
         // The pop condition must mirror the push in beginStructure: a frame was
         // pushed only when the begun descriptor declared a bucket, so only such
-        // a descriptor's endStructure may pop — a nested bucket-less object
+        // a descriptor's endStructure may pop. A nested bucket-less object
         // ending must not steal its parent's frame.
         val savedStack = extraKeysSavedStack
         if (savedStack != null && savedStack.isNotEmpty() && extraKeysIndexFor(descriptor) != -1) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -75,6 +75,9 @@ internal open class StreamingJsonDecoder(
     private var cachedExtraKeysIndex: Int = -1
 
     private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        // Flag check first: when the feature is disabled this is a single
+        // predictable branch, before any cache machinery is touched.
+        if (!configuration.useExtraKeys) return -1
         if (lookupDescriptor !== descriptor) {
             lookupDescriptor = descriptor
             cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)
@@ -173,8 +176,12 @@ internal open class StreamingJsonDecoder(
         lexer.consumeNextToken(mode.end)
         // Restore saved extra keys state if it was saved due to decoder reuse.
         // The stack is null in the common case (no @JsonExtraKeys was ever seen).
+        // The pop condition must mirror the push in beginStructure: a frame was
+        // pushed only when the begun descriptor declared a bucket, so only such
+        // a descriptor's endStructure may pop — a nested bucket-less object
+        // ending must not steal its parent's frame.
         val savedStack = extraKeysSavedStack
-        if (savedStack != null && savedStack.isNotEmpty()) {
+        if (savedStack != null && savedStack.isNotEmpty() && extraKeysIndexFor(descriptor) != -1) {
             val last = savedStack.removeAt(savedStack.lastIndex)
             extraKeys = last.map
             extraKeysEmitted = last.emitted
@@ -210,8 +217,13 @@ internal open class StreamingJsonDecoder(
         deserializer: DeserializationStrategy<T>,
         previousValue: T?
     ): T {
-        val extraKeysIndex = extraKeysIndexFor(descriptor)
-        if (index == extraKeysIndex) {
+        // Cheap first compare: cachedExtraKeysIndex is -1 for the vast majority
+        // of classes, and index is never negative, so this rejects in a single
+        // register comparison. A stale positive hit (cache still holding another
+        // descriptor's index) is corrected by the full extraKeysIndexFor check;
+        // a stale miss is impossible here because decodeElementIndex has always
+        // refreshed the cache for this descriptor right before this call.
+        if (index == cachedExtraKeysIndex && extraKeysIndexFor(descriptor) == index) {
             val obj = JsonObject(extraKeys.orEmpty())
             return readJson(json, obj, deserializer)
         }
@@ -276,10 +288,46 @@ internal open class StreamingJsonDecoder(
     )
 
     private fun decodeObjectIndex(descriptor: SerialDescriptor): Int {
+        // Dispatch once per element-index request: classes without a
+        // @JsonExtraKeys bucket (the overwhelming majority) run a loop that is
+        // identical to the pre-feature code and carry no bucket bookkeeping.
         val extraKeysIndex = extraKeysIndexFor(descriptor)
+        if (extraKeysIndex == -1) return decodeObjectIndexNoBucket(descriptor)
+        return decodeObjectIndexWithBucket(descriptor, extraKeysIndex)
+    }
+
+    private fun decodeObjectIndexNoBucket(descriptor: SerialDescriptor): Int {
         // hasComma checks are required to properly react on trailing commas
         var hasComma = lexer.tryConsumeComma()
         while (lexer.canConsumeValue()) { // TODO: consider merging comma consumption and this check
+            hasComma = false
+            val key = decodeStringKey()
+            lexer.consumeNextToken(COLON)
+            val index = descriptor.getJsonNameIndex(json, key)
+            val isUnknown = if (index != UNKNOWN_NAME) {
+                if (configuration.coerceInputValues && coerceInputValue(descriptor, index)) {
+                    hasComma = lexer.tryConsumeComma()
+                    false // Known element, but coerced
+                } else {
+                    elementMarker?.mark(index)
+                    return index // Known element without coercing, return it
+                }
+            } else {
+                true // unknown element
+            }
+
+            if (isUnknown) { // slow-path for unknown keys handling
+                hasComma = handleUnknown(descriptor, key)
+            }
+        }
+        if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()
+
+        return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
+    }
+
+    private fun decodeObjectIndexWithBucket(descriptor: SerialDescriptor, extraKeysIndex: Int): Int {
+        var hasComma = lexer.tryConsumeComma()
+        while (lexer.canConsumeValue()) {
             hasComma = false
             val key = decodeStringKey()
             lexer.consumeNextToken(COLON)
@@ -296,14 +344,13 @@ internal open class StreamingJsonDecoder(
                 true // unknown element (or bucket's own key)
             }
 
-            if (isUnknown) { // slow-path for unknown keys handling
-                handleUnknown(descriptor, key, extraKeysIndex)
-                hasComma = lexer.tryConsumeComma()
+            if (isUnknown) { // capture instead of skipping/failing
+                hasComma = handleUnknownWithBucket(key)
             }
         }
         if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()
 
-        if (extraKeysIndex != -1 && !extraKeysEmitted) {
+        if (!extraKeysEmitted) {
             extraKeysEmitted = true
             // When optional and nothing captured, fall through so the property keeps its declared default.
             if (extraKeys != null || !descriptor.isElementOptional(extraKeysIndex)) {
@@ -313,13 +360,8 @@ internal open class StreamingJsonDecoder(
         return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
     }
 
-    private fun handleUnknown(descriptor: SerialDescriptor, key: String, extraKeysIndex: Int) {
-        if (discriminatorHolder.trySkip(key)) {
-            lexer.skipElement(configuration.isLenient)
-        } else if (extraKeysIndex != -1) {
-            val collector = extraKeys ?: LinkedHashMap<String, JsonElement>().also { extraKeys = it }
-            collector[key] = JsonTreeReader(configuration, lexer).read()
-        } else if (descriptor.ignoreUnknownKeys(json)) {
+    private fun handleUnknown(descriptor: SerialDescriptor, key: String): Boolean {
+        if (descriptor.ignoreUnknownKeys(json) || discriminatorHolder.trySkip(key)) {
             lexer.skipElement(configuration.isLenient)
         } else {
             // Since path is updated on key decoding, it ends with the key that was successfully decoded last,
@@ -327,6 +369,18 @@ internal open class StreamingJsonDecoder(
             lexer.path.popDescriptor()
             lexer.failOnUnknownKey(key)
         }
+        return lexer.tryConsumeComma()
+    }
+
+    private fun handleUnknownWithBucket(key: String): Boolean {
+        if (discriminatorHolder.trySkip(key)) {
+            lexer.skipElement(configuration.isLenient)
+        } else {
+            // Capture wins over ignoreUnknownKeys when a bucket is present.
+            val collector = extraKeys ?: LinkedHashMap<String, JsonElement>().also { extraKeys = it }
+            collector[key] = JsonTreeReader(configuration, lexer).read()
+        }
+        return lexer.tryConsumeComma()
     }
 
     private fun decodeListIndex(): Int {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -305,7 +305,10 @@ internal open class StreamingJsonDecoder(
 
         if (extraKeysIndex != -1 && !extraKeysEmitted) {
             extraKeysEmitted = true
-            return extraKeysIndex
+            // When optional and nothing captured, fall through so the property keeps its declared default.
+            if (extraKeys != null || !descriptor.isElementOptional(extraKeysIndex)) {
+                return extraKeysIndex
+            }
         }
         return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
     }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -52,21 +52,17 @@ internal open class StreamingJsonDecoder(
     // Lazy-initialised state for @JsonExtraKeys capture.
     // In the common case (no descriptor in this decoder's lifetime declares
     // @JsonExtraKeys) these stay null and pay no allocation cost.
-    private var extraKeysMap: MutableMap<SerialDescriptor, LinkedHashMap<String, JsonElement>>? = null
-    private var extraKeysEmittedMap: MutableMap<SerialDescriptor, Boolean>? = null
+    private var extraKeys: LinkedHashMap<String, JsonElement>? = null
+    private var extraKeysEmitted: Boolean = false
 
+    // Save/restore stack for @JsonExtraKeys state when the decoder reuses
+    // itself across same-mode nested objects (explicitNulls = true). Only
+    // populated when the parent descriptor actually declares @JsonExtraKeys.
     private data class ExtraKeysFrame(
-        val descriptor: SerialDescriptor,
         val map: LinkedHashMap<String, JsonElement>?,
-        val emitted: Boolean?
+        val emitted: Boolean
     )
     private var extraKeysSavedStack: MutableList<ExtraKeysFrame>? = null
-
-    private fun extraKeysMapMutable(): MutableMap<SerialDescriptor, LinkedHashMap<String, JsonElement>> =
-        extraKeysMap ?: mutableMapOf<SerialDescriptor, LinkedHashMap<String, JsonElement>>().also { extraKeysMap = it }
-
-    private fun extraKeysEmittedMapMutable(): MutableMap<SerialDescriptor, Boolean> =
-        extraKeysEmittedMap ?: mutableMapOf<SerialDescriptor, Boolean>().also { extraKeysEmittedMap = it }
 
     private fun extraKeysSavedStackMutable(): MutableList<ExtraKeysFrame> =
         extraKeysSavedStack ?: mutableListOf<ExtraKeysFrame>().also { extraKeysSavedStack = it }
@@ -81,11 +77,7 @@ internal open class StreamingJsonDecoder(
     private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
         if (lookupDescriptor !== descriptor) {
             lookupDescriptor = descriptor
-            cachedExtraKeysIndex = try {
-                descriptor.jsonExtraKeysIndex(json)
-            } catch (_: ArrayIndexOutOfBoundsException) {
-                -1
-            }
+            cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)
         }
         return cachedExtraKeysIndex
     }
@@ -156,10 +148,11 @@ internal open class StreamingJsonDecoder(
             else -> if (mode == newMode && json.configuration.explicitNulls) {
                 val extraKeysIndex = extraKeysIndexFor(descriptor)
                 if (extraKeysIndex != -1) {
-                    // Only allocate the per-frame state when the bucket actually exists.
-                    val savedMap = try { extraKeysMap?.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
-                    val savedEmitted = try { extraKeysEmittedMap?.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
-                    extraKeysSavedStackMutable().add(ExtraKeysFrame(descriptor, savedMap, savedEmitted))
+                    // Save outer frame so a nested same-type object cannot leak
+                    // bucket state into its parent. Only paid when a bucket exists.
+                    extraKeysSavedStackMutable().add(ExtraKeysFrame(extraKeys, extraKeysEmitted))
+                    extraKeys = null
+                    extraKeysEmitted = false
                 }
                 this
             } else {
@@ -183,18 +176,8 @@ internal open class StreamingJsonDecoder(
         val savedStack = extraKeysSavedStack
         if (savedStack != null && savedStack.isNotEmpty()) {
             val last = savedStack.removeAt(savedStack.lastIndex)
-            if (last.descriptor == descriptor) {
-                if (last.map != null) {
-                    extraKeysMapMutable()[descriptor] = last.map
-                } else {
-                    extraKeysMap?.remove(descriptor)
-                }
-                if (last.emitted != null) {
-                    extraKeysEmittedMapMutable()[descriptor] = last.emitted
-                } else {
-                    extraKeysEmittedMap?.remove(descriptor)
-                }
-            }
+            extraKeys = last.map
+            extraKeysEmitted = last.emitted
         }
         // Then cleanup the path
         lexer.path.popDescriptor()
@@ -229,7 +212,7 @@ internal open class StreamingJsonDecoder(
     ): T {
         val extraKeysIndex = extraKeysIndexFor(descriptor)
         if (index == extraKeysIndex) {
-            val obj = JsonObject(extraKeysMap?.get(descriptor).orEmpty())
+            val obj = JsonObject(extraKeys.orEmpty())
             return readJson(json, obj, deserializer)
         }
         val isMapKey = mode == LexerMode.MAP && index and 1 == 0
@@ -319,12 +302,9 @@ internal open class StreamingJsonDecoder(
         }
         if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()
 
-        if (extraKeysIndex != -1) {
-            val emittedMap = extraKeysEmittedMapMutable()
-            if (emittedMap[descriptor] != true) {
-                emittedMap[descriptor] = true
-                return extraKeysIndex
-            }
+        if (extraKeysIndex != -1 && !extraKeysEmitted) {
+            extraKeysEmitted = true
+            return extraKeysIndex
         }
         return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
     }
@@ -333,7 +313,7 @@ internal open class StreamingJsonDecoder(
         if (discriminatorHolder.trySkip(key)) {
             lexer.skipElement(configuration.isLenient)
         } else if (extraKeysIndex != -1) {
-            val collector = extraKeysMapMutable().getOrPut(descriptor) { LinkedHashMap() }
+            val collector = extraKeys ?: LinkedHashMap<String, JsonElement>().also { extraKeys = it }
             collector[key] = JsonTreeReader(configuration, lexer).read()
         } else if (descriptor.ignoreUnknownKeys(json)) {
             lexer.skipElement(configuration.isLenient)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -48,15 +48,47 @@ internal open class StreamingJsonDecoder(
     private val configuration = json.configuration
 
     private val elementMarker: JsonElementMarker? = if (configuration.explicitNulls) null else JsonElementMarker(descriptor)
-    private val extraKeysMap = mutableMapOf<SerialDescriptor, LinkedHashMap<String, JsonElement>>()
-    private val extraKeysEmittedMap = mutableMapOf<SerialDescriptor, Boolean>()
+
+    // Lazy-initialised state for @JsonExtraKeys capture.
+    // In the common case (no descriptor in this decoder's lifetime declares
+    // @JsonExtraKeys) these stay null and pay no allocation cost.
+    private var extraKeysMap: MutableMap<SerialDescriptor, LinkedHashMap<String, JsonElement>>? = null
+    private var extraKeysEmittedMap: MutableMap<SerialDescriptor, Boolean>? = null
 
     private data class ExtraKeysFrame(
         val descriptor: SerialDescriptor,
         val map: LinkedHashMap<String, JsonElement>?,
         val emitted: Boolean?
     )
-    private val extraKeysSavedStack = mutableListOf<ExtraKeysFrame>()
+    private var extraKeysSavedStack: MutableList<ExtraKeysFrame>? = null
+
+    private fun extraKeysMapMutable(): MutableMap<SerialDescriptor, LinkedHashMap<String, JsonElement>> =
+        extraKeysMap ?: mutableMapOf<SerialDescriptor, LinkedHashMap<String, JsonElement>>().also { extraKeysMap = it }
+
+    private fun extraKeysEmittedMapMutable(): MutableMap<SerialDescriptor, Boolean> =
+        extraKeysEmittedMap ?: mutableMapOf<SerialDescriptor, Boolean>().also { extraKeysEmittedMap = it }
+
+    private fun extraKeysSavedStackMutable(): MutableList<ExtraKeysFrame> =
+        extraKeysSavedStack ?: mutableListOf<ExtraKeysFrame>().also { extraKeysSavedStack = it }
+
+    // Cache of the @JsonExtraKeys index for the most recently queried descriptor.
+    // The sentinel `lookupDescriptor !== descriptor` triggers a refresh when the
+    // descriptor changes (e.g. same-mode nested object reuse). This avoids hitting
+    // the per-Json schema cache on every key / element decode.
+    private var lookupDescriptor: SerialDescriptor? = null
+    private var cachedExtraKeysIndex: Int = -1
+
+    private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        if (lookupDescriptor !== descriptor) {
+            lookupDescriptor = descriptor
+            cachedExtraKeysIndex = try {
+                descriptor.jsonExtraKeysIndex(json)
+            } catch (_: ArrayIndexOutOfBoundsException) {
+                -1
+            }
+        }
+        return cachedExtraKeysIndex
+    }
 
     override fun decodeJsonElement(): JsonElement = JsonTreeReader(json.configuration, lexer).read()
 
@@ -122,15 +154,12 @@ internal open class StreamingJsonDecoder(
                 discriminatorHolder
             )
             else -> if (mode == newMode && json.configuration.explicitNulls) {
-                val extraKeysIndex = try {
-                    descriptor.jsonExtraKeysIndex(json)
-                } catch (_: ArrayIndexOutOfBoundsException) {
-                    -1
-                }
+                val extraKeysIndex = extraKeysIndexFor(descriptor)
                 if (extraKeysIndex != -1) {
-                    val savedMap = try { extraKeysMap.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
-                    val savedEmitted = try { extraKeysEmittedMap.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
-                    extraKeysSavedStack.add(ExtraKeysFrame(descriptor, savedMap, savedEmitted))
+                    // Only allocate the per-frame state when the bucket actually exists.
+                    val savedMap = try { extraKeysMap?.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
+                    val savedEmitted = try { extraKeysEmittedMap?.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
+                    extraKeysSavedStackMutable().add(ExtraKeysFrame(descriptor, savedMap, savedEmitted))
                 }
                 this
             } else {
@@ -149,19 +178,21 @@ internal open class StreamingJsonDecoder(
         if (lexer.tryConsumeComma() && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma("")
         // First consume the object so we know it's correct
         lexer.consumeNextToken(mode.end)
-        // Restore saved extra keys state if it was saved due to decoder reuse
-        if (extraKeysSavedStack.isNotEmpty()) {
-            val last = extraKeysSavedStack.removeAt(extraKeysSavedStack.lastIndex)
+        // Restore saved extra keys state if it was saved due to decoder reuse.
+        // The stack is null in the common case (no @JsonExtraKeys was ever seen).
+        val savedStack = extraKeysSavedStack
+        if (savedStack != null && savedStack.isNotEmpty()) {
+            val last = savedStack.removeAt(savedStack.lastIndex)
             if (last.descriptor == descriptor) {
                 if (last.map != null) {
-                    extraKeysMap[descriptor] = last.map
+                    extraKeysMapMutable()[descriptor] = last.map
                 } else {
-                    extraKeysMap.remove(descriptor)
+                    extraKeysMap?.remove(descriptor)
                 }
                 if (last.emitted != null) {
-                    extraKeysEmittedMap[descriptor] = last.emitted
+                    extraKeysEmittedMapMutable()[descriptor] = last.emitted
                 } else {
-                    extraKeysEmittedMap.remove(descriptor)
+                    extraKeysEmittedMap?.remove(descriptor)
                 }
             }
         }
@@ -196,9 +227,9 @@ internal open class StreamingJsonDecoder(
         deserializer: DeserializationStrategy<T>,
         previousValue: T?
     ): T {
-        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        val extraKeysIndex = extraKeysIndexFor(descriptor)
         if (index == extraKeysIndex) {
-            val obj = JsonObject(extraKeysMap[descriptor].orEmpty())
+            val obj = JsonObject(extraKeysMap?.get(descriptor).orEmpty())
             return readJson(json, obj, deserializer)
         }
         val isMapKey = mode == LexerMode.MAP && index and 1 == 0
@@ -262,7 +293,7 @@ internal open class StreamingJsonDecoder(
     )
 
     private fun decodeObjectIndex(descriptor: SerialDescriptor): Int {
-        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        val extraKeysIndex = extraKeysIndexFor(descriptor)
         // hasComma checks are required to properly react on trailing commas
         var hasComma = lexer.tryConsumeComma()
         while (lexer.canConsumeValue()) { // TODO: consider merging comma consumption and this check
@@ -288,9 +319,12 @@ internal open class StreamingJsonDecoder(
         }
         if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()
 
-        if (extraKeysIndex != -1 && !extraKeysEmittedMap.getOrPut(descriptor) { false }) {
-            extraKeysEmittedMap[descriptor] = true
-            return extraKeysIndex
+        if (extraKeysIndex != -1) {
+            val emittedMap = extraKeysEmittedMapMutable()
+            if (emittedMap[descriptor] != true) {
+                emittedMap[descriptor] = true
+                return extraKeysIndex
+            }
         }
         return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
     }
@@ -299,7 +333,7 @@ internal open class StreamingJsonDecoder(
         if (discriminatorHolder.trySkip(key)) {
             lexer.skipElement(configuration.isLenient)
         } else if (extraKeysIndex != -1) {
-            val collector = extraKeysMap.getOrPut(descriptor) { LinkedHashMap() }
+            val collector = extraKeysMapMutable().getOrPut(descriptor) { LinkedHashMap() }
             collector[key] = JsonTreeReader(configuration, lexer).read()
         } else if (descriptor.ignoreUnknownKeys(json)) {
             lexer.skipElement(configuration.isLenient)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -297,7 +297,8 @@ internal open class StreamingJsonDecoder(
             }
 
             if (isUnknown) { // slow-path for unknown keys handling
-                hasComma = handleUnknown(descriptor, key, extraKeysIndex)
+                handleUnknown(descriptor, key, extraKeysIndex)
+                hasComma = lexer.tryConsumeComma()
             }
         }
         if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()
@@ -309,7 +310,7 @@ internal open class StreamingJsonDecoder(
         return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
     }
 
-    private fun handleUnknown(descriptor: SerialDescriptor, key: String, extraKeysIndex: Int): Boolean {
+    private fun handleUnknown(descriptor: SerialDescriptor, key: String, extraKeysIndex: Int) {
         if (discriminatorHolder.trySkip(key)) {
             lexer.skipElement(configuration.isLenient)
         } else if (extraKeysIndex != -1) {
@@ -323,7 +324,6 @@ internal open class StreamingJsonDecoder(
             lexer.path.popDescriptor()
             lexer.failOnUnknownKey(key)
         }
-        return lexer.tryConsumeComma()
     }
 
     private fun decodeListIndex(): Int {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -48,6 +48,15 @@ internal open class StreamingJsonDecoder(
     private val configuration = json.configuration
 
     private val elementMarker: JsonElementMarker? = if (configuration.explicitNulls) null else JsonElementMarker(descriptor)
+    private val extraKeysMap = mutableMapOf<SerialDescriptor, LinkedHashMap<String, JsonElement>>()
+    private val extraKeysEmittedMap = mutableMapOf<SerialDescriptor, Boolean>()
+
+    private data class ExtraKeysFrame(
+        val descriptor: SerialDescriptor,
+        val map: LinkedHashMap<String, JsonElement>?,
+        val emitted: Boolean?
+    )
+    private val extraKeysSavedStack = mutableListOf<ExtraKeysFrame>()
 
     override fun decodeJsonElement(): JsonElement = JsonTreeReader(json.configuration, lexer).read()
 
@@ -113,6 +122,16 @@ internal open class StreamingJsonDecoder(
                 discriminatorHolder
             )
             else -> if (mode == newMode && json.configuration.explicitNulls) {
+                val extraKeysIndex = try {
+                    descriptor.jsonExtraKeysIndex(json)
+                } catch (_: ArrayIndexOutOfBoundsException) {
+                    -1
+                }
+                if (extraKeysIndex != -1) {
+                    val savedMap = try { extraKeysMap.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
+                    val savedEmitted = try { extraKeysEmittedMap.remove(descriptor) } catch (_: ArrayIndexOutOfBoundsException) { null }
+                    extraKeysSavedStack.add(ExtraKeysFrame(descriptor, savedMap, savedEmitted))
+                }
                 this
             } else {
                 StreamingJsonDecoder(json, newMode, lexer, descriptor, discriminatorHolder)
@@ -130,6 +149,22 @@ internal open class StreamingJsonDecoder(
         if (lexer.tryConsumeComma() && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma("")
         // First consume the object so we know it's correct
         lexer.consumeNextToken(mode.end)
+        // Restore saved extra keys state if it was saved due to decoder reuse
+        if (extraKeysSavedStack.isNotEmpty()) {
+            val last = extraKeysSavedStack.removeAt(extraKeysSavedStack.lastIndex)
+            if (last.descriptor == descriptor) {
+                if (last.map != null) {
+                    extraKeysMap[descriptor] = last.map
+                } else {
+                    extraKeysMap.remove(descriptor)
+                }
+                if (last.emitted != null) {
+                    extraKeysEmittedMap[descriptor] = last.emitted
+                } else {
+                    extraKeysEmittedMap.remove(descriptor)
+                }
+            }
+        }
         // Then cleanup the path
         lexer.path.popDescriptor()
     }
@@ -161,6 +196,11 @@ internal open class StreamingJsonDecoder(
         deserializer: DeserializationStrategy<T>,
         previousValue: T?
     ): T {
+        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        if (index == extraKeysIndex) {
+            val obj = JsonObject(extraKeysMap[descriptor].orEmpty())
+            return readJson(json, obj, deserializer)
+        }
         val isMapKey = mode == LexerMode.MAP && index and 1 == 0
         // Reset previous key
         if (isMapKey) {
@@ -222,6 +262,7 @@ internal open class StreamingJsonDecoder(
     )
 
     private fun decodeObjectIndex(descriptor: SerialDescriptor): Int {
+        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
         // hasComma checks are required to properly react on trailing commas
         var hasComma = lexer.tryConsumeComma()
         while (lexer.canConsumeValue()) { // TODO: consider merging comma consumption and this check
@@ -229,7 +270,7 @@ internal open class StreamingJsonDecoder(
             val key = decodeStringKey()
             lexer.consumeNextToken(COLON)
             val index = descriptor.getJsonNameIndex(json, key)
-            val isUnknown = if (index != UNKNOWN_NAME) {
+            val isUnknown = if (index != UNKNOWN_NAME && index != extraKeysIndex) {
                 if (configuration.coerceInputValues && coerceInputValue(descriptor, index)) {
                     hasComma = lexer.tryConsumeComma()
                     false // Known element, but coerced
@@ -238,20 +279,29 @@ internal open class StreamingJsonDecoder(
                     return index // Known element without coercing, return it
                 }
             } else {
-                true // unknown element
+                true // unknown element (or bucket's own key)
             }
 
             if (isUnknown) { // slow-path for unknown keys handling
-                hasComma = handleUnknown(descriptor, key)
+                hasComma = handleUnknown(descriptor, key, extraKeysIndex)
             }
         }
         if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()
 
+        if (extraKeysIndex != -1 && !extraKeysEmittedMap.getOrPut(descriptor) { false }) {
+            extraKeysEmittedMap[descriptor] = true
+            return extraKeysIndex
+        }
         return elementMarker?.nextUnmarkedIndex() ?: CompositeDecoder.DECODE_DONE
     }
 
-    private fun handleUnknown(descriptor: SerialDescriptor, key: String): Boolean {
-        if (descriptor.ignoreUnknownKeys(json) || discriminatorHolder.trySkip(key)) {
+    private fun handleUnknown(descriptor: SerialDescriptor, key: String, extraKeysIndex: Int): Boolean {
+        if (discriminatorHolder.trySkip(key)) {
+            lexer.skipElement(configuration.isLenient)
+        } else if (extraKeysIndex != -1) {
+            val collector = extraKeysMap.getOrPut(descriptor) { LinkedHashMap() }
+            collector[key] = JsonTreeReader(configuration, lexer).read()
+        } else if (descriptor.ignoreUnknownKeys(json)) {
             lexer.skipElement(configuration.isLenient)
         } else {
             // Since path is updated on key decoding, it ends with the key that was successfully decoded last,

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -68,7 +68,7 @@ internal class StreamingJsonEncoder(
     // element comes through encodeSerializableElement and written out as the
     // last members of the enclosing JSON object in endStructure. Because this
     // encoder instance is reused across same-mode nested structures
-    // (modeReuseCache), the state is saved/restored via a stack — but only for
+    // (modeReuseCache), the state is saved/restored via a stack, but only for
     // descriptors that actually declare a bucket, so bucket-free encoding pays
     // nothing beyond the extraKeysIndexFor check in beginStructure.
     private var pendingExtraKeys: Map<String, JsonElement>? = null
@@ -247,7 +247,7 @@ internal class StreamingJsonEncoder(
         // stashed here and spread as the last members of the enclosing object
         // in endStructure. The check lives here rather than in encodeElement
         // because a bucket is always a Map and can only arrive through this
-        // method — primitive properties never pay for it. The mode check
+        // method, so primitive properties never pay for it. The mode check
         // short-circuits map/list entries before the descriptor lookup.
         if (mode == LexerMode.OBJ && extraKeysIndexFor(descriptor) == index) {
             // Validation in JsonNamesMap guarantees the declared type is

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -45,6 +45,8 @@ internal class StreamingJsonEncoder(
     private var forceQuoting: Boolean = false
     private var polymorphicDiscriminator: String? = null
     private var polymorphicSerialName: String? = null
+    private var activeDiscriminator: String? = null
+    private val activeDiscriminatorStack = mutableListOf<String?>()
 
     init {
         val i = mode.ordinal
@@ -87,9 +89,15 @@ internal class StreamingJsonEncoder(
             composer.indent()
         }
 
+        if (mode == newMode) {
+            activeDiscriminatorStack.add(activeDiscriminator)
+            activeDiscriminator = null
+        }
+
         val discriminator = polymorphicDiscriminator
         if (discriminator != null) {
             encodeTypeInfo(discriminator, polymorphicSerialName ?: descriptor.serialName)
+            activeDiscriminator = discriminator
             polymorphicDiscriminator = null
             polymorphicSerialName = null
         }
@@ -98,7 +106,12 @@ internal class StreamingJsonEncoder(
             return this
         }
 
-        return modeReuseCache?.get(newMode.ordinal) ?: StreamingJsonEncoder(composer, json, newMode, modeReuseCache)
+        val cached = modeReuseCache?.get(newMode.ordinal)
+        if (cached != null) {
+            (cached as StreamingJsonEncoder).activeDiscriminator = null
+            return cached
+        }
+        return StreamingJsonEncoder(composer, json, newMode, modeReuseCache)
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {
@@ -106,6 +119,9 @@ internal class StreamingJsonEncoder(
             composer.unIndent()
             composer.nextItemIfNotFirst()
             composer.print(mode.end)
+        }
+        if (activeDiscriminatorStack.isNotEmpty()) {
+            activeDiscriminator = activeDiscriminatorStack.removeAt(activeDiscriminatorStack.lastIndex)
         }
     }
 
@@ -151,6 +167,44 @@ internal class StreamingJsonEncoder(
             }
         }
         return true
+    }
+
+    override fun <T> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T
+    ) {
+        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        if (extraKeysIndex == index) {
+            @Suppress("UNCHECKED_CAST")
+            val map = value as Map<String, JsonElement>
+            val declaredNames = descriptor.getJsonDecodingNames(json)
+            val discriminator = activeDiscriminator
+            for ((k, v) in map) {
+                if (k in declaredNames) {
+                    throw JsonEncodingException(
+                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                            "which conflicts with a declared property name.",
+                        classSerialName = descriptor.serialName
+                    )
+                }
+                if (k == discriminator) {
+                    throw JsonEncodingException(
+                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                            "which conflicts with the active class discriminator '$discriminator'.",
+                        classSerialName = descriptor.serialName
+                    )
+                }
+                if (!composer.writingFirst) composer.print(COMMA)
+                composer.nextItem()
+                encodeString(k)
+                composer.print(COLON); composer.space()
+                encodeJsonElement(v)
+            }
+            return
+        }
+        super.encodeSerializableElement(descriptor, index, serializer, value)
     }
 
     override fun <T : Any> encodeNullableSerializableElement(

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -54,6 +54,9 @@ internal class StreamingJsonEncoder(
     private var cachedExtraKeysIndex: Int = -1
 
     private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        // Flag check first: when the feature is disabled this is a single
+        // predictable branch, before any cache machinery is touched.
+        if (!configuration.useExtraKeys) return -1
         if (lookupDescriptor !== descriptor) {
             lookupDescriptor = descriptor
             cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -190,36 +190,39 @@ internal class StreamingJsonEncoder(
         serializer: SerializationStrategy<T>,
         value: T
     ) {
-        val extraKeysIndex = extraKeysIndexFor(descriptor)
-        if (extraKeysIndex == index) {
-            @Suppress("UNCHECKED_CAST")
-            val map = value as Map<String, JsonElement>
-            val declaredNames = descriptor.getJsonDecodingNames(json)
-            val discriminator = activeDiscriminator
-            for ((k, v) in map) {
-                if (k in declaredNames) {
-                    throw JsonEncodingException(
-                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                            "which conflicts with a declared property name.",
-                        classSerialName = descriptor.serialName
-                    )
-                }
-                if (k == discriminator) {
-                    throw JsonEncodingException(
-                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                            "which conflicts with the active class discriminator '$discriminator'.",
-                        classSerialName = descriptor.serialName
-                    )
-                }
-                if (!composer.writingFirst) composer.print(COMMA)
-                composer.nextItem()
-                encodeString(k)
-                composer.print(COLON); composer.space()
-                encodeJsonElement(v)
-            }
+        // Bucket-spread only applies in OBJ mode. The descriptor-validation in
+        // JsonNamesMap.kt already filters out non-class descriptors, but the
+        // explicit mode check documents intent and is robust to future
+        // loosening of that validation.
+        if (mode != WriteMode.OBJ || extraKeysIndexFor(descriptor) != index) {
+            super.encodeSerializableElement(descriptor, index, serializer, value)
             return
         }
-        super.encodeSerializableElement(descriptor, index, serializer, value)
+        @Suppress("UNCHECKED_CAST")
+        val map = value as Map<String, JsonElement>
+        val declaredNames = descriptor.getJsonDecodingNames(json)
+        val discriminator = activeDiscriminator
+        for ((k, v) in map) {
+            if (k in declaredNames) {
+                throw JsonEncodingException(
+                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                        "which conflicts with a declared property name.",
+                    classSerialName = descriptor.serialName
+                )
+            }
+            if (k == discriminator) {
+                throw JsonEncodingException(
+                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                        "which conflicts with the active class discriminator '$discriminator'.",
+                    classSerialName = descriptor.serialName
+                )
+            }
+            if (!composer.writingFirst) composer.print(COMMA)
+            composer.nextItem()
+            encodeString(k)
+            composer.print(COLON); composer.space()
+            encodeJsonElement(v)
+        }
     }
 
     override fun <T : Any> encodeNullableSerializableElement(

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -175,14 +175,14 @@ internal class StreamingJsonEncoder(
         } else {
             (modeReuseCache?.get(newMode.ordinal) ?: StreamingJsonEncoder(composer, json, newMode, modeReuseCache))
         }
-        if (newMode == WriteMode.OBJ && extraKeysIndexFor(descriptor) != -1) {
+        if (newMode == LexerMode.OBJ && extraKeysIndexFor(descriptor) != -1) {
             (result as StreamingJsonEncoder).pushExtraKeysFrame(discriminator)
         }
         return result
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {
-        if (mode == WriteMode.OBJ) {
+        if (mode == LexerMode.OBJ) {
             val bucketIndex = extraKeysIndexFor(descriptor)
             if (bucketIndex != -1) flushExtraKeys(descriptor, bucketIndex)
         }
@@ -249,7 +249,7 @@ internal class StreamingJsonEncoder(
         // because a bucket is always a Map and can only arrive through this
         // method — primitive properties never pay for it. The mode check
         // short-circuits map/list entries before the descriptor lookup.
-        if (mode == WriteMode.OBJ && extraKeysIndexFor(descriptor) == index) {
+        if (mode == LexerMode.OBJ && extraKeysIndexFor(descriptor) == index) {
             // Validation in JsonNamesMap guarantees the declared type is
             // JsonObject or Map<String, JsonElement>.
             @Suppress("UNCHECKED_CAST")
@@ -265,7 +265,7 @@ internal class StreamingJsonEncoder(
         serializer: SerializationStrategy<T>,
         value: T?
     ) {
-        if (mode == WriteMode.OBJ && extraKeysIndexFor(descriptor) == index) {
+        if (mode == LexerMode.OBJ && extraKeysIndexFor(descriptor) == index) {
             @Suppress("UNCHECKED_CAST")
             pendingExtraKeys = value as Map<String, JsonElement>?
             return

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -45,8 +45,6 @@ internal class StreamingJsonEncoder(
     private var forceQuoting: Boolean = false
     private var polymorphicDiscriminator: String? = null
     private var polymorphicSerialName: String? = null
-    private var activeDiscriminator: String? = null
-    private val activeDiscriminatorStack = mutableListOf<String?>()
 
     // Cache of the @JsonExtraKeys index for the most recently queried descriptor.
     // The sentinel `lookupDescriptor !== descriptor` triggers a refresh when the
@@ -61,6 +59,64 @@ internal class StreamingJsonEncoder(
             cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)
         }
         return cachedExtraKeysIndex
+    }
+
+    // State for @JsonExtraKeys write-back. The bucket value is stashed when its
+    // element comes through encodeSerializableElement and written out as the
+    // last members of the enclosing JSON object in endStructure. Because this
+    // encoder instance is reused across same-mode nested structures
+    // (modeReuseCache), the state is saved/restored via a stack — but only for
+    // descriptors that actually declare a bucket, so bucket-free encoding pays
+    // nothing beyond the extraKeysIndexFor check in beginStructure.
+    private var pendingExtraKeys: Map<String, JsonElement>? = null
+    private var pendingDiscriminator: String? = null
+
+    private class ExtraKeysFrame(val extras: Map<String, JsonElement>?, val discriminator: String?)
+
+    private var extraKeysStack: MutableList<ExtraKeysFrame>? = null
+
+    private fun pushExtraKeysFrame(discriminator: String?) {
+        val stack = extraKeysStack ?: mutableListOf<ExtraKeysFrame>().also { extraKeysStack = it }
+        stack.add(ExtraKeysFrame(pendingExtraKeys, pendingDiscriminator))
+        pendingExtraKeys = null
+        pendingDiscriminator = discriminator
+    }
+
+    private fun flushExtraKeys(descriptor: SerialDescriptor, bucketIndex: Int) {
+        val extras = pendingExtraKeys
+        if (extras != null && extras.isNotEmpty()) {
+            val collisionNames = descriptor.jsonExtraKeysCollisionNames(json, bucketIndex)
+            for ((key, element) in extras) {
+                validateNoExtraKeyCollision(descriptor, key, collisionNames)
+                if (!composer.writingFirst) composer.print(COMMA)
+                composer.nextItem()
+                encodeString(key)
+                composer.print(COLON)
+                composer.space()
+                encodeSerializableValue(JsonElementSerializer, element)
+            }
+        }
+        val stack = extraKeysStack!!
+        val frame = stack.removeAt(stack.lastIndex)
+        pendingExtraKeys = frame.extras
+        pendingDiscriminator = frame.discriminator
+    }
+
+    private fun validateNoExtraKeyCollision(descriptor: SerialDescriptor, key: String, collisionNames: Set<String>) {
+        if (key in collisionNames) {
+            throw JsonEncodingException(
+                "@JsonExtraKeys property of '${descriptor.serialName}' contains key '$key' " +
+                    "which conflicts with a declared property name.",
+                classSerialName = descriptor.serialName
+            )
+        }
+        if (key == pendingDiscriminator) {
+            throw JsonEncodingException(
+                "@JsonExtraKeys property of '${descriptor.serialName}' contains key '$key' " +
+                    "which conflicts with the class discriminator.",
+                classSerialName = descriptor.serialName
+            )
+        }
     }
 
     init {
@@ -104,39 +160,33 @@ internal class StreamingJsonEncoder(
             composer.indent()
         }
 
-        if (mode == newMode) {
-            activeDiscriminatorStack.add(activeDiscriminator)
-            activeDiscriminator = null
-        }
-
         val discriminator = polymorphicDiscriminator
         if (discriminator != null) {
             encodeTypeInfo(discriminator, polymorphicSerialName ?: descriptor.serialName)
-            activeDiscriminator = discriminator
             polymorphicDiscriminator = null
             polymorphicSerialName = null
         }
 
-        if (mode == newMode) {
-            return this
+        val result = if (mode == newMode) {
+            this
+        } else {
+            (modeReuseCache?.get(newMode.ordinal) ?: StreamingJsonEncoder(composer, json, newMode, modeReuseCache))
         }
-
-        val cached = modeReuseCache?.get(newMode.ordinal)
-        if (cached != null) {
-            (cached as StreamingJsonEncoder).activeDiscriminator = null
-            return cached
+        if (newMode == WriteMode.OBJ && extraKeysIndexFor(descriptor) != -1) {
+            (result as StreamingJsonEncoder).pushExtraKeysFrame(discriminator)
         }
-        return StreamingJsonEncoder(composer, json, newMode, modeReuseCache)
+        return result
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {
+        if (mode == WriteMode.OBJ) {
+            val bucketIndex = extraKeysIndexFor(descriptor)
+            if (bucketIndex != -1) flushExtraKeys(descriptor, bucketIndex)
+        }
         if (mode.end != INVALID) {
             composer.unIndent()
             composer.nextItemIfNotFirst()
             composer.print(mode.end)
-        }
-        if (activeDiscriminatorStack.isNotEmpty()) {
-            activeDiscriminator = activeDiscriminatorStack.removeAt(activeDiscriminatorStack.lastIndex)
         }
     }
 
@@ -190,22 +240,20 @@ internal class StreamingJsonEncoder(
         serializer: SerializationStrategy<T>,
         value: T
     ) {
-        // Bucket-spread only applies in OBJ mode. The descriptor-validation in
-        // JsonNamesMap.kt already filters out non-class descriptors, but the
-        // explicit mode check documents intent and is robust to future
-        // loosening of that validation.
-        if (mode != WriteMode.OBJ || extraKeysIndexFor(descriptor) != index) {
-            super.encodeSerializableElement(descriptor, index, serializer, value)
+        // The @JsonExtraKeys bucket is not written as a regular property: it is
+        // stashed here and spread as the last members of the enclosing object
+        // in endStructure. The check lives here rather than in encodeElement
+        // because a bucket is always a Map and can only arrive through this
+        // method — primitive properties never pay for it. The mode check
+        // short-circuits map/list entries before the descriptor lookup.
+        if (mode == WriteMode.OBJ && extraKeysIndexFor(descriptor) == index) {
+            // Validation in JsonNamesMap guarantees the declared type is
+            // JsonObject or Map<String, JsonElement>.
+            @Suppress("UNCHECKED_CAST")
+            pendingExtraKeys = value as Map<String, JsonElement>
             return
         }
-        // Drive the user's MapSerializer through a wrapper that intercepts the
-        // alternating key/value calls and emits each entry as a sibling pair of
-        // the parent JSON object. This works for arbitrary V: the wrapper
-        // delegates value-encoding to the parent encoder via encodeSerializableValue,
-        // which preserves polymorphic-discriminator routing and the JsonElement
-        // short-circuit.
-        val wrapper = JsonExtraKeysSpreadingEncoder(this, composer, descriptor, activeDiscriminator, json)
-        serializer.serialize(wrapper, value)
+        super.encodeSerializableElement(descriptor, index, serializer, value)
     }
 
     override fun <T : Any> encodeNullableSerializableElement(
@@ -214,6 +262,11 @@ internal class StreamingJsonEncoder(
         serializer: SerializationStrategy<T>,
         value: T?
     ) {
+        if (mode == WriteMode.OBJ && extraKeysIndexFor(descriptor) == index) {
+            @Suppress("UNCHECKED_CAST")
+            pendingExtraKeys = value as Map<String, JsonElement>?
+            return
+        }
         if (value != null || configuration.explicitNulls) {
             super.encodeNullableSerializableElement(descriptor, index, serializer, value)
         }
@@ -283,71 +336,5 @@ internal class StreamingJsonEncoder(
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
         encodeString(enumDescriptor.getElementName(index))
-    }
-}
-
-/**
- * Encoder driven by the user's `MapSerializer<String, V>` to spread bucket
- * entries as sibling key/value pairs of the parent JSON object.
- *
- * Extends [AbstractEncoder] so unexpected primitive calls fail loud via the
- * default `encodeValue` (a non-standard custom map serializer that doesn't
- * follow the alternating key/value protocol is unsupported by design).
- */
-@OptIn(ExperimentalSerializationApi::class)
-private class JsonExtraKeysSpreadingEncoder(
-    private val parent: StreamingJsonEncoder,
-    private val composer: Composer,
-    private val parentDescriptor: SerialDescriptor,
-    private val activeDiscriminator: String?,
-    private val json: Json,
-) : AbstractEncoder() {
-
-    override val serializersModule: SerializersModule get() = parent.serializersModule
-
-    private var pendingKey: String? = null
-    private val declaredNames: Set<String> = parentDescriptor.getJsonDecodingNames(json)
-
-    override fun <T> encodeSerializableElement(
-        descriptor: SerialDescriptor,
-        index: Int,
-        serializer: SerializationStrategy<T>,
-        value: T
-    ) {
-        if (index % 2 == 0) {
-            // Even index = key. Validation in JsonNamesMap guarantees the key
-            // serializer is exactly String.serializer(), so the runtime type
-            // is String.
-            pendingKey = value as String
-        } else {
-            val k = pendingKey!!
-            validateNoCollision(k)
-            if (!composer.writingFirst) composer.print(COMMA)
-            composer.nextItem()
-            parent.encodeString(k)
-            composer.print(COLON); composer.space()
-            // Route value-encoding through the parent's encodeSerializableValue
-            // so polymorphic-discriminator setup and the JsonElement short-circuit
-            // both apply.
-            parent.encodeSerializableValue(serializer, value)
-            pendingKey = null
-        }
-    }
-
-    private fun validateNoCollision(k: String) {
-        if (k in declaredNames) {
-            throw JsonEncodingException(
-                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
-                    "which conflicts with a declared property name.",
-                classSerialName = parentDescriptor.serialName
-            )
-        }
-        if (k == activeDiscriminator) {
-            throw JsonEncodingException(
-                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
-                    "which conflicts with the active class discriminator '$activeDiscriminator'.",
-                classSerialName = parentDescriptor.serialName
-            )
-        }
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -48,6 +48,21 @@ internal class StreamingJsonEncoder(
     private var activeDiscriminator: String? = null
     private val activeDiscriminatorStack = mutableListOf<String?>()
 
+    // Cache of the @JsonExtraKeys index for the most recently queried descriptor.
+    // The sentinel `lookupDescriptor !== descriptor` triggers a refresh when the
+    // descriptor changes. This avoids hitting the per-Json schema cache on every
+    // encoded element.
+    private var lookupDescriptor: SerialDescriptor? = null
+    private var cachedExtraKeysIndex: Int = -1
+
+    private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        if (lookupDescriptor !== descriptor) {
+            lookupDescriptor = descriptor
+            cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        }
+        return cachedExtraKeysIndex
+    }
+
     init {
         val i = mode.ordinal
         if (modeReuseCache != null) {
@@ -175,7 +190,7 @@ internal class StreamingJsonEncoder(
         serializer: SerializationStrategy<T>,
         value: T
     ) {
-        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        val extraKeysIndex = extraKeysIndexFor(descriptor)
         if (extraKeysIndex == index) {
             @Suppress("UNCHECKED_CAST")
             val map = value as Map<String, JsonElement>

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -198,31 +198,14 @@ internal class StreamingJsonEncoder(
             super.encodeSerializableElement(descriptor, index, serializer, value)
             return
         }
-        @Suppress("UNCHECKED_CAST")
-        val map = value as Map<String, JsonElement>
-        val declaredNames = descriptor.getJsonDecodingNames(json)
-        val discriminator = activeDiscriminator
-        for ((k, v) in map) {
-            if (k in declaredNames) {
-                throw JsonEncodingException(
-                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                        "which conflicts with a declared property name.",
-                    classSerialName = descriptor.serialName
-                )
-            }
-            if (k == discriminator) {
-                throw JsonEncodingException(
-                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                        "which conflicts with the active class discriminator '$discriminator'.",
-                    classSerialName = descriptor.serialName
-                )
-            }
-            if (!composer.writingFirst) composer.print(COMMA)
-            composer.nextItem()
-            encodeString(k)
-            composer.print(COLON); composer.space()
-            encodeJsonElement(v)
-        }
+        // Drive the user's MapSerializer through a wrapper that intercepts the
+        // alternating key/value calls and emits each entry as a sibling pair of
+        // the parent JSON object. This works for arbitrary V: the wrapper
+        // delegates value-encoding to the parent encoder via encodeSerializableValue,
+        // which preserves polymorphic-discriminator routing and the JsonElement
+        // short-circuit.
+        val wrapper = JsonExtraKeysSpreadingEncoder(this, composer, descriptor, activeDiscriminator, json)
+        serializer.serialize(wrapper, value)
     }
 
     override fun <T : Any> encodeNullableSerializableElement(
@@ -300,5 +283,71 @@ internal class StreamingJsonEncoder(
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
         encodeString(enumDescriptor.getElementName(index))
+    }
+}
+
+/**
+ * Encoder driven by the user's `MapSerializer<String, V>` to spread bucket
+ * entries as sibling key/value pairs of the parent JSON object.
+ *
+ * Extends [AbstractEncoder] so unexpected primitive calls fail loud via the
+ * default `encodeValue` (a non-standard custom map serializer that doesn't
+ * follow the alternating key/value protocol is unsupported by design).
+ */
+@OptIn(ExperimentalSerializationApi::class)
+private class JsonExtraKeysSpreadingEncoder(
+    private val parent: StreamingJsonEncoder,
+    private val composer: Composer,
+    private val parentDescriptor: SerialDescriptor,
+    private val activeDiscriminator: String?,
+    private val json: Json,
+) : AbstractEncoder() {
+
+    override val serializersModule: SerializersModule get() = parent.serializersModule
+
+    private var pendingKey: String? = null
+    private val declaredNames: Set<String> = parentDescriptor.getJsonDecodingNames(json)
+
+    override fun <T> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T
+    ) {
+        if (index % 2 == 0) {
+            // Even index = key. Validation in JsonNamesMap guarantees the key
+            // serializer is exactly String.serializer(), so the runtime type
+            // is String.
+            pendingKey = value as String
+        } else {
+            val k = pendingKey!!
+            validateNoCollision(k)
+            if (!composer.writingFirst) composer.print(COMMA)
+            composer.nextItem()
+            parent.encodeString(k)
+            composer.print(COLON); composer.space()
+            // Route value-encoding through the parent's encodeSerializableValue
+            // so polymorphic-discriminator setup and the JsonElement short-circuit
+            // both apply.
+            parent.encodeSerializableValue(serializer, value)
+            pendingKey = null
+        }
+    }
+
+    private fun validateNoCollision(k: String) {
+        if (k in declaredNames) {
+            throw JsonEncodingException(
+                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
+                    "which conflicts with a declared property name.",
+                classSerialName = parentDescriptor.serialName
+            )
+        }
+        if (k == activeDiscriminator) {
+            throw JsonEncodingException(
+                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
+                    "which conflicts with the active class discriminator '$activeDiscriminator'.",
+                classSerialName = parentDescriptor.serialName
+            )
+        }
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -213,12 +213,17 @@ private open class JsonTreeDecoder(
     private var currentDescriptor: SerialDescriptor? = null
     private var extraKeysIndex: Int = -1
     private var extraKeysEmitted: Boolean = false
+    // Built once in decodeElementIndex; read back by currentElement. Null when no bucket is emitted.
+    private var capturedExtras: JsonObject? = null
+    private var bucketTagName: String? = null
 
     private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
         if (currentDescriptor !== descriptor) {
             currentDescriptor = descriptor
             extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
             extraKeysEmitted = false
+            capturedExtras = null
+            bucketTagName = null
         }
         return extraKeysIndex
     }
@@ -253,9 +258,30 @@ private open class JsonTreeDecoder(
         }
         if (bucketIndex != -1 && !extraKeysEmitted) {
             extraKeysEmitted = true
+            val captured = computeCapturedExtras(descriptor, bucketIndex)
+            // When optional and nothing captured, skip the emit so the property keeps its declared default.
+            if (captured == null && descriptor.isElementOptional(bucketIndex)) {
+                return CompositeDecoder.DECODE_DONE
+            }
+            capturedExtras = JsonObject(captured ?: emptyMap())
+            bucketTagName = descriptor.getJsonElementName(json, bucketIndex)
             return bucketIndex
         }
         return CompositeDecoder.DECODE_DONE
+    }
+
+    private fun computeCapturedExtras(
+        descriptor: SerialDescriptor,
+        bucketIndex: Int
+    ): LinkedHashMap<String, JsonElement>? {
+        var captured: LinkedHashMap<String, JsonElement>? = null
+        for ((k, v) in value) {
+            val nameIndex = descriptor.getJsonNameIndex(json, k)
+            if ((nameIndex == CompositeDecoder.UNKNOWN_NAME || nameIndex == bucketIndex) && k != polymorphicDiscriminator) {
+                (captured ?: LinkedHashMap<String, JsonElement>().also { captured = it })[k] = v
+            }
+        }
+        return captured
     }
 
     private fun setForceNull(descriptor: SerialDescriptor, index: Int): Boolean {
@@ -293,16 +319,9 @@ private open class JsonTreeDecoder(
     }
 
     override fun currentElement(tag: String): JsonElement {
-        val descriptor = currentDescriptor
-        if (descriptor != null && extraKeysIndex != -1 && tag == descriptor.getJsonElementName(json, extraKeysIndex)) {
-            val captured = LinkedHashMap<String, JsonElement>()
-            for ((k, v) in value) {
-                val index = descriptor.getJsonNameIndex(json, k)
-                if ((index == CompositeDecoder.UNKNOWN_NAME || index == extraKeysIndex) && k != polymorphicDiscriminator) {
-                    captured[k] = v
-                }
-            }
-            return JsonObject(captured)
+        val cached = capturedExtras
+        if (cached != null && tag == bucketTagName) {
+            return cached
         }
         return value.getValue(tag)
     }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -214,16 +214,21 @@ private open class JsonTreeDecoder(
     private var extraKeysIndex: Int = -1
     private var extraKeysEmitted: Boolean = false
 
-    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+    private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
         if (currentDescriptor !== descriptor) {
             currentDescriptor = descriptor
             extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
             extraKeysEmitted = false
         }
+        return extraKeysIndex
+    }
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        val bucketIndex = extraKeysIndexFor(descriptor)
         while (position < descriptor.elementsCount) {
             val name = descriptor.getTag(position++)
             val index = position - 1
-            if (index == extraKeysIndex) {
+            if (index == bucketIndex) {
                 continue
             }
             forceNull = false
@@ -246,9 +251,9 @@ private open class JsonTreeDecoder(
                 return index
             }
         }
-        if (extraKeysIndex != -1 && !extraKeysEmitted) {
+        if (bucketIndex != -1 && !extraKeysEmitted) {
             extraKeysEmitted = true
-            return extraKeysIndex
+            return bucketIndex
         }
         return CompositeDecoder.DECODE_DONE
     }
@@ -317,7 +322,7 @@ private open class JsonTreeDecoder(
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {
-        if (descriptor.ignoreUnknownKeys(json) || descriptor.kind is PolymorphicKind || descriptor.jsonExtraKeysIndex(json) != -1) return
+        if (descriptor.ignoreUnknownKeys(json) || descriptor.kind is PolymorphicKind || extraKeysIndexFor(descriptor) != -1) return
         // Validate keys
         val strategy = descriptor.namingStrategy(json)
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -218,6 +218,9 @@ private open class JsonTreeDecoder(
     private var bucketTagName: String? = null
 
     private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        // Flag check first: when the feature is disabled this is a single
+        // predictable branch, before any cache machinery is touched.
+        if (!configuration.useExtraKeys) return -1
         if (currentDescriptor !== descriptor) {
             currentDescriptor = descriptor
             extraKeysIndex = descriptor.jsonExtraKeysIndex(json)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -210,11 +210,22 @@ private open class JsonTreeDecoder(
 ) : AbstractJsonTreeDecoder(json, value, polymorphicDiscriminator) {
     private var position = 0
     private var forceNull: Boolean = false
+    private var currentDescriptor: SerialDescriptor? = null
+    private var extraKeysIndex: Int = -1
+    private var extraKeysEmitted: Boolean = false
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        if (currentDescriptor !== descriptor) {
+            currentDescriptor = descriptor
+            extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+            extraKeysEmitted = false
+        }
         while (position < descriptor.elementsCount) {
             val name = descriptor.getTag(position++)
             val index = position - 1
+            if (index == extraKeysIndex) {
+                continue
+            }
             forceNull = false
 
             if (name in value || setForceNull(descriptor, index)) {
@@ -234,6 +245,10 @@ private open class JsonTreeDecoder(
 
                 return index
             }
+        }
+        if (extraKeysIndex != -1 && !extraKeysEmitted) {
+            extraKeysEmitted = true
+            return extraKeysIndex
         }
         return CompositeDecoder.DECODE_DONE
     }
@@ -272,7 +287,20 @@ private open class JsonTreeDecoder(
         return fallbackName ?: baseName
     }
 
-    override fun currentElement(tag: String): JsonElement = value.getValue(tag)
+    override fun currentElement(tag: String): JsonElement {
+        val descriptor = currentDescriptor
+        if (descriptor != null && extraKeysIndex != -1 && tag == descriptor.getJsonElementName(json, extraKeysIndex)) {
+            val captured = LinkedHashMap<String, JsonElement>()
+            for ((k, v) in value) {
+                val index = descriptor.getJsonNameIndex(json, k)
+                if ((index == CompositeDecoder.UNKNOWN_NAME || index == extraKeysIndex) && k != polymorphicDiscriminator) {
+                    captured[k] = v
+                }
+            }
+            return JsonObject(captured)
+        }
+        return value.getValue(tag)
+    }
 
     fun currentElementOrNull(tag: String): JsonElement? = value[tag]
 
@@ -289,7 +317,7 @@ private open class JsonTreeDecoder(
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {
-        if (descriptor.ignoreUnknownKeys(json) || descriptor.kind is PolymorphicKind) return
+        if (descriptor.ignoreUnknownKeys(json) || descriptor.kind is PolymorphicKind || descriptor.jsonExtraKeysIndex(json) != -1) return
         // Validate keys
         val strategy = descriptor.namingStrategy(json)
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -35,6 +35,9 @@ private sealed class AbstractJsonTreeEncoder(
 
     private var polymorphicDiscriminator: String? = null
     private var polymorphicSerialName: String? = null
+
+    // The discriminator written into this encoder's object, if any. Used by
+    // @JsonExtraKeys write-back to detect key collisions with the discriminator.
     internal var activeDiscriminator: String? = null
 
     override fun elementName(descriptor: SerialDescriptor, index: Int): String =
@@ -233,12 +236,23 @@ private open class JsonTreeEncoder(
         content[key] = element
     }
 
+    // State for @JsonExtraKeys write-back. Unlike the streaming encoder, a tree
+    // encoder instance corresponds to exactly one JSON object, so no
+    // save/restore stack is needed.
+    private var pendingExtraKeys: Map<String, JsonElement>? = null
+    private var pendingBucketDescriptor: SerialDescriptor? = null
+
     override fun <T : Any> encodeNullableSerializableElement(
         descriptor: SerialDescriptor,
         index: Int,
         serializer: SerializationStrategy<T>,
         value: T?
     ) {
+        if (isExtraKeysBucket(descriptor, index)) {
+            @Suppress("UNCHECKED_CAST")
+            stashExtraKeys(descriptor, value as Map<String, JsonElement>?)
+            return
+        }
         if (value != null || configuration.explicitNulls) {
             super.encodeNullableSerializableElement(descriptor, index, serializer, value)
         }
@@ -250,76 +264,52 @@ private open class JsonTreeEncoder(
         serializer: SerializationStrategy<T>,
         value: T
     ) {
-        // Bucket-spread only applies in CLASS mode. The descriptor-validation
-        // in JsonNamesMap.kt already filters out non-class descriptors, but
-        // the explicit kind check documents intent and is robust to future
-        // loosening of that validation. The check also stops the override
-        // firing for JsonTreeMapEncoder, which inherits this method.
-        if (descriptor.kind != StructureKind.CLASS || extraKeysIndexFor(descriptor) != index) {
-            super.encodeSerializableElement(descriptor, index, serializer, value)
+        if (isExtraKeysBucket(descriptor, index)) {
+            @Suppress("UNCHECKED_CAST")
+            stashExtraKeys(descriptor, value as Map<String, JsonElement>)
             return
         }
-        // Drive the user's MapSerializer through a wrapper that converts each
-        // value to a JsonElement via writeJson and merges it into this tree
-        // encoder's content map. Works for arbitrary V.
-        val wrapper = JsonExtraKeysSpreadingTreeEncoder(this, descriptor, activeDiscriminator, json)
-        serializer.serialize(wrapper, value)
+        super.encodeSerializableElement(descriptor, index, serializer, value)
     }
 
-    override fun getCurrent(): JsonElement = JsonObject(content)
-}
+    // The @JsonExtraKeys bucket is not written as a regular property: it is
+    // stashed and spread as the last members of this object in getCurrent().
+    // The kind check stops the stash firing for JsonTreeMapEncoder, which
+    // inherits these methods.
+    private fun isExtraKeysBucket(descriptor: SerialDescriptor, index: Int): Boolean =
+        descriptor.kind == StructureKind.CLASS && extraKeysIndexFor(descriptor) == index
 
-/**
- * Tree-encoder counterpart to [JsonExtraKeysSpreadingEncoder]. Each entry's
- * value is materialised to a [JsonElement] via [writeJson] and stored under
- * the captured key on the parent tree encoder.
- */
-private class JsonExtraKeysSpreadingTreeEncoder(
-    private val treeEncoder: JsonTreeEncoder,
-    private val parentDescriptor: SerialDescriptor,
-    private val activeDiscriminator: String?,
-    private val json: Json,
-) : AbstractEncoder() {
-
-    override val serializersModule: SerializersModule get() = json.serializersModule
-
-    private var pendingKey: String? = null
-    private val declaredNames: Set<String> = parentDescriptor.getJsonDecodingNames(json)
-
-    override fun <T> encodeSerializableElement(
-        descriptor: SerialDescriptor,
-        index: Int,
-        serializer: SerializationStrategy<T>,
-        value: T
-    ) {
-        if (index % 2 == 0) {
-            // Even index = key. Validation in JsonNamesMap guarantees the key
-            // serializer is exactly String.serializer(), so the runtime type
-            // is String.
-            pendingKey = value as String
-        } else {
-            val k = pendingKey!!
-            validateNoCollision(k)
-            treeEncoder.putElement(k, writeJson(json, value, serializer))
-            pendingKey = null
-        }
+    private fun stashExtraKeys(descriptor: SerialDescriptor, extras: Map<String, JsonElement>?) {
+        pendingExtraKeys = extras
+        pendingBucketDescriptor = descriptor
     }
 
-    private fun validateNoCollision(k: String) {
-        if (k in declaredNames) {
-            throw JsonEncodingException(
-                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
-                    "which conflicts with a declared property name.",
-                classSerialName = parentDescriptor.serialName
-            )
+    override fun getCurrent(): JsonElement {
+        val extras = pendingExtraKeys
+        val descriptor = pendingBucketDescriptor
+        if (extras != null && descriptor != null) {
+            pendingExtraKeys = null
+            pendingBucketDescriptor = null
+            val collisionNames = descriptor.jsonExtraKeysCollisionNames(json, extraKeysIndexFor(descriptor))
+            for ((key, element) in extras) {
+                if (key in collisionNames) {
+                    throw JsonEncodingException(
+                        "@JsonExtraKeys property of '${descriptor.serialName}' contains key '$key' " +
+                            "which conflicts with a declared property name.",
+                        classSerialName = descriptor.serialName
+                    )
+                }
+                if (key == activeDiscriminator) {
+                    throw JsonEncodingException(
+                        "@JsonExtraKeys property of '${descriptor.serialName}' contains key '$key' " +
+                            "which conflicts with the class discriminator.",
+                        classSerialName = descriptor.serialName
+                    )
+                }
+                content[key] = element
+            }
         }
-        if (k == activeDiscriminator) {
-            throw JsonEncodingException(
-                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
-                    "which conflicts with the active class discriminator '$activeDiscriminator'.",
-                classSerialName = parentDescriptor.serialName
-            )
-        }
+        return JsonObject(content)
     }
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -225,6 +225,9 @@ private open class JsonTreeEncoder(
     private var cachedExtraKeysIndex: Int = -1
 
     private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        // Flag check first: when the feature is disabled this is a single
+        // predictable branch, before any cache machinery is touched.
+        if (!configuration.useExtraKeys) return -1
         if (lookupDescriptor !== descriptor) {
             lookupDescriptor = descriptor
             cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -35,6 +35,7 @@ private sealed class AbstractJsonTreeEncoder(
 
     private var polymorphicDiscriminator: String? = null
     private var polymorphicSerialName: String? = null
+    internal var activeDiscriminator: String? = null
 
     override fun elementName(descriptor: SerialDescriptor, index: Int): String =
         descriptor.getJsonElementName(json, index)
@@ -168,6 +169,7 @@ private sealed class AbstractJsonTreeEncoder(
             } else {
                 encoder.putElement(discriminator, JsonPrimitive(polymorphicSerialName ?: descriptor.serialName))
             }
+            encoder.activeDiscriminator = discriminator
             polymorphicDiscriminator = null
             polymorphicSerialName = null
         }
@@ -225,6 +227,40 @@ private open class JsonTreeEncoder(
         if (value != null || configuration.explicitNulls) {
             super.encodeNullableSerializableElement(descriptor, index, serializer, value)
         }
+    }
+
+    override fun <T> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T
+    ) {
+        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        if (extraKeysIndex == index) {
+            @Suppress("UNCHECKED_CAST")
+            val map = value as Map<String, JsonElement>
+            val declaredNames = descriptor.getJsonDecodingNames(json)
+            val discriminator = activeDiscriminator
+            for ((k, v) in map) {
+                if (k in declaredNames) {
+                    throw JsonEncodingException(
+                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                            "which conflicts with a declared property name.",
+                        classSerialName = descriptor.serialName
+                    )
+                }
+                if (k == discriminator) {
+                    throw JsonEncodingException(
+                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                            "which conflicts with the active class discriminator '$discriminator'.",
+                        classSerialName = descriptor.serialName
+                    )
+                }
+                putElement(k, v)
+            }
+            return
+        }
+        super.encodeSerializableElement(descriptor, index, serializer, value)
     }
 
     override fun getCurrent(): JsonElement = JsonObject(content)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -214,6 +214,21 @@ private open class JsonTreeEncoder(
 
     protected val content: MutableMap<String, JsonElement> = linkedMapOf()
 
+    // Cache of the @JsonExtraKeys index for the most recently queried descriptor.
+    // The sentinel `lookupDescriptor !== descriptor` triggers a refresh when the
+    // descriptor changes. Avoids hitting the per-Json schema cache on every
+    // encoded element.
+    private var lookupDescriptor: SerialDescriptor? = null
+    private var cachedExtraKeysIndex: Int = -1
+
+    private fun extraKeysIndexFor(descriptor: SerialDescriptor): Int {
+        if (lookupDescriptor !== descriptor) {
+            lookupDescriptor = descriptor
+            cachedExtraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        }
+        return cachedExtraKeysIndex
+    }
+
     override fun putElement(key: String, element: JsonElement) {
         content[key] = element
     }
@@ -235,7 +250,7 @@ private open class JsonTreeEncoder(
         serializer: SerializationStrategy<T>,
         value: T
     ) {
-        val extraKeysIndex = descriptor.jsonExtraKeysIndex(json)
+        val extraKeysIndex = extraKeysIndexFor(descriptor)
         if (extraKeysIndex == index) {
             @Suppress("UNCHECKED_CAST")
             val map = value as Map<String, JsonElement>

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -259,30 +259,68 @@ private open class JsonTreeEncoder(
             super.encodeSerializableElement(descriptor, index, serializer, value)
             return
         }
-        @Suppress("UNCHECKED_CAST")
-        val map = value as Map<String, JsonElement>
-        val declaredNames = descriptor.getJsonDecodingNames(json)
-        val discriminator = activeDiscriminator
-        for ((k, v) in map) {
-            if (k in declaredNames) {
-                throw JsonEncodingException(
-                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                        "which conflicts with a declared property name.",
-                    classSerialName = descriptor.serialName
-                )
-            }
-            if (k == discriminator) {
-                throw JsonEncodingException(
-                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                        "which conflicts with the active class discriminator '$discriminator'.",
-                    classSerialName = descriptor.serialName
-                )
-            }
-            putElement(k, v)
-        }
+        // Drive the user's MapSerializer through a wrapper that converts each
+        // value to a JsonElement via writeJson and merges it into this tree
+        // encoder's content map. Works for arbitrary V.
+        val wrapper = JsonExtraKeysSpreadingTreeEncoder(this, descriptor, activeDiscriminator, json)
+        serializer.serialize(wrapper, value)
     }
 
     override fun getCurrent(): JsonElement = JsonObject(content)
+}
+
+/**
+ * Tree-encoder counterpart to [JsonExtraKeysSpreadingEncoder]. Each entry's
+ * value is materialised to a [JsonElement] via [writeJson] and stored under
+ * the captured key on the parent tree encoder.
+ */
+private class JsonExtraKeysSpreadingTreeEncoder(
+    private val treeEncoder: JsonTreeEncoder,
+    private val parentDescriptor: SerialDescriptor,
+    private val activeDiscriminator: String?,
+    private val json: Json,
+) : AbstractEncoder() {
+
+    override val serializersModule: SerializersModule get() = json.serializersModule
+
+    private var pendingKey: String? = null
+    private val declaredNames: Set<String> = parentDescriptor.getJsonDecodingNames(json)
+
+    override fun <T> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T
+    ) {
+        if (index % 2 == 0) {
+            // Even index = key. Validation in JsonNamesMap guarantees the key
+            // serializer is exactly String.serializer(), so the runtime type
+            // is String.
+            pendingKey = value as String
+        } else {
+            val k = pendingKey!!
+            validateNoCollision(k)
+            treeEncoder.putElement(k, writeJson(json, value, serializer))
+            pendingKey = null
+        }
+    }
+
+    private fun validateNoCollision(k: String) {
+        if (k in declaredNames) {
+            throw JsonEncodingException(
+                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
+                    "which conflicts with a declared property name.",
+                classSerialName = parentDescriptor.serialName
+            )
+        }
+        if (k == activeDiscriminator) {
+            throw JsonEncodingException(
+                "@JsonExtraKeys map in '${parentDescriptor.serialName}' contains key '$k' " +
+                    "which conflicts with the active class discriminator '$activeDiscriminator'.",
+                classSerialName = parentDescriptor.serialName
+            )
+        }
+    }
 }
 
 private class JsonTreeMapEncoder(json: Json, nodeConsumer: (JsonElement) -> Unit) : JsonTreeEncoder(json, nodeConsumer) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -250,32 +250,36 @@ private open class JsonTreeEncoder(
         serializer: SerializationStrategy<T>,
         value: T
     ) {
-        val extraKeysIndex = extraKeysIndexFor(descriptor)
-        if (extraKeysIndex == index) {
-            @Suppress("UNCHECKED_CAST")
-            val map = value as Map<String, JsonElement>
-            val declaredNames = descriptor.getJsonDecodingNames(json)
-            val discriminator = activeDiscriminator
-            for ((k, v) in map) {
-                if (k in declaredNames) {
-                    throw JsonEncodingException(
-                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                            "which conflicts with a declared property name.",
-                        classSerialName = descriptor.serialName
-                    )
-                }
-                if (k == discriminator) {
-                    throw JsonEncodingException(
-                        "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
-                            "which conflicts with the active class discriminator '$discriminator'.",
-                        classSerialName = descriptor.serialName
-                    )
-                }
-                putElement(k, v)
-            }
+        // Bucket-spread only applies in CLASS mode. The descriptor-validation
+        // in JsonNamesMap.kt already filters out non-class descriptors, but
+        // the explicit kind check documents intent and is robust to future
+        // loosening of that validation. The check also stops the override
+        // firing for JsonTreeMapEncoder, which inherits this method.
+        if (descriptor.kind != StructureKind.CLASS || extraKeysIndexFor(descriptor) != index) {
+            super.encodeSerializableElement(descriptor, index, serializer, value)
             return
         }
-        super.encodeSerializableElement(descriptor, index, serializer, value)
+        @Suppress("UNCHECKED_CAST")
+        val map = value as Map<String, JsonElement>
+        val declaredNames = descriptor.getJsonDecodingNames(json)
+        val discriminator = activeDiscriminator
+        for ((k, v) in map) {
+            if (k in declaredNames) {
+                throw JsonEncodingException(
+                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                        "which conflicts with a declared property name.",
+                    classSerialName = descriptor.serialName
+                )
+            }
+            if (k == discriminator) {
+                throw JsonEncodingException(
+                    "@JsonExtraKeys map in '${descriptor.serialName}' contains key '$k' " +
+                        "which conflicts with the active class discriminator '$discriminator'.",
+                    classSerialName = descriptor.serialName
+                )
+            }
+            putElement(k, v)
+        }
     }
 
     override fun getCurrent(): JsonElement = JsonObject(content)

--- a/guide/example/example-json-33.kt
+++ b/guide/example/example-json-33.kt
@@ -1,0 +1,21 @@
+// This file was automatically generated from json.md by Knit tool. Do not edit.
+package example.exampleJson33
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+@OptIn(ExperimentalSerializationApi::class) // useExtraKeys is an experimental setting for now
+val format = Json { useExtraKeys = true }
+
+@OptIn(ExperimentalSerializationApi::class) // JsonExtraKeys is an experimental annotation for now
+@Serializable
+data class Project(
+    val name: String,
+    @JsonExtraKeys val details: JsonObject = JsonObject(emptyMap())
+)
+
+fun main() {
+    val project = format.decodeFromString<Project>("""{"type":"unknown","name":"example","maintainer":"Unknown","license":"Apache 2.0"}""")
+    println(project)
+    println(format.encodeToString(project))
+}

--- a/guide/test/JsonTest.kt
+++ b/guide/test/JsonTest.kt
@@ -248,4 +248,12 @@ class JsonTest {
             "UnknownProject(name=example, details={\"type\":\"unknown\",\"maintainer\":\"Unknown\",\"license\":\"Apache 2.0\"})"
         )
     }
+
+    @Test
+    fun testExampleJson33() {
+        captureOutput("ExampleJson33") { example.exampleJson33.main() }.verifyOutputLines(
+            "Project(name=example, details={\"type\":\"unknown\",\"maintainer\":\"Unknown\",\"license\":\"Apache 2.0\"})",
+            "{\"name\":\"example\",\"type\":\"unknown\",\"maintainer\":\"Unknown\",\"license\":\"Apache 2.0\"}"
+        )
+    }
 }


### PR DESCRIPTION
Adds `@JsonExtraKeys`, a property annotation that captures every key of a JSON object that does not match a declared property, and writes those keys back on encoding.

```kotlin
@Serializable
data class Project(
    val name: String,
    @JsonExtraKeys val details: JsonObject = JsonObject(emptyMap())
)

val json = Json { useExtraKeys = true }
val project = json.decodeFromString<Project>("""{"name":"example","maintainer":"Unknown","license":"Apache 2.0"}""")
// project.details == {"maintainer":"Unknown","license":"Apache 2.0"}
// json.encodeToString(project) reproduces the input
```

### Behavior

- Enabled by the new `useExtraKeys` flag on `JsonBuilder`, off by default (see performance below). Without the flag the annotated property behaves as a regular property.
- The bucket type must be `JsonObject` or `Map<String, JsonElement>`. Typed values (`Map<String, V>`) were in the first version of this PR and were removed on review: the bucket holds keys the class does not know about, so it should not presume their shape. Individual entries can be decoded with `Json.decodeFromJsonElement`.
- At most one bucket per class, and `@JsonNames` is rejected on the bucket property. Both rules are validated lazily on first use.
- Capture takes precedence over `ignoreUnknownKeys` and `@JsonIgnoreUnknownKeys`.
- Keys resolved through `@JsonNames`, a `JsonNamingStrategy`, or the class discriminator are not captured.
- On encoding, the entries are written after the regular properties under their own keys; the bucket's property name is not written. If the bucket contains a key that a declared property or the discriminator would be written under, encoding throws `JsonEncodingException` instead of emitting duplicate keys.
- Streaming and tree encoders and decoders are both supported.

### Performance

`TwitterFeedBenchmark` (macro, bucket-less classes), A/B pairs in the same JVM session:

- Flag off vs `dev`: decode 1571 ± 40 vs 1565 ± 43 ops/s, encode 3181 ± 38 vs 3202 ± 65 ops/s. Parity.
- Flag on vs flag off: decode 1440 ± 30 vs 1552 ± 15 ops/s (-7.2%), encode 2987 ± 34 vs 3241 ± 29 ops/s (-7.8%).

The flag-on cost is why the flag defaults to off. `JsonExtraKeysBenchmark` (micro) and flag-on/flag-off `TwitterFeedBenchmark` variants are committed.

### Known limitation

Descriptors produced by `@Serializer(forClass = ...)` throw from `hashCode()` (#1512), so the schema-cache lookup for the bucket index falls back to uncached computation for them. #3215 would have fixed the root cause; it was closed with a pointer to #3084, so the fallback stays.

### Docs

`docs/json.md` gets a "Preserving unknown keys (experimental)" section next to the existing hand-written serializer example for the same problem, with a knit-generated example and test.

Related issue: #1978 (asks for a typed `Map<String, Response>`; see the note on bucket types above).
