### PR TITLE
fix: partial descriptor behavior

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PluginGeneratedSerialDescriptor.kt
@@ -34,13 +34,36 @@ internal open class PluginGeneratedSerialDescriptor(
     // Cache child serializers, they are not cached by the implementation for nullable types
     private val childSerializers: Array<KSerializer<*>> by lazy(LazyThreadSafetyMode.PUBLICATION) { generatedSerializer?.childSerializers() ?: EMPTY_SERIALIZER_ARRAY }
 
+    // Descriptors created without a generated serializer (e.g. via the `@Serializer(forClass = ...)`
+    // companion shortcut) have no child serializers, so getElementDescriptor is unusable and
+    // identity operations (equals/hashCode/toString) must not rely on element descriptors.
+    private val isIncomplete: Boolean
+        get() = childSerializers.size < elementsCount
+
     // Lazy because of JS specific initialization order (#789)
     internal val typeParameterDescriptors: Array<SerialDescriptor> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         generatedSerializer?.typeParametersSerializers()?.map { it.descriptor }.compactArray()
     }
 
     // Can be without synchronization but Native will likely break due to freezing
-    private val _hashCode: Int by lazy(LazyThreadSafetyMode.PUBLICATION) { hashCodeImpl(typeParameterDescriptors) }
+    private val _hashCode: Int by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        if (isIncomplete) incompleteHashCode() else hashCodeImpl(typeParameterDescriptors)
+    }
+
+    // Identity based on data that is always available: serial name, type parameters,
+    // kind and element names. Kept distinct from equals of complete descriptors
+    // (mixed comparisons are never equal), so the equals/hashCode contract holds.
+    private fun incompleteHashCode(): Int {
+        var result = serialName.hashCode()
+        result = 31 * result + typeParameterDescriptors.contentHashCode()
+        result = 31 * result + kind.hashCode()
+        var namesHash = 1
+        for (i in 0 until elementsCount) {
+            namesHash = 31 * namesHash + names[i].hashCode()
+        }
+        result = 31 * result + namesHash
+        return result
+    }
 
     public fun addElement(name: String, isOptional: Boolean = false) {
         names[++added] = name
@@ -89,13 +112,40 @@ internal open class PluginGeneratedSerialDescriptor(
         return indices
     }
 
-    override fun equals(other: Any?): Boolean = equalsImpl(other) { otherDescriptor ->
-        typeParameterDescriptors.contentEquals(otherDescriptor.typeParameterDescriptors)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PluginGeneratedSerialDescriptor) return false
+        if (serialName != other.serialName) return false
+        if (!typeParameterDescriptors.contentEquals(other.typeParameterDescriptors)) return false
+        if (elementsCount != other.elementsCount) return false
+        val incomplete = isIncomplete
+        // Complete and incomplete descriptors are never equal: their hash codes are
+        // computed from different data, and they describe differently-constructed
+        // serializers. (Mixed comparison used to throw, so nothing relied on it.)
+        if (incomplete != other.isIncomplete) return false
+        if (incomplete) {
+            if (kind != other.kind) return false
+            for (index in 0 until elementsCount) {
+                if (getElementName(index) != other.getElementName(index)) return false
+            }
+            return true
+        }
+        for (index in 0 until elementsCount) {
+            if (getElementDescriptor(index).serialName != other.getElementDescriptor(index).serialName) return false
+            if (getElementDescriptor(index).kind != other.getElementDescriptor(index).kind) return false
+        }
+        return true
     }
 
     override fun hashCode(): Int = _hashCode
 
-    override fun toString(): String = toStringImpl()
+    override fun toString(): String {
+        return if (isIncomplete) {
+            (0 until elementsCount).joinToString(", ", "$serialName(", ")") { getElementName(it) }
+        } else {
+            toStringImpl()
+        }
+    }
 }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/core/commonTest/src/kotlinx/serialization/IncompletePluginDescriptorTest.kt
