### PR TITLE
Fix ProtoBuf schema generation for value classes in collections

### DIFF
--- a/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
+++ b/formats/protobuf/commonMain/src/kotlinx/serialization/protobuf/schema/ProtoBufSchemaGenerator.kt
@@ -270,10 +270,7 @@ public object ProtoBufSchemaGenerator {
         inOneOfStruct: Boolean = false,
         indent: Int = 1,
     ): List<TypeDefinition> {
-        var unwrappedFieldDescriptor = fieldDescriptor
-        while (unwrappedFieldDescriptor.isInline) {
-            unwrappedFieldDescriptor = unwrappedFieldDescriptor.getElementDescriptor(0)
-        }
+        val unwrappedFieldDescriptor = fieldDescriptor.unwrapInlineType()
 
         val nestedTypes: List<TypeDefinition>
         val typeName: String = when {
@@ -320,7 +317,7 @@ public object ProtoBufSchemaGenerator {
     private fun StringBuilder.generateMapType(messageType: TypeDefinition, index: Int): List<TypeDefinition> {
         val messageDescriptor = messageType.descriptor
         val mapDescriptor = messageDescriptor.getElementDescriptor(index)
-        val originalMapValueDescriptor = mapDescriptor.getElementDescriptor(1)
+        val originalMapValueDescriptor = mapDescriptor.getElementDescriptor(1).unwrapInlineType()
         val valueType = if (originalMapValueDescriptor.isProtobufCollection) {
             createNestedCollectionType(messageType, index, originalMapValueDescriptor, "nested collection in map value")
         } else {
@@ -347,7 +344,7 @@ public object ProtoBufSchemaGenerator {
     private fun StringBuilder.generateListType(messageType: TypeDefinition, index: Int): List<TypeDefinition> {
         val messageDescriptor = messageType.descriptor
         val collectionDescriptor = messageDescriptor.getElementDescriptor(index)
-        val originalElementDescriptor = collectionDescriptor.getElementDescriptor(0)
+        val originalElementDescriptor = collectionDescriptor.getElementDescriptor(0).unwrapInlineType()
         val elementType = if (collectionDescriptor.kind == StructureKind.LIST) {
             if (originalElementDescriptor.isProtobufCollection) {
                 createNestedCollectionType(messageType, index, originalElementDescriptor, "nested collection in list")
@@ -458,6 +455,14 @@ public object ProtoBufSchemaGenerator {
 
     private fun SerialDescriptor.isChildOneOfMessage(index: Int): Boolean =
         this.getElementDescriptor(index).isSealedPolymorphic && this.getElementAnnotations(index).any { it is ProtoOneOf }
+
+    private fun SerialDescriptor.unwrapInlineType(): SerialDescriptor {
+        var descriptor = this
+        while (descriptor.isInline) {
+            descriptor = descriptor.getElementDescriptor(0)
+        }
+        return descriptor
+    }
 
     private fun SerialDescriptor.protobufTypeName(annotations: List<Annotation> = emptyList()): String {
         return if (isProtobufScalar) {

--- a/formats/protobuf/jvmTest/resources/InlineClassesInCollections.proto
+++ b/formats/protobuf/jvmTest/resources/InlineClassesInCollections.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package kotlinx.serialization.protobuf.schema.generator;
+
+// serial name 'kotlinx.serialization.protobuf.schema.GenerationTest.InlineClassesInCollections'
+message InlineClassesInCollections {
+  repeated int32 list = 1;
+  repeated int32 array = 2;
+  map<string, int32> map = 3;
+}

--- a/formats/protobuf/jvmTest/resources/common/schema.proto
+++ b/formats/protobuf/jvmTest/resources/common/schema.proto
@@ -151,6 +151,13 @@ enum EnumWithProtoNumber {
   FIVE = 5;
 }
 
+// serial name 'kotlinx.serialization.protobuf.schema.GenerationTest.InlineClassesInCollections'
+message InlineClassesInCollections {
+  repeated int32 list = 1;
+  repeated int32 array = 2;
+  map<string, int32> map = 3;
+}
+
 enum OverriddenEnumName {
   FIRST = 0;
   OverriddenElementName = 1;

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/schema/GenerationTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/schema/GenerationTest.kt
@@ -26,6 +26,7 @@ internal val commonClasses = listOf(
     GenerationTest.NullableNestedCollections::class,
     GenerationTest.OptionalCollections::class,
     GenerationTest.EnumWithProtoNumber::class,
+    GenerationTest.InlineClassesInCollections::class,
 )
 
 class GenerationTest {
@@ -202,6 +203,13 @@ class GenerationTest {
         @ProtoNumber(5)
         FIVE,
     }
+
+    @Serializable
+    class InlineClassesInCollections(
+        val list: List<WrappedUInt>,
+        val array: Array<WrappedUInt>,
+        val map: Map<String, WrappedUInt>,
+    )
 
     @Test
     fun testIndividuals() {


### PR DESCRIPTION
The schema generator only unwrapped `@JvmInline` value classes for plain message fields. Inside a `List`, `Array`, or as a `Map` value the value class was left wrapped, so the schema used the wrapper type and added an extra message for it.

Unwrapping is now shared in a small `unwrapInlineType` helper and applied in `generateListType` and `generateMapType`. Packed repeated fields and map keys are unchanged.

Added `InlineClassesInCollections` to the schema generation test, covering a value class in a `List`, an `Array`, and a `Map` value.

Fixes #3205
