### PR TITLE
CBOR: Encode unsigned integer types as positive integers

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/cbor/CborUnsignedBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/cbor/CborUnsignedBenchmark.kt
@@ -31,9 +31,8 @@ open class CborUnsignedBenchmark {
     val scalars = UnsignedScalars(200u, 32000u, 2147483648u, 9223372036854775808uL)
     val scalarBytes: ByteArray = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
 
-    // Held as Any so JMH's bytecode generator does not reject the inline-class getter name.
-    val array: Any = UIntArray(64) { it.toUInt() }
-    val arrayBytes: ByteArray = Cbor.encodeToByteArray(UIntArraySerializer(), array as UIntArray)
+    val array: UIntArray = UIntArray(64) { it.toUInt() }
+    val arrayBytes: ByteArray = Cbor.encodeToByteArray(UIntArraySerializer(), array)
 
     @Benchmark
     fun encodeScalars(): ByteArray = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
@@ -42,7 +41,7 @@ open class CborUnsignedBenchmark {
     fun decodeScalars(): UnsignedScalars = Cbor.decodeFromByteArray(UnsignedScalars.serializer(), scalarBytes)
 
     @Benchmark
-    fun encodeArray(): ByteArray = Cbor.encodeToByteArray(UIntArraySerializer(), array as UIntArray)
+    fun encodeArray(): ByteArray = Cbor.encodeToByteArray(UIntArraySerializer(), array)
 
     @Benchmark
     fun decodeArray(bh: Blackhole) {

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/cbor/CborUnsignedBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/cbor/CborUnsignedBenchmark.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+@file:OptIn(ExperimentalUnsignedTypes::class, ExperimentalSerializationApi::class)
+
+package kotlinx.benchmarks.cbor
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.cbor.*
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
+
+@Serializable
+data class UnsignedScalars(
+    val a: UByte,
+    val b: UShort,
+    val c: UInt,
+    val d: ULong,
+)
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class CborUnsignedBenchmark {
+    private val scalars = UnsignedScalars(200u, 32000u, 2147483648u, 9223372036854775808uL)
+    private val array = UIntArray(64) { it.toUInt() }
+
+    private val scalarBytes = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
+    private val arrayBytes = Cbor.encodeToByteArray(UIntArraySerializer(), array)
+
+    @Benchmark
+    fun encodeScalars() = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
+
+    @Benchmark
+    fun decodeScalars() = Cbor.decodeFromByteArray(UnsignedScalars.serializer(), scalarBytes)
+
+    @Benchmark
+    fun encodeArray() = Cbor.encodeToByteArray(UIntArraySerializer(), array)
+
+    @Benchmark
+    fun decodeArray() = Cbor.decodeFromByteArray(UIntArraySerializer(), arrayBytes)
+}

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/cbor/CborUnsignedBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/cbor/CborUnsignedBenchmark.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.*
 import kotlinx.serialization.cbor.*
 import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.*
 
 @Serializable
@@ -27,21 +28,24 @@ data class UnsignedScalars(
 @State(Scope.Benchmark)
 @Fork(1)
 open class CborUnsignedBenchmark {
-    private val scalars = UnsignedScalars(200u, 32000u, 2147483648u, 9223372036854775808uL)
-    private val array = UIntArray(64) { it.toUInt() }
+    val scalars = UnsignedScalars(200u, 32000u, 2147483648u, 9223372036854775808uL)
+    val scalarBytes: ByteArray = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
 
-    private val scalarBytes = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
-    private val arrayBytes = Cbor.encodeToByteArray(UIntArraySerializer(), array)
-
-    @Benchmark
-    fun encodeScalars() = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
+    // Held as Any so JMH's bytecode generator does not reject the inline-class getter name.
+    val array: Any = UIntArray(64) { it.toUInt() }
+    val arrayBytes: ByteArray = Cbor.encodeToByteArray(UIntArraySerializer(), array as UIntArray)
 
     @Benchmark
-    fun decodeScalars() = Cbor.decodeFromByteArray(UnsignedScalars.serializer(), scalarBytes)
+    fun encodeScalars(): ByteArray = Cbor.encodeToByteArray(UnsignedScalars.serializer(), scalars)
 
     @Benchmark
-    fun encodeArray() = Cbor.encodeToByteArray(UIntArraySerializer(), array)
+    fun decodeScalars(): UnsignedScalars = Cbor.decodeFromByteArray(UnsignedScalars.serializer(), scalarBytes)
 
     @Benchmark
-    fun decodeArray() = Cbor.decodeFromByteArray(UIntArraySerializer(), arrayBytes)
+    fun encodeArray(): ByteArray = Cbor.encodeToByteArray(UIntArraySerializer(), array as UIntArray)
+
+    @Benchmark
+    fun decodeArray(bh: Blackhole) {
+        bh.consume(Cbor.decodeFromByteArray(UIntArraySerializer(), arrayBytes))
+    }
 }

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
@@ -115,6 +115,23 @@ internal sealed class CborWriter(
         getDestination().encodeString(enumDescriptor.getElementName(index))
     }
 
+    override fun encodeInline(descriptor: SerialDescriptor): Encoder =
+        if (descriptor.isUnsignedNumber) UnsignedNumberWriter() else super.encodeInline(descriptor)
+
+    private fun writeUnsigned(value: ULong) {
+        getDestination().encodeUnsignedNumber(value)
+    }
+
+    private inner class UnsignedNumberWriter : AbstractEncoder() {
+        override val serializersModule: SerializersModule
+            get() = this@CborWriter.serializersModule
+
+        override fun encodeByte(value: Byte) = writeUnsigned(value.toUByte().toULong())
+        override fun encodeShort(value: Short) = writeUnsigned(value.toUShort().toULong())
+        override fun encodeInt(value: Int) = writeUnsigned(value.toUInt().toULong())
+        override fun encodeLong(value: Long) = writeUnsigned(value.toULong())
+    }
+
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         val destination = getDestination()
         isClass = descriptor.getElementDescriptor(index).kind == StructureKind.CLASS
@@ -249,6 +266,8 @@ internal fun ByteArrayOutput.writeByte(byteValue: Int) = write(byteValue)
 internal fun ByteArrayOutput.encodeBoolean(value: Boolean) = write(if (value) TRUE else FALSE)
 
 internal fun ByteArrayOutput.encodeNumber(value: Long) = write(composeNumber(value))
+
+internal fun ByteArrayOutput.encodeUnsignedNumber(value: ULong) = write(composePositive(value))
 
 internal fun ByteArrayOutput.encodeByteString(data: ByteArray) {
     this.encodeByteArray(data, HEADER_BYTE_STRING)

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
@@ -116,21 +116,23 @@ internal sealed class CborWriter(
     }
 
     override fun encodeInline(descriptor: SerialDescriptor): Encoder =
-        if (descriptor.isUnsignedNumber) UnsignedNumberWriter() else super.encodeInline(descriptor)
-
-    private fun writeUnsigned(value: ULong) {
-        getDestination().encodeUnsignedNumber(value)
-    }
+        if (descriptor.isUnsignedNumber) unsignedNumberWriter else super.encodeInline(descriptor)
 
     private inner class UnsignedNumberWriter : AbstractEncoder() {
         override val serializersModule: SerializersModule
             get() = this@CborWriter.serializersModule
+
+        private fun writeUnsigned(value: ULong) {
+            getDestination().encodeUnsignedNumber(value)
+        }
 
         override fun encodeByte(value: Byte) = writeUnsigned(value.toUByte().toULong())
         override fun encodeShort(value: Short) = writeUnsigned(value.toUShort().toULong())
         override fun encodeInt(value: Int) = writeUnsigned(value.toUInt().toULong())
         override fun encodeLong(value: Long) = writeUnsigned(value.toULong())
     }
+
+    private val unsignedNumberWriter = UnsignedNumberWriter()
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         val destination = getDestination()

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
@@ -32,6 +32,8 @@ internal sealed class CborWriter(
 
     protected var encodeByteArrayAsByteString = false
 
+    protected var encodeNumberAsUnsigned = false
+
     class Data(val bytes: ByteArrayOutput, var elementCount: Int)
 
     protected abstract fun getDestination(): ByteArrayOutput
@@ -79,21 +81,41 @@ internal sealed class CborWriter(
 
 
     override fun encodeByte(value: Byte) {
-        getDestination().encodeNumber(value.toLong())
+        if (encodeNumberAsUnsigned) {
+            encodeNumberAsUnsigned = false
+            getDestination().encodeUnsignedNumber(value.toUByte().toULong())
+        } else {
+            getDestination().encodeNumber(value.toLong())
+        }
     }
 
 
     override fun encodeShort(value: Short) {
-        getDestination().encodeNumber(value.toLong())
+        if (encodeNumberAsUnsigned) {
+            encodeNumberAsUnsigned = false
+            getDestination().encodeUnsignedNumber(value.toUShort().toULong())
+        } else {
+            getDestination().encodeNumber(value.toLong())
+        }
     }
 
     override fun encodeInt(value: Int) {
-        getDestination().encodeNumber(value.toLong())
+        if (encodeNumberAsUnsigned) {
+            encodeNumberAsUnsigned = false
+            getDestination().encodeUnsignedNumber(value.toUInt().toULong())
+        } else {
+            getDestination().encodeNumber(value.toLong())
+        }
     }
 
 
     override fun encodeLong(value: Long) {
-        getDestination().encodeNumber(value)
+        if (encodeNumberAsUnsigned) {
+            encodeNumberAsUnsigned = false
+            getDestination().encodeUnsignedNumber(value.toULong())
+        } else {
+            getDestination().encodeNumber(value)
+        }
     }
 
 
@@ -115,24 +137,10 @@ internal sealed class CborWriter(
         getDestination().encodeString(enumDescriptor.getElementName(index))
     }
 
-    override fun encodeInline(descriptor: SerialDescriptor): Encoder =
-        if (descriptor.isUnsignedNumber) unsignedNumberWriter else super.encodeInline(descriptor)
-
-    private inner class UnsignedNumberWriter : AbstractEncoder() {
-        override val serializersModule: SerializersModule
-            get() = this@CborWriter.serializersModule
-
-        private fun writeUnsigned(value: ULong) {
-            getDestination().encodeUnsignedNumber(value)
-        }
-
-        override fun encodeByte(value: Byte) = writeUnsigned(value.toUByte().toULong())
-        override fun encodeShort(value: Short) = writeUnsigned(value.toUShort().toULong())
-        override fun encodeInt(value: Int) = writeUnsigned(value.toUInt().toULong())
-        override fun encodeLong(value: Long) = writeUnsigned(value.toULong())
+    override fun encodeInline(descriptor: SerialDescriptor): Encoder {
+        encodeNumberAsUnsigned = descriptor.isUnsignedNumber
+        return this
     }
-
-    private val unsignedNumberWriter = UnsignedNumberWriter()
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         val destination = getDestination()

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -60,11 +60,12 @@ internal fun SerialDescriptor.isInlineByteString(): Boolean {
     return isInline && isByteString(0)
 }
 
+// kotlinx-serialization-json keeps the same set in StreamingJsonEncoder; keep both in sync.
 private val unsignedNumberDescriptors = setOf(
-    UByte.serializer().descriptor,
-    UShort.serializer().descriptor,
     UInt.serializer().descriptor,
     ULong.serializer().descriptor,
+    UByte.serializer().descriptor,
+    UShort.serializer().descriptor,
 )
 
 internal val SerialDescriptor.isUnsignedNumber: Boolean

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -6,6 +6,7 @@
 package kotlinx.serialization.cbor.internal
 
 import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
 import kotlinx.serialization.cbor.*
 import kotlinx.serialization.descriptors.*
 
@@ -58,6 +59,16 @@ internal fun SerialDescriptor.isInlineByteString(): Boolean {
     // inline item classes should only have 1 item
     return isInline && isByteString(0)
 }
+
+private val unsignedNumberDescriptors = setOf(
+    UByte.serializer().descriptor,
+    UShort.serializer().descriptor,
+    UInt.serializer().descriptor,
+    ULong.serializer().descriptor,
+)
+
+internal val SerialDescriptor.isUnsignedNumber: Boolean
+    get() = isInline && this in unsignedNumberDescriptors
 
 @OptIn(ExperimentalSerializationApi::class)
 internal fun SerialDescriptor.getValueTags(index: Int): ULongArray? = findAnnotation<ValueTags>(index)?.tags

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
@@ -4,8 +4,7 @@ package kotlinx.serialization.cbor
 
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class CborNumberEncodingTest {
 
@@ -220,11 +219,23 @@ class CborNumberEncodingTest {
         assertEquals(expected = "18c8", actual = Cbor.encodeToHexString(UByte.serializer(), 200u))
         assertEquals(expected = "197d00", actual = Cbor.encodeToHexString(UShort.serializer(), 32000u))
         assertEquals(expected = "1a80000000", actual = Cbor.encodeToHexString(UInt.serializer(), 2147483648u))
-        assertEquals(expected = "1b8000000000000000", actual = Cbor.encodeToHexString(ULong.serializer(), 9223372036854775808uL))
+        assertEquals(
+            expected = "1b8000000000000000",
+            actual = Cbor.encodeToHexString(ULong.serializer(), 9223372036854775808uL)
+        )
         assertEquals(expected = "9f18d0ff", actual = Cbor.encodeToHexString(UByteArraySerializer(), ubyteArrayOf(208u)))
-        assertEquals(expected = "9f198000ff", actual = Cbor.encodeToHexString(UShortArraySerializer(), ushortArrayOf(32768u)))
-        assertEquals(expected = "9f1a80000000ff", actual = Cbor.encodeToHexString(UIntArraySerializer(), uintArrayOf(2147483648u)))
-        assertEquals(expected = "9f1b8000000000000000ff", actual = Cbor.encodeToHexString(ULongArraySerializer(), ulongArrayOf(9223372036854775808uL)))
+        assertEquals(
+            expected = "9f198000ff",
+            actual = Cbor.encodeToHexString(UShortArraySerializer(), ushortArrayOf(32768u))
+        )
+        assertEquals(
+            expected = "9f1a80000000ff",
+            actual = Cbor.encodeToHexString(UIntArraySerializer(), uintArrayOf(2147483648u))
+        )
+        assertEquals(
+            expected = "9f1b8000000000000000ff",
+            actual = Cbor.encodeToHexString(ULongArraySerializer(), ulongArrayOf(9223372036854775808uL))
+        )
     }
 
     @Test
@@ -232,6 +243,33 @@ class CborNumberEncodingTest {
         assertEquals(expected = 200u, actual = Cbor.decodeFromHexString(UByte.serializer(), "3837"))
         assertEquals(expected = 32768u, actual = Cbor.decodeFromHexString(UShort.serializer(), "397fff"))
         assertEquals(expected = 2147483648u, actual = Cbor.decodeFromHexString(UInt.serializer(), "3a7fffffff"))
-        assertEquals(expected = 9223372036854775808uL, actual = Cbor.decodeFromHexString(ULong.serializer(), "3b7fffffffffffffff"))
+        assertEquals(
+            expected = 9223372036854775808uL,
+            actual = Cbor.decodeFromHexString(ULong.serializer(), "3b7fffffffffffffff")
+        )
+        assertContentEquals(expected = ubyteArrayOf(208u), actual = Cbor.decodeFromHexString("9f382fff"))
+        assertContentEquals(expected = ushortArrayOf(32768u), actual = Cbor.decodeFromHexString("9f397fffff"))
+        assertContentEquals(expected = uintArrayOf(2147483648u), actual = Cbor.decodeFromHexString("9f3a7fffffffff"))
+        assertContentEquals(
+            expected = ulongArrayOf(9223372036854775808uL),
+            actual = Cbor.decodeFromHexString("9f3b7fffffffffffffffff")
+        )
+    }
+
+    @Test
+    fun testUnsignedArrayMixedDecoding() {
+        assertContentEquals(expected = ubyteArrayOf(208u, 208u), actual = Cbor.decodeFromHexString("9f382f18d0ff"))
+        assertContentEquals(
+            expected = ushortArrayOf(32768u, 32768u),
+            actual = Cbor.decodeFromHexString("9f397fff198000ff")
+        )
+        assertContentEquals(
+            expected = uintArrayOf(2147483648u, 2147483648u),
+            actual = Cbor.decodeFromHexString("9f3a7fffffff1a80000000ff")
+        )
+        assertContentEquals(
+            expected = ulongArrayOf(9223372036854775808uL, 9223372036854775808uL),
+            actual = Cbor.decodeFromHexString("9f3b7fffffffffffffff1b8000000000000000ff")
+        )
     }
 }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
@@ -1,7 +1,9 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package kotlinx.serialization.cbor
 
-import kotlinx.serialization.decodeFromByteArray
-import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -211,5 +213,14 @@ class CborNumberEncodingTest {
             expected = -4294967296,
             actual = Cbor.decodeFromByteArray(bytes),
         )
+    }
+
+    @Test
+    fun testEncodingUnsignedValuesAsPositiveInteger() {
+        assertEquals(expected = "18c8", actual = Cbor.encodeToHexString(UByte.serializer(), 200u))
+        assertEquals(expected = "197d00", actual = Cbor.encodeToHexString(UShort.serializer(), 32000u))
+        assertEquals(expected = "1a80000000", actual = Cbor.encodeToHexString(UInt.serializer(), 2147483648u))
+        assertEquals(expected = "1b8000000000000000", actual = Cbor.encodeToHexString(ULong.serializer(), 9223372036854775808uL))
+        assertEquals(expected = "9f18d0ff", actual = Cbor.encodeToHexString(UByteArraySerializer(), ubyteArrayOf(208u)))
     }
 }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborNumberEncodingTest.kt
@@ -222,5 +222,16 @@ class CborNumberEncodingTest {
         assertEquals(expected = "1a80000000", actual = Cbor.encodeToHexString(UInt.serializer(), 2147483648u))
         assertEquals(expected = "1b8000000000000000", actual = Cbor.encodeToHexString(ULong.serializer(), 9223372036854775808uL))
         assertEquals(expected = "9f18d0ff", actual = Cbor.encodeToHexString(UByteArraySerializer(), ubyteArrayOf(208u)))
+        assertEquals(expected = "9f198000ff", actual = Cbor.encodeToHexString(UShortArraySerializer(), ushortArrayOf(32768u)))
+        assertEquals(expected = "9f1a80000000ff", actual = Cbor.encodeToHexString(UIntArraySerializer(), uintArrayOf(2147483648u)))
+        assertEquals(expected = "9f1b8000000000000000ff", actual = Cbor.encodeToHexString(ULongArraySerializer(), ulongArrayOf(9223372036854775808uL)))
+    }
+
+    @Test
+    fun testDecodingLegacySignedEncodingOfUnsignedValues() {
+        assertEquals(expected = 200u, actual = Cbor.decodeFromHexString(UByte.serializer(), "3837"))
+        assertEquals(expected = 32768u, actual = Cbor.decodeFromHexString(UShort.serializer(), "397fff"))
+        assertEquals(expected = 2147483648u, actual = Cbor.decodeFromHexString(UInt.serializer(), "3a7fffffff"))
+        assertEquals(expected = 9223372036854775808uL, actual = Cbor.decodeFromHexString(ULong.serializer(), "3b7fffffffffffffff"))
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 
+// kotlinx-serialization-cbor keeps the same set in its Encoding.kt; keep both in sync.
 private val unsignedNumberDescriptors = setOf(
     UInt.serializer().descriptor,
     ULong.serializer().descriptor,


### PR DESCRIPTION
The CBOR encoder writes UByte/UShort/UInt/ULong values that exceed the matching signed type's max as CBOR major type 1 (negative integers), because the underlying serializer converts each to its signed counterpart before reaching `encodeNumber`. Override `encodeInline` in `CborWriter` to recognize the unsigned-type descriptors and reinterpret the value as positive.

Closes #3181