+++ b/core/commonTest/src/kotlinx/serialization/IncompletePluginDescriptorTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization
+
+import kotlinx.serialization.internal.*
+import kotlin.test.*
+
+/**
+ * [PluginGeneratedSerialDescriptor] instances created without a generated serializer
+ * (e.g. by the `@Serializer(forClass = ...)` companion shortcut) have no child serializers,
+ * so identity operations must not touch element descriptors. Historically hashCode(),
+ * equals() and toString() threw [IndexOutOfBoundsException] for such descriptors,
+ * which made them unusable as cache keys (see the useAlternativeNames limitation).
+ */
+class IncompletePluginDescriptorTest {
+
+    @Serializable
+    @SerialName("IncompleteTestShape")
+    data class CompleteTwin(val a: Int, val b: String)
+
+    private fun incomplete(name: String, vararg elements: String) =
+        PluginGeneratedSerialDescriptor(name, generatedSerializer = null, elementsCount = elements.size).apply {
+            elements.forEach { addElement(it) }
+        }
+
+    @Test
+    fun testHashCodeDoesNotThrowAndIsStable() {
+        val descriptor = incomplete("IncompleteTestShape", "a", "b")
+        val first = descriptor.hashCode()
+        assertEquals(first, descriptor.hashCode())
+    }
+
+    @Test
+    fun testToStringDoesNotThrow() {
+        val descriptor = incomplete("IncompleteTestShape", "a", "b")
+        val repr = descriptor.toString()
+        assertTrue("IncompleteTestShape" in repr)
+        assertTrue("a" in repr)
+    }
+
+    @Test
+    fun testStructurallyEqualIncompleteDescriptors() {
+        val d1 = incomplete("IncompleteTestShape", "a", "b")
+        val d2 = incomplete("IncompleteTestShape", "a", "b")
+        assertEquals(d1, d2)
+        assertEquals(d2, d1)
+        assertEquals(d1.hashCode(), d2.hashCode())
+    }
+
+    @Test
+    fun testDifferentElementNamesNotEqual() {
+        val d1 = incomplete("IncompleteTestShape", "a", "b")
+        val d2 = incomplete("IncompleteTestShape", "a", "c")
+        assertNotEquals(d1, d2)
+    }
+
+    @Test
+    fun testIncompleteVsCompleteNotEqualAndDoesNotThrow() {
+        val complete = CompleteTwin.serializer().descriptor
+        val partial = incomplete("IncompleteTestShape", "a", "b")
+        // Same serial name, same element names — but different construction.
+        // Mixed comparison used to throw; now it must simply be unequal.
+        assertNotEquals<Any>(complete, partial)
+        assertNotEquals<Any>(partial, complete)
+    }
+
+    @Test
+    fun testCompleteDescriptorBehaviorUnchanged() {
+        val d1 = CompleteTwin.serializer().descriptor
+        assertEquals(d1, d1)
+        assertEquals(d1.hashCode(), d1.hashCode())
+        assertTrue("a: " in d1.toString())
+    }
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonCustomSerializersTest.kt
@@ -107,10 +107,9 @@ class JsonCustomSerializersTest : JsonTestBase() {
 
     private val moduleWithB = serializersModuleOf(B::class, BSerializer)
 
-    private fun createJsonWithB() = Json { isLenient = true; serializersModule = moduleWithB; useAlternativeNames = false }
-    // useAlternativeNames uses SerialDescriptor.hashCode,
-    // which is unavailable for partially-customized serializers such as in this file
-    private val jsonNoAltNames = Json { useAlternativeNames = false }
+    private fun createJsonWithB() = Json { isLenient = true; serializersModule = moduleWithB }
+
+    private val json = Json
 
     @Test
     fun testWriteCustom() = parametrizedTest { jsonTestingMode ->
@@ -163,35 +162,35 @@ class JsonCustomSerializersTest : JsonTestBase() {
     @Test
     fun testWriteCustomInvertedOrder() = parametrizedTest { jsonTestingMode ->
         val obj = C(1, 2)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"b":2,"a":1}""", s)
     }
 
     @Test
     fun testWriteCustomOmitDefault() = parametrizedTest { jsonTestingMode ->
         val obj = C(b = 2)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"b":2}""", s)
     }
 
     @Test
     fun testReadCustomInvertedOrder() = parametrizedTest { jsonTestingMode ->
         val obj = C(1, 2)
-        val s = jsonNoAltNames.decodeFromString<C>("""{"b":2,"a":1}""", jsonTestingMode)
+        val s = json.decodeFromString<C>("""{"b":2,"a":1}""", jsonTestingMode)
         assertEquals(obj, s)
     }
 
     @Test
     fun testReadCustomOmitDefault() = parametrizedTest { jsonTestingMode ->
         val obj = C(b = 2)
-        val s = jsonNoAltNames.decodeFromString<C>("""{"b":2}""", jsonTestingMode)
+        val s = json.decodeFromString<C>("""{"b":2}""", jsonTestingMode)
         assertEquals(obj, s)
     }
 
     @Test
     fun testWriteListOfOptional() = parametrizedTest { jsonTestingMode ->
         val obj = listOf(C(a = 1), C(b = 2), C(3, 4))
-        val s = jsonNoAltNames.encodeToString(ListSerializer(C), obj, jsonTestingMode)
+        val s = json.encodeToString(ListSerializer(C), obj, jsonTestingMode)
         assertEquals("""[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]""", s)
     }
 
@@ -199,21 +198,21 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadListOfOptional() = parametrizedTest { jsonTestingMode ->
         val obj = listOf(C(a = 1), C(b = 2), C(3, 4))
         val j = """[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]"""
-        val s = jsonNoAltNames.decodeFromString(ListSerializer<C>(C), j, jsonTestingMode)
+        val s = json.decodeFromString(ListSerializer<C>(C), j, jsonTestingMode)
         assertEquals(obj, s)
     }
 
     @Test
     fun testWriteOptionalList1() = parametrizedTest { jsonTestingMode ->
         val obj = CList1(listOf(C(a = 1), C(b = 2), C(3, 4)))
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"c":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}""", s)
     }
 
     @Test
     fun testWriteOptionalList1Quoted() = parametrizedTest { jsonTestingMode ->
         val obj = CList1(listOf(C(a = 1), C(b = 2), C(3, 4)))
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"c":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}""", s)
     }
 
