### PR TITLE
Align collections' SerialDescriptors with the contract

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptor.kt
@@ -68,7 +68,7 @@ import kotlinx.serialization.encoding.*
  * In practice, for regular classes it is allowed to invoke `getElement*(index)` methods
  * with an index from `0` to [elementsCount] range and the element at the particular index corresponds to the
  * serializable property at the given position.
- * For collections and maps, index parameter for `getElement*(index)` methods is effectively bounded
+ * For collections and maps, index parameter for `getElement*(index)` methods should be non-negative and is effectively bounded
  * by the maximal number of collection/map elements.
  *
  * ### Thread-safety and mutability
@@ -319,6 +319,8 @@ public interface SerialDescriptor {
      * userDescriptor.getElementIndex("alias") // Returns 1
      * userDescriptor.getElementIndex("lastName") // Returns CompositeDecoder.UNKNOWN_NAME = -3
      * ```
+     *
+     * @throws IllegalStateException if the current descriptor does not support children elements (e.g. is a primitive)
      */
     public fun getElementIndex(name: String): Int
 

--- a/core/commonMain/src/kotlinx/serialization/internal/CollectionDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/CollectionDescriptors.kt
@@ -5,27 +5,32 @@ package kotlinx.serialization.internal
 
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
 
 internal sealed class ListLikeDescriptor(val elementDescriptor: SerialDescriptor) : SerialDescriptor {
     override val kind: SerialKind get() = StructureKind.LIST
     override val elementsCount: Int = 1
 
-    override fun getElementName(index: Int): String = index.toString()
+    override fun getElementName(index: Int): String {
+        requireNonNegativeIndex(index, serialName)
+        return index.toString()
+    }
+
     override fun getElementIndex(name: String): Int =
-        name.toIntOrNull() ?: throw IllegalArgumentException("$name is not a valid list index")
+        name.toIntOrNull()?.takeIf { it >= 0 } ?: UNKNOWN_NAME
 
     override fun isElementOptional(index: Int): Boolean {
-        require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+        requireNonNegativeIndex(index, serialName)
         return false
     }
 
     override fun getElementAnnotations(index: Int): List<Annotation> {
-        require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+        requireNonNegativeIndex(index, serialName)
         return emptyList()
     }
 
     override fun getElementDescriptor(index: Int): SerialDescriptor {
-        require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+        requireNonNegativeIndex(index, serialName)
         return elementDescriptor
     }
 
@@ -50,22 +55,27 @@ internal sealed class MapLikeDescriptor(
 ) : SerialDescriptor {
     override val kind: SerialKind get() = StructureKind.MAP
     override val elementsCount: Int = 2
-    override fun getElementName(index: Int): String = index.toString()
+
+    override fun getElementName(index: Int): String {
+        requireNonNegativeIndex(index, serialName)
+        return index.toString()
+    }
+
     override fun getElementIndex(name: String): Int =
-        name.toIntOrNull() ?: throw IllegalArgumentException("$name is not a valid map index")
+        name.toIntOrNull()?.takeIf { it >= 0 } ?: UNKNOWN_NAME
 
     override fun isElementOptional(index: Int): Boolean {
-        require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+        requireNonNegativeIndex(index, serialName)
         return false
     }
 
     override fun getElementAnnotations(index: Int): List<Annotation> {
-        require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+        requireNonNegativeIndex(index, serialName)
         return emptyList()
     }
 
     override fun getElementDescriptor(index: Int): SerialDescriptor {
-        require(index >= 0) { "Illegal index $index, $serialName expects only non-negative indices"}
+        requireNonNegativeIndex(index, serialName)
         return when (index % 2) {
             0 -> keyDescriptor
             1 -> valueDescriptor
@@ -90,6 +100,10 @@ internal sealed class MapLikeDescriptor(
     }
 
     override fun toString(): String = "$serialName($keyDescriptor, $valueDescriptor)"
+}
+
+private fun requireNonNegativeIndex(index: Int, name: String) {
+    if (index < 0) throw IndexOutOfBoundsException("Illegal index $index, $name expects only non-negative indices")
 }
 
 internal const val ARRAY_NAME = "kotlin.Array"

--- a/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -136,7 +136,9 @@ class SerialDescriptorSpecificationTest {
         assertSame(Int.serializer().descriptor, descriptor.getElementDescriptor(1))
         assertFalse(descriptor.isElementOptional(0))
         assertFalse(descriptor.isElementOptional(1))
-        assertFailsWith<IllegalArgumentException> { descriptor.isElementOptional(-1) }
+        assertFailsWith<IndexOutOfBoundsException> { descriptor.isElementOptional(-1) }
+        assertFailsWith<IndexOutOfBoundsException> { descriptor.getElementName(-3) }
+        assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("?"))
     }
 
     @Test
@@ -158,7 +160,9 @@ class SerialDescriptorSpecificationTest {
         assertFalse(descriptor.isElementOptional(1))
         assertFalse(descriptor.isElementOptional(2))
         assertFalse(descriptor.isElementOptional(3))
-        assertFailsWith<IllegalArgumentException> { descriptor.isElementOptional(-1) }
+        assertFailsWith<IndexOutOfBoundsException> { descriptor.isElementOptional(-1) }
+        assertFailsWith<IndexOutOfBoundsException> { descriptor.getElementName(-3) }
+        assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("abc"))
     }
 
     @Serializable

--- a/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/SerialDescriptorSpecificationTest.kt
@@ -139,6 +139,7 @@ class SerialDescriptorSpecificationTest {
         assertFailsWith<IndexOutOfBoundsException> { descriptor.isElementOptional(-1) }
         assertFailsWith<IndexOutOfBoundsException> { descriptor.getElementName(-3) }
         assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("?"))
+        assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("-10"))
     }
 
     @Test
@@ -163,6 +164,7 @@ class SerialDescriptorSpecificationTest {
         assertFailsWith<IndexOutOfBoundsException> { descriptor.isElementOptional(-1) }
         assertFailsWith<IndexOutOfBoundsException> { descriptor.getElementName(-3) }
         assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("abc"))
+        assertEquals(UNKNOWN_NAME, descriptor.getElementIndex("-10"))
     }
 
     @Serializable


### PR DESCRIPTION
getElementIndex(name) should return UNKNOWN_NAME instead of throwing, whilst getElementName(index) should throw IOOBE on invalid indices.

Fixes #3163