### PR TITLE
Return UNKNOWN_NAME from list/map descriptor getElementIndex for non-index names

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/CollectionDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/CollectionDescriptors.kt
@@ -5,14 +5,14 @@ package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 internal sealed class ListLikeDescriptor(val elementDescriptor: SerialDescriptor) : SerialDescriptor {
     override val kind: SerialKind get() = StructureKind.LIST
     override val elementsCount: Int = 1
 
     override fun getElementName(index: Int): String = index.toString()
-    override fun getElementIndex(name: String): Int =
-        name.toIntOrNull() ?: throw IllegalArgumentException("$name is not a valid list index")
+    override fun getElementIndex(name: String): Int = name.toIntOrNull() ?: CompositeDecoder.UNKNOWN_NAME
 
     override fun isElementOptional(index: Int): Boolean {
         require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
@@ -51,8 +51,7 @@ internal sealed class MapLikeDescriptor(
     override val kind: SerialKind get() = StructureKind.MAP
     override val elementsCount: Int = 2
     override fun getElementName(index: Int): String = index.toString()
-    override fun getElementIndex(name: String): Int =
-        name.toIntOrNull() ?: throw IllegalArgumentException("$name is not a valid map index")
+    override fun getElementIndex(name: String): Int = name.toIntOrNull() ?: CompositeDecoder.UNKNOWN_NAME
 
     override fun isElementOptional(index: Int): Boolean {
         require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}

--- a/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -137,6 +137,8 @@ class SerialDescriptorSpecificationTest {
         assertFalse(descriptor.isElementOptional(0))
         assertFalse(descriptor.isElementOptional(1))
         assertFailsWith<IllegalArgumentException> { descriptor.isElementOptional(-1) }
+        assertEquals(0, descriptor.getElementIndex("0"))
+        assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("key"))
     }
 
     @Test
@@ -159,6 +161,8 @@ class SerialDescriptorSpecificationTest {
         assertFalse(descriptor.isElementOptional(2))
         assertFalse(descriptor.isElementOptional(3))
         assertFailsWith<IllegalArgumentException> { descriptor.isElementOptional(-1) }
+        assertEquals(0, descriptor.getElementIndex("0"))
+        assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("key"))
     }
 
     @Serializable


### PR DESCRIPTION
`ListLikeDescriptor.getElementIndex` and `MapLikeDescriptor.getElementIndex` threw `IllegalArgumentException` for names that are not valid integer indices, while `SerialDescriptor.getElementIndex` is documented to return `CompositeDecoder.UNKNOWN_NAME` for unknown element names. This aligns both implementations with the documented contract.

Closes #3163