@@ -221,13 +220,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList1() = parametrizedTest { jsonTestingMode ->
         val obj = CList1(listOf(C(a = 1), C(b = 2), C(3, 4)))
         val j = """{"c":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList2a() = parametrizedTest { jsonTestingMode ->
         val obj = CList2(7, listOf(C(a = 5), C(b = 6), C(7, 8)))
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}],"d":7}""", s)
     }
 
@@ -235,13 +234,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList2a() = parametrizedTest { jsonTestingMode ->
         val obj = CList2(7, listOf(C(a = 5), C(b = 6), C(7, 8)))
         val j = """{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}],"d":7}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList2b() = parametrizedTest { jsonTestingMode ->
         val obj = CList2(c = listOf(C(a = 5), C(b = 6), C(7, 8)))
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}]}""", s)
     }
 
@@ -249,13 +248,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList2b() = parametrizedTest { jsonTestingMode ->
         val obj = CList2(c = listOf(C(a = 5), C(b = 6), C(7, 8)))
         val j = """{"c":[{"b":42,"a":5},{"b":6},{"b":8,"a":7}]}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList3a() = parametrizedTest { jsonTestingMode ->
         val obj = CList3(listOf(C(a = 1), C(b = 2), C(3, 4)), 99)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"e":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}],"f":99}""", s)
     }
 
@@ -263,13 +262,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList3a() = parametrizedTest { jsonTestingMode ->
         val obj = CList3(listOf(C(a = 1), C(b = 2), C(3, 4)), 99)
         val j = """{"e":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}],"f":99}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList3b() = parametrizedTest { jsonTestingMode ->
         val obj = CList3(f = 99)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"f":99}""", s)
     }
 
@@ -277,13 +276,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList3b() = parametrizedTest { jsonTestingMode ->
         val obj = CList3(f = 99)
         val j = """{"f":99}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList4a() = parametrizedTest { jsonTestingMode ->
         val obj = CList4(listOf(C(a = 1), C(b = 2), C(3, 4)), 54)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"h":54,"g":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}""", s)
     }
 
