### PR TITLE
[CborElement API] Cleanup

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -86,7 +86,7 @@ public sealed class Cbor(
 
     override fun <T> decodeFromByteArray(deserializer: DeserializationStrategy<T>, bytes: ByteArray): T {
         val stream = ByteArrayInput(bytes)
-        val reader = CborReader(this, CborParserImpl(stream, configuration.verifyObjectTags))
+        val reader = CborReader(this, StreamingCborParser(stream, configuration.verifyObjectTags))
         val result = reader.decodeSerializableValue(deserializer)
         if (stream.availableBytes > 0) {
             throw CborDecodingException(

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborElement.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborElement.kt
@@ -122,7 +122,6 @@ public class CborInteger(
  * depending on whether a positive or a negative number was passed.
  * If you want to create a negative number exceeding [Long.MIN_VALUE], manually specify sign: `CborInt(ULong.MAX_VALUE, isPositive = false)`.
  */
-@Suppress("FunctionName")
 public fun CborInteger(value: Long, vararg tags: ULong): CborInteger =
     if (value >= 0L) CborInteger(value.toULong(), isPositive = true, tags = tags)
     else CborInteger(ULong.MAX_VALUE - value.toULong() + 1uL, isPositive = false, tags = tags)
@@ -130,7 +129,6 @@ public fun CborInteger(value: Long, vararg tags: ULong): CborInteger =
 /**
  * Creates an unsigned CBOR integer (major type 0).
  */
-@Suppress("FunctionName")
 public fun CborInteger(value: ULong, vararg tags: ULong): CborInteger =
     CborInteger(value, isPositive = true, tags = tags)
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborElement.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborElement.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused")
-@file:OptIn(ExperimentalUnsignedTypes::class, DelicateCborApi::class, ExperimentalSerializationApi::class)
+@file:OptIn(ExperimentalUnsignedTypes::class, DelicateCborApi::class)
 
 package kotlinx.serialization.cbor
 
@@ -20,6 +20,7 @@ internal val EMPTY_TAGS: ULongArray = ULongArray(0)
  *
  * The whole hierarchy is [serializable][Serializable] only by [Cbor] format.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborElementSerializer::class)
 public sealed class CborElement(
     /**
@@ -63,6 +64,7 @@ public sealed class CborElement(
  * Class representing CBOR primitive value.
  * CBOR primitives include numbers, strings, booleans, byte arrays and special null value [CborNull].
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborPrimitiveSerializer::class)
 public sealed class CborPrimitive(
     tags: ULongArray = EMPTY_TAGS
@@ -75,6 +77,7 @@ public sealed class CborPrimitive(
  *
  * depending on the value of [isPositive]. Note that [absoluteValue] **must not be** `0` when [isPositive] is set to `false`.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborIntSerializer::class)
 public class CborInteger(
     public val absoluteValue: ULong,
@@ -122,6 +125,7 @@ public class CborInteger(
  * depending on whether a positive or a negative number was passed.
  * If you want to create a negative number exceeding [Long.MIN_VALUE], manually specify sign: `CborInt(ULong.MAX_VALUE, isPositive = false)`.
  */
+@ExperimentalSerializationApi
 public fun CborInteger(value: Long, vararg tags: ULong): CborInteger =
     if (value >= 0L) CborInteger(value.toULong(), isPositive = true, tags = tags)
     else CborInteger(ULong.MAX_VALUE - value.toULong() + 1uL, isPositive = false, tags = tags)
@@ -129,18 +133,21 @@ public fun CborInteger(value: Long, vararg tags: ULong): CborInteger =
 /**
  * Creates an unsigned CBOR integer (major type 0).
  */
+@ExperimentalSerializationApi
 public fun CborInteger(value: ULong, vararg tags: ULong): CborInteger =
     CborInteger(value, isPositive = true, tags = tags)
 
 /**
  * Converts this integer to [Long], throwing if it cannot be represented as [Long].
  */
+@ExperimentalSerializationApi
 public val CborInteger.long: Long
     get() = longOrNull ?: throw ArithmeticException("$this cannot be represented as Long")
 
 /**
  * Converts this integer to [Long], or returns `null` if it cannot be represented as [Long].
  */
+@ExperimentalSerializationApi
 public val CborInteger.longOrNull: Long?
     get() {
         val max = Long.MAX_VALUE.toULong()
@@ -158,12 +165,14 @@ public val CborInteger.longOrNull: Long?
 /**
  * Converts this integer to [Int], throwing if it cannot be represented as [Int].
  */
+@ExperimentalSerializationApi
 public val CborInteger.int: Int
     get() = intOrNull ?: throw ArithmeticException("$this cannot be represented as Int")
 
 /**
  * Converts this integer to [Int], or returns `null` if it cannot be represented as [Int].
  */
+@ExperimentalSerializationApi
 public val CborInteger.intOrNull: Int?
     get() {
         val longValue = longOrNull ?: return null
@@ -174,12 +183,14 @@ public val CborInteger.intOrNull: Int?
 /**
  * Converts this integer to [Short], throwing if it cannot be represented as [Short].
  */
+@ExperimentalSerializationApi
 public val CborInteger.short: Short
     get() = shortOrNull ?: throw ArithmeticException("$this cannot be represented as Short")
 
 /**
  * Converts this integer to [Short], or returns `null` if it cannot be represented as [Short].
  */
+@ExperimentalSerializationApi
 public val CborInteger.shortOrNull: Short?
     get() {
         val longValue = longOrNull ?: return null
@@ -190,12 +201,14 @@ public val CborInteger.shortOrNull: Short?
 /**
  * Converts this integer to [Byte], throwing if it cannot be represented as [Byte].
  */
+@ExperimentalSerializationApi
 public val CborInteger.byte: Byte
     get() = byteOrNull ?: throw ArithmeticException("$this cannot be represented as Byte")
 
 /**
  * Converts this integer to [Byte], or returns `null` if it cannot be represented as [Byte].
  */
+@ExperimentalSerializationApi
 public val CborInteger.byteOrNull: Byte?
     get() {
         val longValue = longOrNull ?: return null
@@ -206,6 +219,7 @@ public val CborInteger.byteOrNull: Byte?
 /**
  * Class representing CBOR floating point value (major type 7).
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborFloatSerializer::class)
 public class CborFloat(
     public val value: Double,
@@ -231,6 +245,7 @@ public class CborFloat(
 /**
  * Class representing CBOR string value.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborStringSerializer::class)
 public class CborString(
     public val value: String,
@@ -256,6 +271,7 @@ public class CborString(
 /**
  * Class representing CBOR boolean value.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborBooleanSerializer::class)
 public class CborBoolean(
     public val value: Boolean,
@@ -293,6 +309,7 @@ public class CborBoolean(
 /**
  * Class representing CBOR byte string value.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborByteStringSerializer::class)
 public class CborByteString(
     bytes: ByteArray,
@@ -335,6 +352,7 @@ public class CborByteString(
 /**
  * Class representing CBOR `null` value
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborNullSerializer::class)
 public class CborNull(vararg tags: ULong) : CborPrimitive(tags) {
 
@@ -356,6 +374,7 @@ public class CborNull(vararg tags: ULong) : CborPrimitive(tags) {
 /**
  * Class representing CBOR `undefined` value
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborUndefinedSerializer::class)
 public class CborUndefined(vararg tags: ULong) : CborPrimitive(tags) {
 
@@ -380,6 +399,7 @@ public class CborUndefined(vararg tags: ULong) : CborPrimitive(tags) {
  * Since this class also implements [Map] interface, you can use
  * traditional methods like [Map.get] or [Map.getValue] to obtain CBOR elements.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborMapSerializer::class)
 public class CborMap(
     private val content: Map<CborElement, CborElement>,
@@ -440,6 +460,7 @@ public class CborMap(
  * Since this class also implements [List] interface, you can use
  * traditional methods like [List.get] or [List.size] to obtain CBOR elements.
  */
+@ExperimentalSerializationApi
 @Serializable(with = CborArraySerializer::class)
 public class CborArray(
     private val content: List<CborElement>,
@@ -467,7 +488,7 @@ public class CborArray(
 /**
  * Creates a copy of this [CborPrimitive] with the specified [tags], discarding any existing tags.
  */
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 @Suppress("UNCHECKED_CAST")
 public fun <T : CborElement> T.copy(vararg tags: ULong): T =
     when (this) {
@@ -485,62 +506,80 @@ public fun <T : CborElement> T.copy(vararg tags: ULong): T =
 /**
  * Creates a copy of this [CborPrimitive] with the specified [tags], discarding any existing tags.
  */
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 public fun <T : CborPrimitive> T.copy(tags: List<ULong>): T = copy(*tags.toULongArray())
 
 
 /*START BOOLEAN*/
 /** Creates copy of this [CborBoolean] with the specified [value], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborBoolean.copy(value: Boolean): CborBoolean = CborBoolean(value, *(rawTags.copyOf()))
 /** Creates copy of this [CborBoolean] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborBoolean.copy(value: Boolean, vararg tags: ULong): CborBoolean = CborBoolean(value, *tags)
 /** Creates copy of this [CborBoolean] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborBoolean.copy(value: Boolean, tags: List<ULong>): CborBoolean = copy(value, *tags.toULongArray())
 /*END BOOLEAN*/
 
 /*START INTEGER*/
 /** Creates copy of this [CborInteger] with the specified [value], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborInteger.copy(value: Long): CborInteger = CborInteger(value, *(rawTags.copyOf()))
 /** Creates copy of this [CborInteger] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborInteger.copy(value: Long, vararg tags: ULong): CborInteger = CborInteger(value, *tags)
 /** Creates copy of this [CborInteger] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborInteger.copy(value: Long, tags: List<ULong>): CborInteger = copy(value, *tags.toULongArray())
 
 /** Creates copy of this [CborInteger] with the specified [absoluteValue] and [isPositive], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborInteger.copy(absoluteValue: ULong, isPositive: Boolean): CborInteger =
     CborInteger(absoluteValue, isPositive, *(rawTags.copyOf()))
 /** Creates copy of this [CborInteger] with the specified [absoluteValue], [isPositive] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborInteger.copy(absoluteValue: ULong, isPositive: Boolean, vararg tags: ULong): CborInteger =
     CborInteger(absoluteValue, isPositive, *tags)
 /** Creates copy of this [CborInteger] with the specified [absoluteValue], [isPositive] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborInteger.copy(absoluteValue: ULong, isPositive: Boolean, tags: List<ULong>): CborInteger =
     copy(absoluteValue, isPositive, *tags.toULongArray())
 /*END INTEGER*/
 
 /*START FLOAT*/
 /** Creates copy of this [CborFloat] with the specified [value], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborFloat.copy(value: Double): CborFloat = CborFloat(value, *(rawTags.copyOf()))
 /** Creates copy of this [CborFloat] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborFloat.copy(value: Double, vararg tags: ULong): CborFloat = CborFloat(value, *tags)
 /** Creates copy of this [CborFloat] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborFloat.copy(value: Double, tags: List<ULong>): CborFloat = copy(value, *tags.toULongArray())
 /*END FLOAT*/
 
 /*START STRING*/
 /** Creates copy of this [CborString] with the specified [value], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborString.copy(value: String): CborString = CborString(value, *(rawTags.copyOf()))
 /** Creates copy of this [CborString] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborString.copy(value: String, vararg tags: ULong): CborString = CborString(value, *tags)
 /** Creates copy of this [CborString] with the specified [value] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborString.copy(value: String, tags: List<ULong>): CborString = copy(value, *tags.toULongArray())
 /*END STRING*/
 
 /*START BYTE STRING*/
 /** Creates copy of this [CborByteString] with the specified [bytes], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborByteString.copy(bytes: ByteArray): CborByteString = CborByteString(bytes, *(rawTags.copyOf()))
 /** Creates copy of this [CborByteString] with the specified [bytes] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborByteString.copy(bytes: ByteArray, vararg tags: ULong): CborByteString = CborByteString(bytes, *tags)
 /** Creates copy of this [CborByteString] with the specified [bytes] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborByteString.copy(bytes: ByteArray, tags: List<ULong>): CborByteString =
     copy(bytes, *tags.toULongArray())
 /*END BYTE STRING*/
@@ -548,39 +587,48 @@ public fun CborByteString.copy(bytes: ByteArray, tags: List<ULong>): CborByteStr
 
 /*START MAP*/
 /** Creates copy of this [CborMap] with the specified [content], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborMap.copy(content: Map<CborElement, CborElement>): CborMap = CborMap(content, *(rawTags.copyOf()))
 /** Creates copy of this [CborMap] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborMap.copy(content: Map<CborElement, CborElement>, vararg tags: ULong): CborMap = CborMap(content, *tags)
 /** Creates copy of this [CborMap] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborMap.copy(content: Map<CborElement, CborElement>, tags: List<ULong>): CborMap =
     copy(content, *tags.toULongArray())
 
 /** Creates copy of this [CborMap] with the specified [content], copying all tags.*/
+@ExperimentalSerializationApi
 @JvmName("copyStringMap")
 public fun CborMap.copy(content: Map<String, CborElement>): CborMap =
     CborMap(content.mapKeys { (k, _) -> CborString(k) }, *(rawTags.copyOf()))
 
 /** Creates copy of this [CborMap] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 @JvmName("copyStringMapVarargs")
 public fun CborMap.copy(content: Map<String, CborElement>, vararg tags: ULong): CborMap =
     CborMap(content.mapKeys { (k, _) -> CborString(k) }, *tags)
 
 /** Creates copy of this [CborMap] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 @JvmName("copyStringMapList")
 public fun CborMap.copy(content: Map<String, CborElement>, tags: List<ULong>): CborMap =
     copy(content, *tags.toULongArray())
 
 /** Creates copy of this [CborMap] with the specified [content], copying all tags.*/
+@ExperimentalSerializationApi
 @JvmName("copyLongMap")
 public fun CborMap.copy(content: Map<Long, CborElement>): CborMap =
     CborMap(content.mapKeys { (k, _) -> CborInteger(k) }, *(rawTags.copyOf()))
 
 /** Creates copy of this [CborMap] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 @JvmName("copyLongMapVarargs")
 public fun CborMap.copy(content: Map<Long, CborElement>, vararg tags: ULong): CborMap =
     CborMap(content.mapKeys { (k, _) -> CborInteger(k) }, *tags)
 
 /** Creates copy of this [CborMap] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 @JvmName("copyLongMapList")
 public fun CborMap.copy(content: Map<Long, CborElement>, tags: List<ULong>): CborMap =
     copy(content, *tags.toULongArray())
@@ -589,18 +637,24 @@ public fun CborMap.copy(content: Map<Long, CborElement>, tags: List<ULong>): Cbo
 
 /*START ARRAY*/
 /** Creates copy of this [CborArray] with the specified [content], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborArray.copy(content: List<CborElement>): CborArray = CborArray(content, *(rawTags.copyOf()))
 /** Creates copy of this [CborArray] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborArray.copy(content: List<CborElement>, vararg tags: ULong): CborArray = CborArray(content, *tags)
 /** Creates copy of this [CborArray] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborArray.copy(content: List<CborElement>, tags: List<ULong>): CborArray =
     copy(content, *tags.toULongArray())
 
 /** Creates copy of this [CborArray] with the specified [content], copying all tags.*/
+@ExperimentalSerializationApi
 public fun CborArray.copy(content: Array<CborElement>): CborArray = CborArray(content, *(rawTags.copyOf()))
 /** Creates copy of this [CborArray] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborArray.copy(content: Array<CborElement>, vararg tags: ULong): CborArray = CborArray(content, *tags)
 /** Creates copy of this [CborArray] with the specified [content] and [tags].*/
+@ExperimentalSerializationApi
 public fun CborArray.copy(content: Array<CborElement>, tags: List<ULong>): CborArray =
     copy(content, *tags.toULongArray())
 /*END ARRAY*/

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborElementSerializers.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborElementSerializers.kt
@@ -54,6 +54,7 @@ internal object CborElementSerializer : KSerializer<CborElement>, CborSerializer
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborPrimitive].
  * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborPrimitiveSerializer : KSerializer<CborPrimitive>, CborSerializer {
     override val descriptor: SerialDescriptor =
         buildSerialDescriptor("kotlinx.serialization.cbor.CborPrimitive", PolymorphicKind.SEALED)
@@ -99,6 +100,7 @@ internal object CborNullSerializer : KSerializer<CborNull>, CborSerializer {
     }
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborUndefinedSerializer : KSerializer<CborUndefined>, CborSerializer {
     override val descriptor: SerialDescriptor =
         buildSerialDescriptor("kotlinx.serialization.cbor.CborUndefined", SerialKind.ENUM)
@@ -116,7 +118,7 @@ internal object CborUndefinedSerializer : KSerializer<CborUndefined>, CborSerial
     }
 }
 
-
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborIntSerializer : KSerializer<CborInteger>, CborSerializer {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("kotlinx.serialization.cbor.CborInt", PrimitiveKind.LONG)
@@ -139,6 +141,7 @@ internal object CborIntSerializer : KSerializer<CborInteger>, CborSerializer {
     }
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborFloatSerializer : KSerializer<CborFloat>, CborSerializer {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("kotlinx.serialization.cbor.CborDouble", PrimitiveKind.DOUBLE)
@@ -160,6 +163,7 @@ internal object CborFloatSerializer : KSerializer<CborFloat>, CborSerializer {
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborString].
  * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborStringSerializer : KSerializer<CborString>, CborSerializer {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("kotlinx.serialization.cbor.CborString", PrimitiveKind.STRING)
@@ -182,6 +186,7 @@ internal object CborStringSerializer : KSerializer<CborString>, CborSerializer {
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborBoolean].
  * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborBooleanSerializer : KSerializer<CborBoolean>, CborSerializer {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("kotlinx.serialization.cbor.CborBoolean", PrimitiveKind.BOOLEAN)
@@ -204,6 +209,7 @@ internal object CborBooleanSerializer : KSerializer<CborBoolean>, CborSerializer
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborByteString].
  * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborByteStringSerializer : KSerializer<CborByteString>, CborSerializer {
     override val descriptor: SerialDescriptor =
         SerialDescriptor("kotlinx.serialization.cbor.CborByteString", ByteArraySerializer().descriptor)
@@ -226,6 +232,7 @@ internal object CborByteStringSerializer : KSerializer<CborByteString>, CborSeri
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborMap].
  * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborMapSerializer : KSerializer<CborMap>, CborSerializer {
     override val descriptor: SerialDescriptor =
         SerialDescriptor(
@@ -250,6 +257,7 @@ internal object CborMapSerializer : KSerializer<CborMap>, CborSerializer {
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborArray].
  * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal object CborArraySerializer : KSerializer<CborArray>, CborSerializer {
     override val descriptor: SerialDescriptor =
         SerialDescriptor(
@@ -270,7 +278,7 @@ internal object CborArraySerializer : KSerializer<CborArray>, CborSerializer {
     }
 }
 
-
+@ExperimentalSerializationApi
 internal fun Decoder.asCborDecoder(): CborDecoder = this as? CborDecoder
     ?: throw IllegalStateException(
         "This serializer can be used only with Cbor format. " +
@@ -289,7 +297,6 @@ internal fun Encoder.asCborWriter() = this as? CborWriter
  * Returns serial descriptor that delegates all the calls to descriptor returned by [deferred] block.
  * Used to resolve cyclic dependencies between recursive serializable structures.
  */
-@OptIn(ExperimentalSerializationApi::class)
 private fun defer(deferred: () -> SerialDescriptor): SerialDescriptor = object : SerialDescriptor {
     private val original: SerialDescriptor by lazy(deferred)
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborElementSerializers.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborElementSerializers.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 @file:OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class, DelicateCborApi::class)
 
 package kotlinx.serialization.cbor.internal

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborElementSerializers.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborElementSerializers.kt
@@ -52,7 +52,7 @@ internal object CborElementSerializer : KSerializer<CborElement>, CborSerializer
 
 /**
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborPrimitive].
- * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
+ * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
 @OptIn(ExperimentalSerializationApi::class)
 internal object CborPrimitiveSerializer : KSerializer<CborPrimitive>, CborSerializer {
@@ -80,7 +80,7 @@ internal object CborPrimitiveSerializer : KSerializer<CborPrimitive>, CborSerial
 
 /**
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborNull].
- * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
+ * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
 internal object CborNullSerializer : KSerializer<CborNull>, CborSerializer {
 
@@ -161,7 +161,7 @@ internal object CborFloatSerializer : KSerializer<CborFloat>, CborSerializer {
 
 /**
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborString].
- * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
+ * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
 @OptIn(ExperimentalSerializationApi::class)
 internal object CborStringSerializer : KSerializer<CborString>, CborSerializer {
@@ -184,7 +184,7 @@ internal object CborStringSerializer : KSerializer<CborString>, CborSerializer {
 
 /**
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborBoolean].
- * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
+ * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
 @OptIn(ExperimentalSerializationApi::class)
 internal object CborBooleanSerializer : KSerializer<CborBoolean>, CborSerializer {
@@ -255,7 +255,7 @@ internal object CborMapSerializer : KSerializer<CborMap>, CborSerializer {
 
 /**
  * Serializer object providing [SerializationStrategy] and [DeserializationStrategy] for [CborArray].
- * It can only be used by with [Cbor] format an its input ([CborDecoder] and [CborEncoder]).
+ * It can only be used by with [Cbor] format and its input ([CborDecoder] and [CborEncoder]).
  */
 @OptIn(ExperimentalSerializationApi::class)
 internal object CborArraySerializer : KSerializer<CborArray>, CborSerializer {

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborParser.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborParser.kt
@@ -1,8 +1,9 @@
-@file:OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+@file:OptIn(ExperimentalUnsignedTypes::class)
 
 package kotlinx.serialization.cbor.internal
-
-import kotlinx.serialization.*
 
 /**
  * Common interface for CBOR parsers that can read CBOR data from different sources.

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborTreeReader.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborTreeReader.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 @file:OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
 
 package kotlinx.serialization.cbor.internal

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborTreeReader.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborTreeReader.kt
@@ -15,8 +15,8 @@ internal class CborTreeReader(
     //no config values make sense here, because we have no "schema".
     //we cannot validate tags, or disregard nulls, can we?!
     //still, this needs to go here, in case it evolves to a point where we need to respect certain config values
-    private val configuration: CborConfiguration,
-    private val parser: CborParserImpl
+    @Suppress("UNUSED") private val configuration: CborConfiguration,
+    private val parser: StreamingCborParser
 ) {
     /**
      * Reads the next CBOR element from the parser.

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborTreeReader.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborTreeReader.kt
@@ -25,52 +25,52 @@ internal class CborTreeReader(
         // Read any tags before the actual value
         val tags = readTags()
 
-        val result = when (parser.curByte shr 5) { // Get major type from the first 3 bits
-            0 -> { // Major type 0: unsigned integer
+        if (parser.isEof()) throw CborDecodingException("Unexpected EOF")
+
+        val majorType = parser.curByte and MAJOR_TYPE_MASK
+        val result = when (majorType) { // Get major type from the first 3 bits
+            HEADER_POSITIVE -> { // Major type 0: unsigned integer
                 val value = parser.nextULong()
                 CborInteger(value, isPositive = true, tags = tags)
             }
 
-            1 -> { // Major type 1: negative integer
+            HEADER_NEGATIVE -> { // Major type 1: negative integer
                 val value = parser.nextULong() + 1uL
                 CborInteger(value, isPositive = false, tags = tags)
             }
 
-            2 -> { // Major type 2: byte string
+            HEADER_BYTE_STRING -> { // Major type 2: byte string
                 CborByteString(parser.nextByteString(), tags = tags)
             }
 
-            3 -> { // Major type 3: text string
+            HEADER_STRING -> { // Major type 3: text string
                 CborString(parser.nextString(), tags = tags)
             }
 
-            4 -> { // Major type 4: array
+            HEADER_ARRAY -> { // Major type 4: array
                 readArray(tags)
             }
 
-            5 -> { // Major type 5: map
+            HEADER_MAP -> { // Major type 5: map
                 readMap(tags)
             }
 
-            7 -> { // Major type 7: simple/float/break
+            HEADER_SIMPLE -> { // Major type 7: simple/float/break
                 when (parser.curByte) {
-                    0xF4 -> {
+                    FALSE, TRUE -> {
                         CborBoolean(parser.nextBoolean(null), tags = tags)
                     }
 
-                    0xF5 -> {
-                        CborBoolean(parser.nextBoolean(null), tags = tags)
-                    }
-
-                    0xF6 -> {
+                    NULL -> {
                         parser.nextNull(null)
                         CborNull(tags = tags)
                     }
 
-                    0xF7 -> {
+                    UNDEFINED -> {
                         parser.skipElement(null)
                         CborUndefined(tags = tags)
                     }
+
                     // Half/Float32/Float64
                     NEXT_HALF, NEXT_FLOAT, NEXT_DOUBLE -> CborFloat(parser.nextDouble(null), tags = tags)
                     else -> throw CborDecodingException(
@@ -81,8 +81,7 @@ internal class CborTreeReader(
 
             else -> {
                 val errByte = parser.curByte shr 5
-                throw if (errByte == -1) CborDecodingException("Unexpected EOF")
-                else CborDecodingException("Invalid CBOR major type: $errByte")
+                throw CborDecodingException("Invalid CBOR major type: $errByte")
             }
         }
         return result
@@ -93,10 +92,10 @@ internal class CborTreeReader(
      * @return An array of tags, possibly empty
      */
     private fun readTags(): ULongArray {
-        if ((parser.curByte shr 5) != 6) return EMPTY_TAGS
+        if (parser.curByte and MAJOR_TYPE_MASK != HEADER_TAG) return EMPTY_TAGS
 
         val tags = mutableListOf<ULong>()
-        while ((parser.curByte shr 5) == 6) { // Major type 6: tag
+        while ((parser.curByte and MAJOR_TYPE_MASK) == HEADER_TAG) { // Major type 6: tag
             tags.add(parser.nextTag())
         }
         return tags.toULongArray()

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborWriter.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/CborWriter.kt
@@ -1,8 +1,4 @@
-@file:OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
-
 package kotlinx.serialization.cbor.internal
-
-import kotlinx.serialization.*
 
 /**
  * Common interface for CBOR writers that can emit CBOR data to different destinations.
@@ -23,6 +19,8 @@ internal sealed interface CborWriter {
     fun encodeUndefined()
 
     // Tag writing
+    @OptIn(ExperimentalUnsignedTypes::class)
     fun encodeTags(tags: ULongArray)
+    @OptIn(ExperimentalUnsignedTypes::class)
     fun encodeElementTags(tags: ULongArray)
 }

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -17,7 +17,7 @@ internal open class CborReader(override val cbor: Cbor, internal val parser: Cbo
 
     override fun decodeCborElement(): CborElement =
         when (parser) {
-            is CborParserImpl -> CborTreeReader(cbor.configuration, parser).read()
+            is StreamingCborParser -> CborTreeReader(cbor.configuration, parser).read()
             is StructuredCborParser -> parser.layer.current
         }
 
@@ -208,7 +208,10 @@ internal open class CborReader(override val cbor: Cbor, internal val parser: Cbo
 
 }
 
-internal class CborParserImpl(private val input: ByteArrayInput, private val verifyObjectTags: Boolean) : CborParser {
+/**
+ * Parses CBOR data items from a CBOR-encoded byte sequence.
+ */
+internal class StreamingCborParser(private val input: ByteArrayInput, private val verifyObjectTags: Boolean) : CborParser {
     private var curByteOrEof: Int = -1
 
     internal val curByte: Int
@@ -746,7 +749,8 @@ internal class PeekingIterator private constructor(
 }
 
 /**
- * CBOR parser that operates on [CborElement] instead of bytes. Closely mirrors the behaviour of [CborParserImpl], so the
+ * CBOR parser that operates on [CborElement] instead of bytes.
+ * Closely mirrors the behaviour of [StreamingCborParser], so the
  * [CborDecoder] can remain largely unchanged.
  */
 internal class StructuredCborParser(internal val element: CborElement, private val verifyObjectTags: Boolean) :

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -378,7 +378,7 @@ internal class StreamingCborParser(private val input: ByteArrayInput, private va
                     // the expected tags. (yes this could co somewhere else, but putting it here groups the code nicely
                     // into if-else branches.
                     if ((collectedTags.size < it.size) || (collectedTags.subList(0, it.size) != it.asList())) {
-                        throw CborDecodingException("CBOR tags $collectedTags do not start with specified tags $it")
+                        throw CborDecodingException("CBOR tags $collectedTags do not start with specified tags ${it.contentToString()}")
                     }
                 }
             }
@@ -439,10 +439,10 @@ internal class StreamingCborParser(private val input: ByteArrayInput, private va
     private fun readNumber(): Long {
         val headerByte = peekCurByteOrFail()
         val majorType = headerByte and MAJOR_TYPE_MASK
-        if (majorType != HEADER_NEGATIVE.toInt() && majorType != HEADER_POSITIVE.toInt()) {
+        if (majorType != HEADER_NEGATIVE && majorType != HEADER_POSITIVE) {
             throw CborDecodingException("an unsigned or negative integer", headerByte)
         }
-        val negative = majorType == HEADER_NEGATIVE.toInt()
+        val negative = majorType == HEADER_NEGATIVE
         val unsignedValue = readUnsignedIntegerIgnoringMajorType { majorType.majorTypeName }
         return if (negative) -(unsignedValue + 1) else unsignedValue
     }
@@ -702,8 +702,8 @@ private val Int.majorTypeName: String
         HEADER_ARRAY -> "array"
         HEADER_MAP -> "map"
         HEADER_TAG -> "tag"
-        HEADER_POSITIVE.toInt() -> "unsigned integer"
-        HEADER_NEGATIVE.toInt() -> "negative integer"
+        HEADER_POSITIVE -> "unsigned integer"
+        HEADER_NEGATIVE -> "negative integer"
         else -> "<unknown>"
     }
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Decoder.kt
@@ -54,7 +54,6 @@ internal open class CborReader(override val cbor: Cbor, internal val parser: Cbo
 
     protected open fun skipBeginToken(objectTags: ULongArray?) = setSize(parser.startMap(objectTags))
 
-    @OptIn(ExperimentalSerializationApi::class)
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
         val re = if (descriptor.hasArrayTag()) {
             CborArrayReader(cbor, parser)
@@ -991,13 +990,11 @@ private fun floatFromHalfBits(bits: Short): Float {
 }
 
 
-@OptIn(ExperimentalSerializationApi::class)
 private fun SerialDescriptor.getElementNameForCborLabel(label: Long): String? {
     return elementNames.firstOrNull { getCborLabel(getElementIndex(it)) == label }
 }
 
 
-@OptIn(ExperimentalSerializationApi::class)
 private fun SerialDescriptor.getElementIndexOrThrow(name: String): Int {
     val index = getElementIndex(name)
     if (index == CompositeDecoder.UNKNOWN_NAME)

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoder.kt
@@ -640,12 +640,12 @@ private fun encodeToByteArray(value: ULong, bytes: Int, tag: Byte): ByteArray {
 private fun composeNegative(value: Long): ByteArray {
     val aVal = if (value == Long.MIN_VALUE) Long.MAX_VALUE else -1 - value
     val data = composePositive(aVal.toULong())
-    data[0] = data[0] or HEADER_NEGATIVE
+    data[0] = data[0] or HEADER_NEGATIVE.toByte()
     return data
 }
 
 private fun composeNegativeULong(value: ULong): ByteArray {
     val data = composePositive(value-1uL)
-    data[0] = data[0] or HEADER_NEGATIVE
+    data[0] = data[0] or HEADER_NEGATIVE.toByte()
     return data
 }

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -60,21 +60,16 @@ internal fun SerialDescriptor.isInlineByteString(): Boolean {
     return isInline && isByteString(0)
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 internal fun SerialDescriptor.getValueTags(index: Int): ULongArray? = findAnnotation<ValueTags>(index)?.tags
 
-@OptIn(ExperimentalSerializationApi::class)
 internal fun SerialDescriptor.getKeyTags(index: Int): ULongArray? = findAnnotation<KeyTags>(index)?.tags
 
-@OptIn(ExperimentalSerializationApi::class)
 internal fun SerialDescriptor.getCborLabel(index: Int): Long? = findAnnotation<CborLabel>(index)?.label
 
-@OptIn(ExperimentalSerializationApi::class)
 internal fun SerialDescriptor.hasArrayTag(): Boolean {
     return annotations.any { it is CborObjectAsArray }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 internal inline fun <reified A : Annotation> SerialDescriptor.findAnnotation(elementIndex: Int): A? =
     getElementAnnotations(elementIndex).firstOrNull { it is A } as A?
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -30,11 +30,12 @@ internal const val ADDITIONAL_INFO_MASK: Int = 0b000_11111
 
 internal const val HEADER_BYTE_STRING: Int = 0b010_00000
 internal const val HEADER_STRING: Int = 0b011_00000
-internal const val HEADER_POSITIVE: Byte = 0b000_00000
-internal const val HEADER_NEGATIVE: Byte = 0b001_00000
+internal const val HEADER_POSITIVE: Int = 0b000_00000
+internal const val HEADER_NEGATIVE: Int = 0b001_00000
 internal const val HEADER_ARRAY: Int = 0b100_00000
 internal const val HEADER_MAP: Int = 0b101_00000
 internal const val HEADER_TAG: Int = 0b110_00000
+internal const val HEADER_SIMPLE: Int = 0b111_00000
 
 /** Value to represent an indefinite length CBOR item within a "length stack". */
 internal const val LENGTH_STACK_INDEFINITE = -1

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Unsigned.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Unsigned.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 @file:OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
 
 package kotlinx.serialization.cbor.internal

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Unsigned.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Unsigned.kt
@@ -77,7 +77,7 @@ internal class UnsignedInlineDecoder(
                 integer.absoluteValue.toLong()
             }
 
-            is CborParserImpl -> {
+            is StreamingCborParser -> {
                 parser.processTags(tags)
                 val header = parser.curByte
                 if ((header and MAJOR_TYPE_MASK) != HEADER_POSITIVE.toInt()) {

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Unsigned.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Unsigned.kt
@@ -80,7 +80,7 @@ internal class UnsignedInlineDecoder(
             is StreamingCborParser -> {
                 parser.processTags(tags)
                 val header = parser.curByte
-                if ((header and MAJOR_TYPE_MASK) != HEADER_POSITIVE.toInt()) {
+                if ((header and MAJOR_TYPE_MASK) != HEADER_POSITIVE) {
                     throw CborDecodingException("unsigned integer", header)
                 }
                 parser.nextULong(null).toLong()

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
@@ -78,7 +78,7 @@ class CborDecoderTest {
     @Test
     fun testDecodeCollectionSize() {
         fun decodeCollectionSize(data: String, descriptor: SerialDescriptor): Int {
-            val parser = CborParserImpl(ByteArrayInput(data.hexToByteArray()), false)
+            val parser = StreamingCborParser(ByteArrayInput(data.hexToByteArray()), false)
             val decoder = CborReader(Cbor, parser).beginStructure(descriptor)
             return decoder.decodeCollectionSize(descriptor)
         }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDecoderTest.kt
@@ -2,8 +2,6 @@
  * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:OptIn(ExperimentalUnsignedTypes::class)
-
 package kotlinx.serialization.cbor
 
 import kotlinx.serialization.*

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDelegatedPropertiesTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDelegatedPropertiesTest.kt
@@ -157,7 +157,29 @@ class CborDelegatedPropertiesTest {
         val label: Long?,
         val keyTags: ULongArray = ulongArrayOf(),
         val valueTags: ULongArray = ulongArrayOf(),
-    )
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as FieldSpec
+
+            if (label != other.label) return false
+            if (name != other.name) return false
+            if (!keyTags.contentEquals(other.keyTags)) return false
+            if (!valueTags.contentEquals(other.valueTags)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = label.hashCode()
+            result = 31 * result + name.hashCode()
+            result = 31 * result + keyTags.contentHashCode()
+            result = 31 * result + valueTags.contentHashCode()
+            return result
+        }
+    }
 
     private object MapBackedPersonSerializer : KSerializer<MapBackedPerson> {
         override val descriptor: SerialDescriptor = buildClassSerialDescriptor("MapBackedPerson")

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDelegatedPropertiesTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborDelegatedPropertiesTest.kt
@@ -20,7 +20,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertIs
 
 class CborDelegatedPropertiesTest {
 
@@ -250,7 +250,7 @@ class CborDelegatedPropertiesTest {
             person.put("country", CborString("AT"))
         }
         val element = cbor.encodeToCborElement(MapBackedPersonSerializer, value)
-        assertTrue(element is CborMap)
+        assertIs<CborMap>(element)
         val decoded = cbor.decodeFromCborElement(MapBackedPersonSerializer, element)
         assertEquals(value, decoded)
         assertEquals("female", decoded.gender)
@@ -266,7 +266,7 @@ class CborDelegatedPropertiesTest {
         }
 
         val element = cbor.encodeToCborElement(MapBackedPersonSerializer, value)
-        assertTrue(element is CborMap)
+        assertIs<CborMap>(element)
         assertEquals(CborString("Ada"), element.getValue(NAME_LABEL))
         assertEquals(CborInteger(42), element.getValue(AGE_LABEL))
         assertEquals(CborString("female"), element.getValue(GENDER_LABEL))
@@ -278,6 +278,6 @@ class CborDelegatedPropertiesTest {
         assertEquals(42, decoded.age)
         assertEquals("female", decoded.gender)
         assertEquals(CborString("AT"), decoded.backing["country"])
-        assertTrue(decoded.backing["name"] is CborString)
+        assertIs<CborString>(decoded.backing["name"])
     }
 }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementEqualityTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementEqualityTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package kotlinx.serialization.cbor
 
 import kotlin.test.*

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementSerializerBehaviorTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementSerializerBehaviorTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package kotlinx.serialization.cbor
 
 import kotlinx.serialization.*
@@ -41,7 +43,7 @@ class CborElementSerializerBehaviorTest {
         override fun decodeInt(): Int = error("unused")
         override fun decodeLong(): Long = error("unused")
         override fun decodeNotNullMark(): Boolean = error("unused")
-        override fun decodeNull(): Nothing? = error("unused")
+        override fun decodeNull(): Nothing = error("unused")
         override fun decodeShort(): Short = error("unused")
         override fun decodeString(): String = error("unused")
         override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T = error("unused")
@@ -52,7 +54,7 @@ class CborElementSerializerBehaviorTest {
         val ex = assertFailsWith<IllegalStateException> {
             CborElement.serializer().serialize(NonCborEncoder, CborInteger(1))
         }
-        assertTrue(ex.message?.contains("This serializer can be used only with Cbor format") == true)
+        assertContains(ex.message!!, "This serializer can be used only with Cbor format")
     }
 
     @Test
@@ -60,7 +62,7 @@ class CborElementSerializerBehaviorTest {
         val ex = assertFailsWith<IllegalStateException> {
             CborElement.serializer().deserialize(NonCborDecoder)
         }
-        assertTrue(ex.message?.contains("This serializer can be used only with Cbor format") == true)
+        assertContains(ex.message!!, "This serializer can be used only with Cbor format")
     }
 
     @Test
@@ -91,7 +93,7 @@ class CborElementSerializerBehaviorTest {
     fun structuredByteStringDecodesToByteArray() {
         val cbor = Cbor { alwaysUseByteString = true }
         val element = cbor.encodeToCborElement(byteArrayOf(1, 2, 3))
-        assertTrue(element is CborByteString)
+        assertIs<CborByteString>(element)
         assertTrue(cbor.decodeFromCborElement<ByteArray>(element).contentEquals(byteArrayOf(1, 2, 3)))
     }
 }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementSerializerBehaviorTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementSerializerBehaviorTest.kt
@@ -1,18 +1,11 @@
 package kotlinx.serialization.cbor
 
-import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.SerializationStrategy
-import kotlinx.serialization.cbor.internal.CborDecodingException
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.CompositeDecoder
-import kotlinx.serialization.encoding.CompositeEncoder
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.modules.EmptySerializersModule
-import kotlinx.serialization.modules.SerializersModule
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import kotlinx.serialization.*
+import kotlinx.serialization.cbor.internal.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.modules.*
+import kotlin.test.*
 
 class CborElementSerializerBehaviorTest {
 

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementTest.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalSerializationApi::class)
+@file:OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
 
 package kotlinx.serialization.cbor
 
@@ -21,8 +21,8 @@ class CborElementTest {
     fun testEncodeToCborElementRootPrimitiveByteArrayAlwaysUseByteString() {
         val configured = Cbor { alwaysUseByteString = true }
         val element = configured.encodeToCborElement(byteArrayOf(1, 2, 3))
-        assertTrue(element is CborByteString)
-        assertTrue(element.toByteArray().contentEquals(byteArrayOf(1, 2, 3)))
+        assertIs<CborByteString>(element)
+        assertContentEquals(byteArrayOf(1, 2, 3), element.toByteArray())
         assertTrue(configured.decodeFromCborElement<ByteArray>(element).contentEquals(byteArrayOf(1, 2, 3)))
     }
 
@@ -43,7 +43,7 @@ class CborElementTest {
     fun testEncodeDecodeRootListViaCborElement() {
         val value = listOf(1, 2, 3)
         val element = cbor.encodeToCborElement(value)
-        assertTrue(element is CborArray)
+        assertIs<CborArray>(element)
         assertEquals(value, cbor.decodeFromCborElement<List<Int>>(element))
     }
 
@@ -68,8 +68,8 @@ class CborElementTest {
     fun testCborNumberZero() {
         val numberElement = CborInteger(0uL)
         assertEquals(numberElement, CborInteger(0))
-        assertEquals(numberElement.isPositive, true)
-        assertEquals(numberElement.absoluteValue, 0uL)
+        assertEquals(true, numberElement.isPositive)
+        assertEquals(0uL, numberElement.absoluteValue)
         val numberBytes = cbor.encodeToByteArray(numberElement)
         val decodedNumber = cbor.decodeFromByteArray<CborElement>(numberBytes)
         assertEquals(numberElement, decodedNumber)
@@ -79,8 +79,8 @@ class CborElementTest {
     @Test
     fun testCborNumberMax() {
         val numberElement = CborInteger(ULong.MAX_VALUE)
-        assertEquals(numberElement.isPositive, true)
-        assertEquals(numberElement.absoluteValue, ULong.MAX_VALUE)
+        assertEquals(true, numberElement.isPositive)
+        assertEquals(ULong.MAX_VALUE, numberElement.absoluteValue)
         val numberBytes = cbor.encodeToByteArray(numberElement)
         val decodedNumber = cbor.decodeFromByteArray<CborElement>(numberBytes)
         assertEquals(numberElement, decodedNumber)
@@ -88,10 +88,10 @@ class CborElementTest {
     }
 
     @Test
-    fun testCborNumberMaxHalv() {
+    fun testCborNumberMaxHalf() {
         val numberElement = CborInteger(Long.MAX_VALUE)
-        assertEquals(numberElement.isPositive, true)
-        assertEquals(numberElement.absoluteValue, Long.MAX_VALUE.toULong())
+        assertEquals(true, numberElement.isPositive)
+        assertEquals(Long.MAX_VALUE.toULong(), numberElement.absoluteValue)
         val numberBytes = cbor.encodeToByteArray(numberElement)
         val decodedNumber = cbor.decodeFromByteArray<CborElement>(numberBytes)
         assertEquals(numberElement, decodedNumber)
@@ -102,8 +102,8 @@ class CborElementTest {
     @Test
     fun testCborNumberMin() {
         val numberElement = CborInteger(ULong.MAX_VALUE, isPositive = false)
-        assertEquals(numberElement.isPositive, false)
-        assertEquals(numberElement.absoluteValue, ULong.MAX_VALUE)
+        assertEquals(false, numberElement.isPositive)
+        assertEquals(ULong.MAX_VALUE, numberElement.absoluteValue)
         val numberBytes = cbor.encodeToByteArray(numberElement)
         val decodedNumber = cbor.decodeFromByteArray<CborElement>(numberBytes)
         assertEquals(numberElement, decodedNumber)
@@ -116,10 +116,10 @@ class CborElementTest {
 
 
     @Test
-    fun testCborNumberMinHalv() {
+    fun testCborNumberMinHalf() {
         val numberElement = CborInteger(Long.MAX_VALUE.toULong(), isPositive = false)
-        assertEquals(numberElement.isPositive, false)
-        assertEquals(numberElement.absoluteValue, Long.MAX_VALUE.toULong())
+        assertEquals(false, numberElement.isPositive)
+        assertEquals(Long.MAX_VALUE.toULong(), numberElement.absoluteValue)
         val numberBytes = cbor.encodeToByteArray(numberElement)
         val decodedNumber = cbor.decodeFromByteArray<CborElement>(numberBytes)
         assertEquals(numberElement, decodedNumber)
@@ -163,7 +163,7 @@ class CborElementTest {
         val byteStringBytes = cbor.encodeToByteArray(byteStringElement)
         val decodedByteString = cbor.decodeFromByteArray<CborElement>(byteStringBytes)
         assertEquals(byteStringElement, decodedByteString)
-        assertTrue((decodedByteString as CborByteString).toByteArray().contentEquals(byteArray))
+        assertContentEquals(byteArray, (decodedByteString as CborByteString).toByteArray())
     }
 
     @Test
@@ -180,20 +180,20 @@ class CborElementTest {
         val decodedList = cbor.decodeFromByteArray<CborElement>(listBytes)
 
         // Verify the type and size
-        assertTrue(decodedList is CborArray)
+        assertIs<CborArray>(decodedList)
         assertEquals(4, decodedList.size)
 
         // Verify individual elements
-        assertTrue(decodedList[0] is CborInteger)
+        assertIs<CborInteger>(decodedList[0])
         assertEquals(1uL, (decodedList[0] as CborInteger).absoluteValue)
 
-        assertTrue(decodedList[1] is CborString)
+        assertIs<CborString>(decodedList[1])
         assertEquals("two", (decodedList[1] as CborString).value)
 
-        assertTrue(decodedList[2] is CborBoolean)
+        assertIs<CborBoolean>(decodedList[2])
         assertEquals(true, (decodedList[2] as CborBoolean).value)
 
-        assertTrue(decodedList[3] is CborNull)
+        assertIs<CborNull>(decodedList[3])
     }
 
     @Test
@@ -210,33 +210,33 @@ class CborElementTest {
 
         val output = ByteArrayOutput()
         IndefiniteLengthCborWriter(cbor, output).encodeCborElement(mapElement)
-        assertEquals(mapBytes.toHexString(), output.toByteArray().toHexString())
+        assertContentEquals(mapBytes, output.toByteArray())
 
         val decodedMap = cbor.decodeFromByteArray<CborElement>(mapBytes)
 
         // Verify the type and size
-        assertTrue(decodedMap is CborMap)
+        assertIs<CborMap>(decodedMap)
         assertEquals(4, decodedMap.size)
 
         // Verify individual entries
         assertTrue(decodedMap.containsKey(CborString("key1")))
         val value1 = decodedMap[CborString("key1")]
-        assertTrue(value1 is CborInteger)
-        assertEquals(42uL, (value1 as CborInteger).absoluteValue)
+        assertIs<CborInteger>(value1)
+        assertEquals(42uL, value1.absoluteValue)
 
         assertTrue(decodedMap.containsKey(CborString("key2")))
         val value2 = decodedMap[CborString("key2")]
-        assertTrue(value2 is CborString)
-        assertEquals("value", (value2 as CborString).value)
+        assertIs<CborString>(value2)
+        assertEquals("value", value2.value)
 
         assertTrue(decodedMap.containsKey(CborInteger(3u)))
         val value3 = decodedMap[CborInteger(3u)]
-        assertTrue(value3 is CborBoolean)
-        assertEquals(true, (value3 as CborBoolean).value)
+        assertIs<CborBoolean>(value3)
+        assertTrue(value3.value)
 
         assertTrue(decodedMap.containsKey(CborNull()))
         val value4 = decodedMap[CborNull()]
-        assertTrue(value4 is CborNull)
+        assertIs<CborNull>(value4)
     }
 
     @Test
@@ -271,56 +271,55 @@ class CborElementTest {
         val decodedComplex = cbor.decodeFromByteArray<CborElement>(complexBytes)
 
         // Verify the type
-        assertTrue(decodedComplex is CborMap)
+        assertIs<CborMap>(decodedComplex)
 
         // Verify the primitives list
         assertTrue(decodedComplex.containsKey(CborString("primitives")))
         val primitivesValue = decodedComplex[CborString("primitives")]
-        assertTrue(primitivesValue is CborArray)
+        assertIs<CborArray>(primitivesValue)
 
         assertEquals(5, primitivesValue.size)
 
-        assertTrue(primitivesValue[0] is CborInteger)
+        assertIs<CborInteger>(primitivesValue[0])
         assertEquals(123uL, (primitivesValue[0] as CborInteger).absoluteValue)
 
-        assertTrue(primitivesValue[1] is CborString)
+        assertIs<CborString>(primitivesValue[1])
         assertEquals("text", (primitivesValue[1] as CborString).value)
 
-        assertTrue(primitivesValue[2] is CborBoolean)
+        assertIs<CborBoolean>(primitivesValue[2])
         assertEquals(false, (primitivesValue[2] as CborBoolean).value)
 
-        assertTrue(primitivesValue[3] is CborByteString)
-        assertTrue((primitivesValue[3] as CborByteString).toByteArray().contentEquals(byteArrayOf(10, 20, 30)))
+        assertIs<CborByteString>(primitivesValue[3])
+        assertContentEquals(byteArrayOf(10, 20, 30), (primitivesValue[3] as CborByteString).toByteArray())
 
-        assertTrue(primitivesValue[4] is CborNull)
+        assertIs<CborNull>(primitivesValue[4])
 
         // Verify the nested map
         assertTrue(decodedComplex.containsKey(CborString("nested")))
         val nestedValue = decodedComplex[CborString("nested")]
-        assertTrue(nestedValue is CborMap)
+        assertIs<CborMap>(nestedValue)
 
         assertEquals(2, nestedValue.size)
 
         // Verify the inner list
         assertTrue(nestedValue.containsKey(CborString("inner")))
         val innerValue = nestedValue[CborString("inner")]
-        assertTrue(innerValue is CborArray)
+        assertIs<CborArray>(innerValue)
 
         assertEquals(2, innerValue.size)
 
-        assertTrue(innerValue[0] is CborInteger)
+        assertIs<CborInteger>(innerValue[0])
         assertEquals(1uL, (innerValue[0] as CborInteger).absoluteValue)
 
-        assertTrue(innerValue[1] is CborInteger)
+        assertIs<CborInteger>(innerValue[1])
         assertEquals(2uL, (innerValue[1] as CborInteger).absoluteValue)
 
         // Verify the empty list
         assertTrue(nestedValue.containsKey(CborString("empty")))
         val emptyValue = nestedValue[CborString("empty")]
-        assertTrue(emptyValue is CborArray)
-        val empty = emptyValue
+        assertIs<CborArray>(emptyValue)
 
-        assertEquals(0, empty.size)
+        assertEquals(0, emptyValue.size)
     }
 
     @Test
@@ -334,12 +333,12 @@ class CborElementTest {
     fun testDecodeStrings() {
         // Test data from CborParserTest.testParseStrings
         val element = cbor.decodeFromHexString<CborElement>("6568656C6C6F")
-        assertTrue(element is CborString)
+        assertIs<CborString>(element)
         assertEquals("hello", element.value)
 
         val longStringElement =
             cbor.decodeFromHexString<CborElement>("7828737472696E672074686174206973206C6F6E676572207468616E2032332063686172616374657273")
-        assertTrue(longStringElement is CborString)
+        assertIs<CborString>(longStringElement)
         assertEquals("string that is longer than 23 characters", longStringElement.value)
     }
 
@@ -347,11 +346,11 @@ class CborElementTest {
     fun testDecodeFloatingPoint() {
         // Test data from CborParserTest.testParseDoubles
         val doubleElement = cbor.decodeFromHexString<CborElement>("fb7e37e43c8800759c")
-        assertTrue(doubleElement is CborFloat)
+        assertIs<CborFloat>(doubleElement)
         assertEquals(1e+300, doubleElement.value)
 
         val floatElement = cbor.decodeFromHexString<CborElement>("fa47c35000")
-        assertTrue(floatElement is CborFloat)
+        assertIs<CborFloat>(floatElement)
         assertEquals(100000.0f, floatElement.value.toFloat())
     }
 
@@ -359,33 +358,30 @@ class CborElementTest {
     fun testDecodeByteString() {
         // Test data from CborParserTest.testRfc7049IndefiniteByteStringExample
         val element = cbor.decodeFromHexString<CborElement>("5F44aabbccdd43eeff99FF")
-        assertTrue(element is CborByteString)
-        val byteString = element as CborByteString
+        assertIs<CborByteString>(element)
         val expectedBytes = HexConverter.parseHexBinary("aabbccddeeff99")
-        assertTrue(byteString.toByteArray().contentEquals(expectedBytes))
+        assertContentEquals(expectedBytes, element.toByteArray())
     }
 
     @Test
     fun testDecodeArray() {
         // Test data from CborParserTest.testSkipCollections
         val element = cbor.decodeFromHexString<CborElement>("830118ff1a00010000")
-        assertTrue(element is CborArray)
-        val list = element as CborArray
-        assertEquals(3, list.size)
-        assertEquals(1uL, (list[0] as CborInteger).absoluteValue)
-        assertEquals(255uL, (list[1] as CborInteger).absoluteValue)
-        assertEquals(65536uL, (list[2] as CborInteger).absoluteValue)
+        assertIs<CborArray>(element)
+        assertEquals(3, element.size)
+        assertEquals(1uL, (element[0] as CborInteger).absoluteValue)
+        assertEquals(255uL, (element[1] as CborInteger).absoluteValue)
+        assertEquals(65536uL, (element[2] as CborInteger).absoluteValue)
     }
 
     @Test
     fun testDecodeMap() {
         // Test data from CborParserTest.testSkipCollections
         val element = cbor.decodeFromHexString<CborElement>("a26178676b6f746c696e7861796d73657269616c697a6174696f6e")
-        assertTrue(element is CborMap)
-        val map = element as CborMap
-        assertEquals(2, map.size)
-        assertEquals(CborString("kotlinx"), map[CborString("x")])
-        assertEquals(CborString("serialization"), map[CborString("y")])
+        assertIs<CborMap>(element)
+        assertEquals(2, element.size)
+        assertEquals(CborString("kotlinx"), element[CborString("x")])
+        assertEquals(CborString("serialization"), element[CborString("y")])
     }
 
     @Test
@@ -393,33 +389,31 @@ class CborElementTest {
         // Test data from CborParserTest.testSkipIndefiniteLength
         val element =
             cbor.decodeFromHexString<CborElement>("a461615f42cafe43010203ff61627f6648656c6c6f2065776f726c64ff61639f676b6f746c696e786d73657269616c697a6174696f6eff6164bf613101613202613303ff")
-        assertTrue(element is CborMap)
-        val map = element as CborMap
-        assertEquals(4, map.size)
+        assertIs<CborMap>(element)
+        assertEquals(4, element.size)
 
         // Check the byte string
-        val byteString = map[CborString("a")] as CborByteString
+        val byteString = element[CborString("a")] as CborByteString
         val expectedBytes = HexConverter.parseHexBinary("cafe010203")
-        assertTrue(byteString.toByteArray().contentEquals(expectedBytes))
+        assertContentEquals(expectedBytes, byteString.toByteArray())
 
         // Check the text string
-        assertEquals(CborString("Hello world"), map[CborString("b")])
+        assertEquals(CborString("Hello world"), element[CborString("b")])
 
         // Check the array
-        val array = map[CborString("c")] as CborArray
+        val array = element[CborString("c")] as CborArray
         assertEquals(2, array.size)
         assertEquals(CborString("kotlinx"), array[0])
         assertEquals(CborString("serialization"), array[1])
 
         // Check the nested map
-        val nestedMap = map[CborString("d")] as CborMap
+        val nestedMap = element[CborString("d")] as CborMap
         assertEquals(3, nestedMap.size)
         assertEquals(CborInteger(1u), nestedMap[CborString("1")])
         assertEquals(CborInteger(2u), nestedMap[CborString("2")])
         assertEquals(CborInteger(3u), nestedMap[CborString("3")])
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
     @Test
     fun testTagsRoundTrip() {
         val cbor = Cbor { encodeValueTags = true }
@@ -428,11 +422,10 @@ class CborElementTest {
 
         // Encode and decode
         val bytes = cbor.encodeToByteArray(originalElement)
-        println(bytes.toHexString())
         val decodedElement = cbor.decodeFromByteArray<CborElement>(bytes)
 
         // Verify the value and tags
-        assertTrue(decodedElement is CborString)
+        assertIs<CborString>(decodedElement)
         assertEquals("Hello, tagged world!", decodedElement.value)
         assertEquals(1, decodedElement.tags.size)
         assertEquals(42u, decodedElement.tags.first())
@@ -547,6 +540,7 @@ class CborElementTest {
                 assertEquals(hex, cbor.encodeToHexString(obj))
                 assertEquals(hex, cbor.encodeToHexString(struct))
                 assertEquals(struct, cbor.decodeFromHexString<CborElement>(hex))
+                // TODO
                 //we have an ambiguity here (null vs. CborNull), so we cannot compare for equality with the object
                 //assertEquals(obj, cbor.decodeFromCbor(struct))
                 //assertEquals(obj, cbor.decodeFromHexString(hex))
@@ -614,89 +608,73 @@ class CborElementTest {
     @Test
     fun testCborElementWithValueTagsFails() {
         val cbor = Cbor { encodeValueTags = true }
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly."
+        ) {
             cbor.encodeToByteArray(MixedValueTaggedElement.serializer(), MixedValueTaggedElement(CborBoolean(false)))
-        }.message
-        assertEquals(
-            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
-            message
-        )
+        }
 
-        val structuredMessage = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly."
+        ) {
             cbor.encodeToCborElement(MixedValueTaggedElement.serializer(), MixedValueTaggedElement(CborBoolean(false)))
-        }.message
-        assertEquals(
-            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
-            structuredMessage
-        )
+        }
     }
 
     @Test
     fun testCborElementWithKeyTagsFails() {
         val cbor = Cbor { encodeKeyTags = true }
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required.",
+        ) {
             cbor.encodeToByteArray(MixedKeyTaggedElement.serializer(), MixedKeyTaggedElement(CborBoolean(false)))
-        }.message
-        assertEquals(
-            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required.",
-            message
-        )
+        }
 
-        val structuredMessage = assertFailsWith<SerializationException> {
+        assertFailsWith<SerializationException>(
+            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required."
+        ) {
             cbor.encodeToCborElement(MixedKeyTaggedElement.serializer(), MixedKeyTaggedElement(CborBoolean(false)))
-        }.message
-        assertEquals(
-            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required.",
-            structuredMessage
-        )
+        }
     }
 
     @Test
     fun testConcreteCborElementWithValueTagsFails() {
         val cbor = Cbor { encodeValueTags = true }
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly."
+        ) {
             cbor.encodeToByteArray(MixedValueTaggedInteger.serializer(), MixedValueTaggedInteger(CborInteger(1)))
-        }.message
-        assertEquals(
-            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
-            message
-        )
+        }
     }
 
     @Test
     fun testTaggedCborElementPropertyDecodingFails() {
         val hex = cbor.encodeToHexString(CborMap(mapOf(CborString("cborElement") to CborBoolean(false))))
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly."
+        ) {
             cbor.decodeFromHexString(MixedValueTaggedElement.serializer(), hex)
-        }.message
-        assertEquals(
-            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
-            message
-        )
+        }
     }
 
     @Test
     fun testKeyTaggedCborElementPropertyDecodingFails() {
         val hex = cbor.encodeToHexString(CborMap(mapOf(CborString("cborElement") to CborBoolean(false))))
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required."
+        ) {
             cbor.decodeFromHexString(MixedKeyTaggedElement.serializer(), hex)
-        }.message
-        assertEquals(
-            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required.",
-            message
-        )
+        }
     }
 
     @Test
     fun testConcreteCborElementPropertyDecodingFails() {
         val hex = cbor.encodeToHexString(CborMap(mapOf(CborString("cborElement") to CborInteger(1))))
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly."
+        ) {
             cbor.decodeFromHexString(MixedValueTaggedInteger.serializer(), hex)
-        }.message
-        assertEquals(
-            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
-            message
-        )
+        }
     }
 
     @Test
@@ -716,7 +694,6 @@ class CborElementTest {
         assertEquals(element, cbor.decodeFromHexString(CborElement.serializer(), hex))
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     fun testCborUndefinedRoundTrip() {
         val cbor = Cbor { encodeValueTags = true }
@@ -1041,43 +1018,35 @@ class CborElementTest {
             encodeValueTags = true
         }
 
-        val encodeMessage = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required."
+        ) {
             cbor.encodeToByteArray(LabelledRawElementBox.serializer(), box)
-        }.message
-        assertEquals(
-            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required.",
-            encodeMessage
-        )
+        }
 
-        val structuredMessage = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required."
+        ) {
             cbor.encodeToCborElement(LabelledRawElementBox.serializer(), box)
-        }.message
-        assertEquals(
-            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required.",
-            structuredMessage
-        )
+        }
 
-        val decodeMessage = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required."
+        ) {
             cbor.decodeFromCborElement(
                 LabelledRawElementBox.serializer(),
                 CborMap(mapOf(CborInteger(1) to CborString("x")))
             )
-        }.message
-        assertEquals(
-            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required.",
-            decodeMessage
-        )
+        }
     }
 
     @Test
     fun testCborLabelOnConcreteCborElementPropertyFails() {
-        val message = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required."
+        ) {
             cbor.encodeToByteArray(LabelledRawIntegerBox.serializer(), LabelledRawIntegerBox(CborInteger(1)))
-        }.message
-        assertEquals(
-            "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required.",
-            message
-        )
+        }
     }
 
     @Test
@@ -1093,24 +1062,20 @@ class CborElementTest {
 
     @Test
     fun testCborLabelDoesNotMakeTaggedCborElementPropertyAllowed() {
-        val valueMessage = assertFailsWith<SerializationException> {
+        assertFailsWithMessage<SerializationException>(
+            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly."
+        ) {
             cbor.encodeToByteArray(
                 LabelledValueTaggedElement.serializer(),
                 LabelledValueTaggedElement(CborBoolean(false))
             )
-        }.message
-        assertEquals(
-            "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
-            valueMessage
-        )
+        }
 
-        val keyMessage = assertFailsWith<SerializationException> {
+        assertFailsWith<SerializationException>(
+            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required."
+        ) {
             cbor.encodeToByteArray(LabelledKeyTaggedElement.serializer(), LabelledKeyTaggedElement(CborBoolean(false)))
-        }.message
-        assertEquals(
-            "KeyTags cannot be represented by a CborElement value; model the containing CborMap key directly if tagged keys are required.",
-            keyMessage
-        )
+        }
     }
 
     @Test
@@ -1148,7 +1113,6 @@ class CborElementTest {
         )
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     fun testTagsPreservedWhenDecodingTypedElements() {
         val cbor = Cbor { encodeValueTags = true }

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborElementTest.kt
@@ -10,14 +10,14 @@ class CborElementTest {
 
     private val cbor = Cbor {}
 
-        @Test
+    @Test
     fun testEncodeToCborElementRootPrimitiveInt() {
         val element = cbor.encodeToCborElement(42)
         assertEquals(CborInteger(42), element)
         assertEquals(42, cbor.decodeFromCborElement<Int>(element))
     }
 
-        @Test
+    @Test
     fun testEncodeToCborElementRootPrimitiveByteArrayAlwaysUseByteString() {
         val configured = Cbor { alwaysUseByteString = true }
         val element = configured.encodeToCborElement(byteArrayOf(1, 2, 3))
@@ -32,14 +32,14 @@ class CborElementTest {
     @Serializable
     private data class Wrapper(val datum: Wrapped?)
 
-        @Test
+    @Test
     fun testEncodeDecodeNullableClassViaCborElement() {
         val wrapper = Wrapper(null)
         val element = cbor.encodeToCborElement(wrapper)
         assertEquals(wrapper, cbor.decodeFromCborElement<Wrapper>(element))
     }
 
-        @Test
+    @Test
     fun testEncodeDecodeRootListViaCborElement() {
         val value = listOf(1, 2, 3)
         val element = cbor.encodeToCborElement(value)
@@ -127,10 +127,9 @@ class CborElementTest {
 
         val long = cbor.decodeFromCborElement<Long>(numberElement)
 
-        assertEquals(Long.MIN_VALUE+1, long)
+        assertEquals(Long.MIN_VALUE + 1, long)
         assertEquals(Long.MIN_VALUE + 1, numberElement.long)
     }
-
 
 
     @Test
@@ -211,7 +210,7 @@ class CborElementTest {
 
         val output = ByteArrayOutput()
         IndefiniteLengthCborWriter(cbor, output).encodeCborElement(mapElement)
-        assertEquals(mapBytes.toHexString(),output.toByteArray().toHexString() )
+        assertEquals(mapBytes.toHexString(), output.toByteArray().toHexString())
 
         val decodedMap = cbor.decodeFromByteArray<CborElement>(mapBytes)
 
@@ -612,7 +611,7 @@ class CborElementTest {
 
     }
 
-        @Test
+    @Test
     fun testCborElementWithValueTagsFails() {
         val cbor = Cbor { encodeValueTags = true }
         val message = assertFailsWith<SerializationException> {
@@ -632,7 +631,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testCborElementWithKeyTagsFails() {
         val cbor = Cbor { encodeKeyTags = true }
         val message = assertFailsWith<SerializationException> {
@@ -652,7 +651,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testConcreteCborElementWithValueTagsFails() {
         val cbor = Cbor { encodeValueTags = true }
         val message = assertFailsWith<SerializationException> {
@@ -664,7 +663,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testTaggedCborElementPropertyDecodingFails() {
         val hex = cbor.encodeToHexString(CborMap(mapOf(CborString("cborElement") to CborBoolean(false))))
         val message = assertFailsWith<SerializationException> {
@@ -676,7 +675,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testKeyTaggedCborElementPropertyDecodingFails() {
         val hex = cbor.encodeToHexString(CborMap(mapOf(CborString("cborElement") to CborBoolean(false))))
         val message = assertFailsWith<SerializationException> {
@@ -688,7 +687,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testConcreteCborElementPropertyDecodingFails() {
         val hex = cbor.encodeToHexString(CborMap(mapOf(CborString("cborElement") to CborInteger(1))))
         val message = assertFailsWith<SerializationException> {
@@ -700,7 +699,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testCborElementTagsRemainAllowed() {
         val cbor = Cbor { encodeValueTags = true }
         val element = CborBoolean(false, 2337u)
@@ -709,7 +708,7 @@ class CborElementTest {
         assertEquals(obj, cbor.decodeFromHexString(MixedUntaggedElement.serializer(), hex))
     }
 
-        @Test
+    @Test
     fun testTaggedCborMapKeyRemainsAllowed() {
         val cbor = Cbor { encodeKeyTags = true }
         val element = CborMap(mapOf(CborString("key", 42u) to CborBoolean(true)))
@@ -749,7 +748,7 @@ class CborElementTest {
         assertEquals(element, cbor.decodeFromByteArray(CborElement.serializer(), bytes))
     }
 
-        @Test
+    @Test
     fun testRootCborElementTagsRespectEncodeValueTags() {
         val element = CborBoolean(false, 1u)
 
@@ -757,7 +756,7 @@ class CborElementTest {
         assertEquals("c1f4", Cbor { encodeValueTags = true }.encodeToHexString(CborElement.serializer(), element))
     }
 
-        @Test
+    @Test
     fun testArrayCborElementTagsRespectEncodeValueTags() {
         val element = CborArray(listOf(CborBoolean(false, 1u)))
 
@@ -768,7 +767,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testMapCborElementTagsRespectKeyAndValueSwitches() {
         val element = CborMap(mapOf(CborString("k", 1u) to CborBoolean(false, 2u)))
 
@@ -790,7 +789,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testNestedCborElementTagsRespectLocalPosition() {
         val element = CborMap(
             mapOf(
@@ -818,7 +817,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testCborMapTagsRespectPositionWhenUsedAsMapKey() {
         val element = CborMap(mapOf(CborMap(emptyMap(), 1u) to CborBoolean(true, 2u)))
 
@@ -840,7 +839,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testEncodeToCborElementRespectsRawElementTagSwitches() {
         val element = CborMap(mapOf(CborString("k", 1u) to CborBoolean(false, 2u)), 3u)
 
@@ -865,7 +864,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testAllRootCborElementKindsRespectEncodeValueTags() {
         val elements = listOf(
             CborNull(1u) to CborNull(),
@@ -884,7 +883,10 @@ class CborElementTest {
         for ((tagged, untagged) in elements) {
             assertEquals(
                 untagged,
-                cbor.decodeFromByteArray(CborElement.serializer(), cbor.encodeToByteArray(CborElement.serializer(), tagged))
+                cbor.decodeFromByteArray(
+                    CborElement.serializer(),
+                    cbor.encodeToByteArray(CborElement.serializer(), tagged)
+                )
             )
             assertEquals(
                 tagged,
@@ -895,7 +897,7 @@ class CborElementTest {
         }
     }
 
-        @Test
+    @Test
     fun testAllRawCborElementMapKeyKindsRespectEncodeKeyTags() {
         val taggedKeys = listOf(
             CborString("text", 1u) to CborString("text"),
@@ -921,7 +923,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testGenericSerializableRawCborElementRespectsNestedTagSwitches() {
         val element = CborMap(mapOf(CborString("k", 1u) to CborBoolean(false, 2u)), 3u)
         val box = GenericBox<CborElement>(element)
@@ -947,7 +949,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testGenericSerializableRawCborElementListAndMapRespectTagSwitches() {
         val listBox = GenericListBox<CborElement>(listOf(CborString("v", 1u)))
         val listSerializer = GenericListBox.serializer(CborElement.serializer())
@@ -980,7 +982,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testGenericSerializableConcreteCborElementSubtypesRespectTagSwitches() {
         val mapBox = GenericBox(CborMap(mapOf(CborString("k", 1u) to CborString("v", 2u)), 3u))
         val mapSerializer = GenericBox.serializer(CborMap.serializer())
@@ -1030,7 +1032,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testCborLabelOnCborElementPropertyFails() {
         val box = LabelledRawElementBox(CborString("x"))
         val cbor = Cbor {
@@ -1056,7 +1058,10 @@ class CborElementTest {
         )
 
         val decodeMessage = assertFailsWith<SerializationException> {
-            cbor.decodeFromCborElement(LabelledRawElementBox.serializer(), CborMap(mapOf(CborInteger(1) to CborString("x"))))
+            cbor.decodeFromCborElement(
+                LabelledRawElementBox.serializer(),
+                CborMap(mapOf(CborInteger(1) to CborString("x")))
+            )
         }.message
         assertEquals(
             "CborLabel cannot be represented by a CborElement value; model the containing CborMap key directly if numeric labels are required.",
@@ -1064,7 +1069,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testCborLabelOnConcreteCborElementPropertyFails() {
         val message = assertFailsWith<SerializationException> {
             cbor.encodeToByteArray(LabelledRawIntegerBox.serializer(), LabelledRawIntegerBox(CborInteger(1)))
@@ -1075,7 +1080,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testRawCborMapNumericKeyRemainsAllowed() {
         val element = CborMap(mapOf(CborInteger(1) to CborString("x")))
         val encoded = cbor.encodeToByteArray(CborElement.serializer(), element)
@@ -1086,10 +1091,13 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testCborLabelDoesNotMakeTaggedCborElementPropertyAllowed() {
         val valueMessage = assertFailsWith<SerializationException> {
-            cbor.encodeToByteArray(LabelledValueTaggedElement.serializer(), LabelledValueTaggedElement(CborBoolean(false)))
+            cbor.encodeToByteArray(
+                LabelledValueTaggedElement.serializer(),
+                LabelledValueTaggedElement(CborBoolean(false))
+            )
         }.message
         assertEquals(
             "CBOR tag annotations cannot be applied to CborElement properties; add tags to the CborElement instance directly.",
@@ -1105,7 +1113,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testDecodingRawCborElementPreservesTagsIndependentOfEncodeSwitches() {
         assertEquals(CborBoolean(false, 1u), cbor.decodeFromHexString(CborElement.serializer(), "c1f4"))
         assertEquals(
@@ -1114,7 +1122,7 @@ class CborElementTest {
         )
     }
 
-        @Test
+    @Test
     fun testConcreteCborElementSerializersRespectRawTagSwitches() {
         val string = CborString("v", 1u)
         assertEquals(CborString("v"), cbor.decodeFromByteArray(CborString.serializer(), cbor.encodeToByteArray(string)))

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborParserTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborParserTest.kt
@@ -12,9 +12,9 @@ import kotlin.test.*
 
 class CborParserTest {
 
-    private fun withParser(input: String, block: CborParserImpl.() -> Unit) {
+    private fun withParser(input: String, block: StreamingCborParser.() -> Unit) {
         val bytes = HexConverter.parseHexBinary(input.uppercase())
-        CborParserImpl(ByteArrayInput(bytes), false).block()
+        StreamingCborParser(ByteArrayInput(bytes), false).block()
     }
 
     @Test
@@ -48,7 +48,7 @@ class CborParserTest {
     // See https://datatracker.ietf.org/doc/html/rfc8949#section-3.3
     @Test
     fun testUnsupportedSimpleValueEncodings() {
-        fun CborParserImpl.tryReadAllSimpleValues() {
+        fun StreamingCborParser.tryReadAllSimpleValues() {
             assertFailsWith<CborDecodingException> { nextBoolean() }
             assertFailsWith<CborDecodingException> { nextNull() }
             assertFailsWith<CborDecodingException> { nextFloat() }
@@ -899,28 +899,28 @@ class CborParserTest {
 }
 
 
-private fun CborParserImpl.nextNumber(tag: ULong): Long = nextNumber(ulongArrayOf(tag))
+private fun StreamingCborParser.nextNumber(tag: ULong): Long = nextNumber(ulongArrayOf(tag))
 
-private fun CborParserImpl.nextDouble(tag: ULong) = nextDouble(ulongArrayOf(tag))
+private fun StreamingCborParser.nextDouble(tag: ULong) = nextDouble(ulongArrayOf(tag))
 
-private fun CborParserImpl.nextString(tag: ULong) = nextString(ulongArrayOf(tag))
+private fun StreamingCborParser.nextString(tag: ULong) = nextString(ulongArrayOf(tag))
 
-private fun CborParserImpl.startArray(tag: ULong): Int = startArray(ulongArrayOf(tag))
+private fun StreamingCborParser.startArray(tag: ULong): Int = startArray(ulongArrayOf(tag))
 
-private fun CborParserImpl.startMap(tag: ULong) = startMap(ulongArrayOf(tag))
+private fun StreamingCborParser.startMap(tag: ULong) = startMap(ulongArrayOf(tag))
 
-private fun CborParserImpl.skipElement(singleTag: ULong) = skipElement(ulongArrayOf(singleTag))
+private fun StreamingCborParser.skipElement(singleTag: ULong) = skipElement(ulongArrayOf(singleTag))
 
-private fun CborParserImpl.skipElement() = skipElement(null)
+private fun StreamingCborParser.skipElement() = skipElement(null)
 
-private fun CborParserImpl.expect(expected: String, tag: ULong? = null) {
+private fun StreamingCborParser.expect(expected: String, tag: ULong? = null) {
     assertEquals(expected, actual = nextString(tag?.let { ulongArrayOf(it) }), "string")
 }
 
-private fun CborParserImpl.expectMap(size: Int, tag: ULong? = null) {
+private fun StreamingCborParser.expectMap(size: Int, tag: ULong? = null) {
     assertEquals(size, actual = startMap(tag?.let { ulongArrayOf(it) }), "map size")
 }
 
-private fun CborParserImpl.expectEof() {
+private fun StreamingCborParser.expectEof() {
     assertTrue(isEof(), "Expected EOF.")
 }


### PR DESCRIPTION
For starters, cleaned up the code:
- fixed formatting
- addressed some fired inspections 
- added missing `ExperimentalSerializationApi` annotation to all Cbor elements
- fixed opt-ins
- fixed typos
- renamed `CborParserImpl` so `StreamingCborParser` (to mimic the name choice from cx-ser-json)