### PR TITLE
Disable redundant targets when building as part of the aggregate build

### DIFF
--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -19,3 +19,15 @@ val Project.overriddenLanguageVersion : String?
 
 val Project.teamcityInteractionEnabled : Boolean
     get() = !hasProperty("no_teamcity_interaction") && !hasProperty("build_snapshot_up")
+
+// Property so cli-compiler-options can reference it
+const val KOTLIN_ADDITIONAL_CLI_OPTIONS_PROPERTY = "kotlin_additional_cli_options"
+
+val Project.isKotlinUserProjectsBuild: Boolean
+    get() = providers.gradleProperty(KOTLIN_ADDITIONAL_CLI_OPTIONS_PROPERTY).isPresent
+
+fun Project.disabledInAggregateBuild(configure: () -> Unit) {
+    if (!isKotlinUserProjectsBuild) {
+        configure()
+    }
+}

--- a/buildSrc/src/main/kotlin/cli-compiler-options.gradle.kts
+++ b/buildSrc/src/main/kotlin/cli-compiler-options.gradle.kts
@@ -15,7 +15,7 @@ import kotlin.collections.joinToString
  */
 
 // Used only for User Projects TeamCity configurations, no IDE there
-val kotlinAdditionalCliOptions = providers.gradleProperty("kotlin_additional_cli_options")
+val kotlinAdditionalCliOptions = providers.gradleProperty(KOTLIN_ADDITIONAL_CLI_OPTIONS_PROPERTY)
     .orNull?.let { options ->
         options.removeSurrounding("\"").split(" ").filter { it.isNotBlank() }
     }

--- a/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
@@ -23,36 +23,42 @@ kotlin {
     // Tier 2
     linuxX64()
     linuxArm64()
-    watchosSimulatorArm64()
+    disabledInAggregateBuild {
+        watchosSimulatorArm64()
+    }
     watchosArm32()
     watchosArm64()
-    tvosSimulatorArm64()
+    disabledInAggregateBuild {
+        tvosSimulatorArm64()
+    }
     tvosArm64()
     iosArm64()
 
-    // Tier 3
-    mingwX64()
-    iosX64()
-    watchosDeviceArm64()
-    // https://github.com/square/okio/issues/1242#issuecomment-1759357336
-    if (doesNotDependOnOkio(project)) {
-        androidNativeArm32()
-        androidNativeArm64()
-        androidNativeX86()
-        androidNativeX64()
+    disabledInAggregateBuild {
+        // Tier 3
+        mingwX64()
+        iosX64()
+        watchosDeviceArm64()
+        // https://github.com/square/okio/issues/1242#issuecomment-1759357336
+        if (doesNotDependOnOkio(project)) {
+            androidNativeArm32()
+            androidNativeArm64()
+            androidNativeX86()
+            androidNativeX64()
 
-        // Deprecated, but not removed
-        @Suppress("DEPRECATION")
-        linuxArm32Hfp()
+            // Deprecated, but not removed
+            @Suppress("DEPRECATION")
+            linuxArm32Hfp()
+        }
+
+        // Deprecated
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+        macosX64()
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+        watchosX64()
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+        tvosX64()
     }
-
-    // Deprecated
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    macosX64()
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    watchosX64()
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    tvosX64()
 
     // setup tests running in RELEASE mode
     targets.withType<KotlinNativeTarget>().configureEach {

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.gradle.dsl.JsModuleKind
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 val serialization_version = property("mainLibVersion") as String
+val isKotlinUserProjectsBuild = providers.gradleProperty("kotlin_additional_cli_options").isPresent
 
 // Versions substituted in settings.gradle.kts
 plugins {
@@ -49,11 +50,15 @@ kotlin {
         nodejs()
     }
     jvm()
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    macosX64()
+    disabledInAggregateBuild {
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+        macosX64()
+    }
     macosArm64()
     linuxX64()
-    mingwX64()
+    disabledInAggregateBuild {
+        mingwX64()
+    }
 
     sourceSets {
         all {
@@ -162,4 +167,10 @@ dependencies {
 
 tasks.withType<KotlinNpmInstallTask>().configureEach {
     args.add("--ignore-engines")
+}
+
+fun disabledInAggregateBuild(configure: () -> Unit) {
+    if (!isKotlinUserProjectsBuild) {
+        configure()
+    }
 }


### PR DESCRIPTION
kotlinx-serialization full builds runs on every commit to Kotlin repository and often is on a critical path of aggregate build completion, so cutting on redundant (obsolete, deprecated and/or nearly-duplicating) targets yields both wall time and total CI consumption reduction

#KTI-3388