@@ -291,14 +290,14 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList4a() = parametrizedTest { jsonTestingMode ->
         val obj = CList4(listOf(C(a = 1), C(b = 2), C(3, 4)), 54)
         val j = """{"h":54,"g":[{"b":42,"a":1},{"b":2},{"b":4,"a":3}]}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList4b() = parametrizedTest { jsonTestingMode ->
         val obj = CList4(h = 97)
         val j = """{"h":97}"""
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals(j, s)
     }
 
@@ -306,13 +305,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList4b() = parametrizedTest { jsonTestingMode ->
         val obj = CList4(h = 97)
         val j = """{"h":97}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList5a() = parametrizedTest { jsonTestingMode ->
         val obj = CList5(listOf(9, 8, 7, 6, 5), 5)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"h":5,"g":[9,8,7,6,5]}""", s)
     }
 
@@ -320,13 +319,13 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList5a() = parametrizedTest { jsonTestingMode ->
         val obj = CList5(listOf(9, 8, 7, 6, 5), 5)
         val j = """{"h":5,"g":[9,8,7,6,5]}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testWriteOptionalList5b() = parametrizedTest { jsonTestingMode ->
         val obj = CList5(h = 999)
-        val s = jsonNoAltNames.encodeToString(obj, jsonTestingMode)
+        val s = json.encodeToString(obj, jsonTestingMode)
         assertEquals("""{"h":999}""", s)
     }
 
@@ -334,14 +333,14 @@ class JsonCustomSerializersTest : JsonTestBase() {
     fun testReadOptionalList5b() = parametrizedTest { jsonTestingMode ->
         val obj = CList5(h = 999)
         val j = """{"h":999}"""
-        assertEquals(obj, jsonNoAltNames.decodeFromString(j, jsonTestingMode))
+        assertEquals(obj, json.decodeFromString(j, jsonTestingMode))
     }
 
     @Test
     fun testMapBuiltinsTest() = parametrizedTest { jsonTestingMode ->
         val map = mapOf(1 to "1", 2 to "2")
         val serial = MapSerializer(Int.serializer(), String.serializer())
-        val s = jsonNoAltNames.encodeToString(serial, map, jsonTestingMode)
+        val s = json.encodeToString(serial, map, jsonTestingMode)
         assertEquals("""{"1":"1","2":"2"}""", s)
     }
 

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonIncompleteDescriptorTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonIncompleteDescriptorTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+/**
+ * Serializers produced by the `@Serializer(forClass = ...)` companion shortcut have
+ * descriptors without child serializers. Their broken hashCode() used to escape through
+ * Json's descriptor-keyed schema cache whenever the alternative-names slow path was
+ * taken — the reason JsonCustomSerializersTest historically ran with
+ * `useAlternativeNames = false`. With hashCode fixed at the source, the default
+ * configuration must work.
+ */
+class JsonIncompleteDescriptorTest : JsonTestBase() {
+
+    @Serializable(Model.Companion::class)
+    data class Model(val a: Int = 0, val b: String = "") {
+        @Serializer(forClass = Model::class)
+        companion object
+    }
+
+    @Test
+    fun testUnknownKeysWithDefaultAlternativeNames() = parametrizedTest { mode ->
+        // ignoreUnknownKeys + an unknown key forces the deserializationNamesMap
+        // slow path (useAlternativeNames is true by default), which caches by
+        // descriptor hashCode. Used to throw ArrayIndexOutOfBoundsException.
+        val json = Json(default) { ignoreUnknownKeys = true }
+        val result = json.decodeFromString<Model>("""{"a":1,"b":"x","unknown":42}""", mode)
+        assertEquals(Model(1, "x"), result)
+    }
+}


### PR DESCRIPTION
Fixes #1512

### Problem

`PluginGeneratedSerialDescriptor` instances created without a generated serializer throw
`ArrayIndexOutOfBoundsException` from `hashCode()`, `equals()` and `toString()`. This happens
for serializers produced by the `@Serializer(forClass = ...)` companion shortcut:

```kotlin
@Serializable(Model.Companion::class)
data class Model(val a: Int, val b: String) {
    @Serializer(forClass = Model::class)
    companion object
}
```

For these, the plugin constructs the descriptor with `generatedSerializer = null`, so
`childSerializers` is empty while **elementsCount > 0** and all three identity methods walk
**getElementDescriptor(i)**, which indexes into the empty array.

The bug is invisible on ordinary encode/decode (nothing calls `hashCode`), but it breaks any
feature that uses descriptors as cache keys in `DescriptorSchemaCache`. This is exactly the
crash reported in #1512 (open since 2021). The stack trace there is this path verbatim:
`DescriptorSchemaCache.get` -> `PluginGeneratedSerialDescriptor.hashCode` -> AIOOBE. The
originally reported trigger is `useAlternativeNames = true` (the documented limitation:
`JsonCustomSerializersTest` must run with `useAlternativeNames = false`), and a later report
in that thread hits the same crash via `coerceInputValues = true`. Because the root cause is
descriptor identity itself, every schema-cache entry point is affected the same way: in #3189
it forced a try-catch around the schema-cache lookup, and any future descriptor-keyed cache
would inherit the same landmine.

### Fix

Identity of such "incomplete" descriptors is now computed from data the descriptor itself
owns: serial name, type parameters, kind, and element names, instead of the child descriptors
it cannot provide:

- Complete descriptors are untouched: same hash values, same equality semantics as before.
- Incomplete descriptors hash/compare by serialName + typeParams + kind + element names.
- Complete vs incomplete never compare equal (previously threw), which is what keeps the
equals/hashCode contract intact with two different hash formulas. The kind check also
prevents accidental equality with EnumDescriptor, which reuses the null-serializer
construction but overrides hashCode itself.
- toString() for incomplete descriptors prints element names without child type names.

The new branch executes only inside the existing lazy _hashCode initializer and in equals,
so there is no hot-path cost (verified: TwitterFeedBenchmark decode/encode at parity with
master).

| Benchmark | master (ops/s) | this PR (ops/s) | Δ |
|---|---|---|---|
| `decodeTwitter` | 1591 ± 22 | 1596 ± 38 | +0.3%, intervals overlap (parity) |
| `encodeTwitter` | 3244 ± 12 | 3200 ± 54 | -1.4%, intervals overlap (parity) |
