### PR TITLE
Stabilize various default serializers, helpers, and features:

### DIFF
--- a/core/api/kotlinx-serialization-core.api
+++ b/core/api/kotlinx-serialization-core.api
@@ -230,9 +230,9 @@ public final class kotlinx/serialization/descriptors/ClassSerialDescriptorBuilde
 	public static synthetic fun element$default (Lkotlinx/serialization/descriptors/ClassSerialDescriptorBuilder;Ljava/lang/String;Lkotlinx/serialization/descriptors/SerialDescriptor;Ljava/util/List;ZILjava/lang/Object;)V
 	public final fun getAnnotations ()Ljava/util/List;
 	public final fun getSerialName ()Ljava/lang/String;
-	public final fun isNullable ()Z
+	public final synthetic fun isNullable ()Z
 	public final fun setAnnotations (Ljava/util/List;)V
-	public final fun setNullable (Z)V
+	public final synthetic fun setNullable (Z)V
 }
 
 public final class kotlinx/serialization/descriptors/ContextAwareKt {

--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -344,7 +344,6 @@ public annotation class Polymorphic
  *
  * A compiler version `2.0.20` or higher is required.
  */
-@ExperimentalSerializationApi
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class KeepGeneratedSerializer

--- a/core/commonMain/src/kotlinx/serialization/ContextualSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/ContextualSerializer.kt
@@ -37,8 +37,14 @@ import kotlin.reflect.*
  * If type of the property marked with `@Contextual` is `@Serializable` by itself, the plugin-generated serializer is
  * used as a fallback if no serializers associated with a given type is registered in the module.
  * The fallback serializer is determined by the static type of the property, not by its actual type.
+ *
+ * @param serializableClass A class this serializer is intended for. Used to look up a runtime-defined serializer in a [SerializersModule].
+ * @param fallbackSerializer Serializer to use if no serializer associated with a given type is registered in the [SerializersModule].
+ * @param typeArgumentsSerializers If [serializableClass] is a parameterized type, this array should contain serializers for its type arguments.
+ *
+ * @see SerializersModule.getContextual
+ * @see SerializersModuleBuilder.contextual
  */
-@ExperimentalSerializationApi
 public class ContextualSerializer<T : Any>(
     private val serializableClass: KClass<T>,
     private val fallbackSerializer: KSerializer<T>?,

--- a/core/commonMain/src/kotlinx/serialization/PolymorphicSerializer.kt
+++ b/core/commonMain/src/kotlinx/serialization/PolymorphicSerializer.kt
@@ -62,7 +62,9 @@ import kotlin.reflect.*
  * }
  * ```
  *
- * @see SerializersModule
+ * @param baseClass Base class of the polymorphic hierarchy. Only classes that are registered in its scope in the [SerializersModule] can be serialized by this serializer.
+ *
+ * @see SerializersModule.getPolymorphic
  * @see SerializersModuleBuilder.polymorphic
  */
 @OptIn(ExperimentalSerializationApi::class)

--- a/core/commonMain/src/kotlinx/serialization/Serializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/Serializers.kt
@@ -99,7 +99,6 @@ public fun serializer(type: KType): KSerializer<Any?> = EmptySerializersModule()
  * @throws SerializationException if [kClass] is a `kotlin.Array`
  * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
-@ExperimentalSerializationApi
 public fun serializer(
     kClass: KClass<*>,
     typeArgumentsSerializers: List<KSerializer<*>>,
@@ -177,7 +176,6 @@ public fun SerializersModule.serializer(type: KType): KSerializer<Any?> =
  * @throws SerializationException if [kClass] is a `kotlin.Array`
  * @throws SerializationException if size of [typeArgumentsSerializers] does not match the expected generic parameters count
  */
-@ExperimentalSerializationApi
 public fun SerializersModule.serializer(
     kClass: KClass<*>,
     typeArgumentsSerializers: List<KSerializer<*>>,
@@ -408,14 +406,12 @@ internal fun noCompiledSerializer(forClass: String): KSerializer<*> =
     throw SerializationException(notRegisteredMessage(forClass))
 
 // Used when compiler intrinsic is inserted
-@OptIn(ExperimentalSerializationApi::class)
 @Suppress("unused")
 @PublishedApi
 internal fun noCompiledSerializer(module: SerializersModule, kClass: KClass<*>): KSerializer<*> {
     return module.getContextual(kClass) ?: kClass.serializerNotRegistered()
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 @Suppress("unused")
 @PublishedApi
 internal fun noCompiledSerializer(
@@ -433,14 +429,12 @@ internal fun noCompiledSerializer(
  * If no request KClass is an interface, plugin performs call to [moduleThenPolymorphic] to achieve special behavior for interface serializers.
  * (They are only serializers that have module priority over default [PolymorphicSerializer]).
  */
-@OptIn(ExperimentalSerializationApi::class)
 @Suppress("unused")
 @PublishedApi
 internal fun moduleThenPolymorphic(module: SerializersModule, kClass: KClass<*>): KSerializer<*> {
     return module.getContextual(kClass) ?: PolymorphicSerializer(kClass)
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 @Suppress("unused")
 @PublishedApi
 internal fun moduleThenPolymorphic(module: SerializersModule, kClass: KClass<*>, argSerializers: Array<KSerializer<*>>): KSerializer<*> {

--- a/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/builtins/BuiltinSerializers.kt
@@ -80,7 +80,6 @@ public fun ByteArraySerializer(): KSerializer<ByteArray> = ByteArraySerializer
  * Returns serializer for [UByteArray] with [descriptor][SerialDescriptor] of [StructureKind.LIST] kind.
  * Each element of the array is serialized one by one with [UByte.Companion.serializer].
  */
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 public fun UByteArraySerializer(): KSerializer<UByteArray> = UByteArraySerializer
 
@@ -99,7 +98,6 @@ public fun ShortArraySerializer(): KSerializer<ShortArray> = ShortArraySerialize
  * Returns serializer for [UShortArray] with [descriptor][SerialDescriptor] of [StructureKind.LIST] kind.
  * Each element of the array is serialized one by one with [UShort.Companion.serializer].
  */
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 public fun UShortArraySerializer(): KSerializer<UShortArray> = UShortArraySerializer
 
@@ -118,7 +116,6 @@ public fun IntArraySerializer(): KSerializer<IntArray> = IntArraySerializer
  * Returns serializer for [UIntArray] with [descriptor][SerialDescriptor] of [StructureKind.LIST] kind.
  * Each element of the array is serialized one by one with [UInt.Companion.serializer].
  */
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 public fun UIntArraySerializer(): KSerializer<UIntArray> = UIntArraySerializer
 
@@ -137,7 +134,6 @@ public fun LongArraySerializer(): KSerializer<LongArray> = LongArraySerializer
  * Returns serializer for [ULongArray] with [descriptor][SerialDescriptor] of [StructureKind.LIST] kind.
  * Each element of the array is serialized one by one with [ULong.Companion.serializer].
  */
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 public fun ULongArraySerializer(): KSerializer<ULongArray> = ULongArraySerializer
 
@@ -190,7 +186,6 @@ public fun String.Companion.serializer(): KSerializer<String> = StringSerializer
  * Each element of the array is serialized with the given [elementSerializer].
  */
 @Suppress("UNCHECKED_CAST")
-@ExperimentalSerializationApi
 public inline fun <reified T : Any, reified E : T?> ArraySerializer(elementSerializer: KSerializer<E>): KSerializer<Array<E>> =
     ArraySerializer<T, E>(T::class, elementSerializer)
 
@@ -198,7 +193,6 @@ public inline fun <reified T : Any, reified E : T?> ArraySerializer(elementSeria
  * Returns serializer for reference [Array] of type [E] with [descriptor][SerialDescriptor] of [StructureKind.LIST] kind.
  * Each element of the array is serialized with the given [elementSerializer].
  */
-@ExperimentalSerializationApi
 public fun <T : Any, E : T?> ArraySerializer(
     kClass: KClass<T>,
     elementSerializer: KSerializer<E>
@@ -291,5 +285,4 @@ public fun Uuid.Companion.serializer(): KSerializer<Uuid> = UuidSerializer
  *
  * It is used as a dummy in case it is necessary to pass a type to a parameterized class. At the same time, it is expected that this generic type will not participate in serialization.
  */
-@ExperimentalSerializationApi
 public fun NothingSerializer(): KSerializer<Nothing> = NothingSerializer

--- a/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
+++ b/core/commonMain/src/kotlinx/serialization/descriptors/SerialDescriptors.kt
@@ -186,16 +186,9 @@ public inline fun <reified T> serialDescriptor(): SerialDescriptor = serializer<
  */
 public fun serialDescriptor(type: KType): SerialDescriptor = serializer(type).descriptor
 
-/* The rest of the functions intentionally left experimental for later stabilization
- It is unclear whether they should be left as-is,
- or moved to ClassSerialDescriptorBuilder (because this is the main place for them to be used),
- or simply deprecated in favor of ListSerializer(Element.serializer()).descriptor
-*/
-
 /**
  * Creates a descriptor for the type `List<T>` where `T` is the type associated with [elementDescriptor].
  */
-@ExperimentalSerializationApi
 public fun listSerialDescriptor(elementDescriptor: SerialDescriptor): SerialDescriptor {
     return ArrayListClassDesc(elementDescriptor)
 }
@@ -203,7 +196,6 @@ public fun listSerialDescriptor(elementDescriptor: SerialDescriptor): SerialDesc
 /**
  * Creates a descriptor for the type `List<T>`.
  */
-@ExperimentalSerializationApi
 public inline fun <reified T> listSerialDescriptor(): SerialDescriptor {
     return listSerialDescriptor(serializer<T>().descriptor)
 }
@@ -212,7 +204,6 @@ public inline fun <reified T> listSerialDescriptor(): SerialDescriptor {
  * Creates a descriptor for the type `Map<K, V>` where `K` and `V` are types
  * associated with [keyDescriptor] and [valueDescriptor] respectively.
  */
-@ExperimentalSerializationApi
 public fun mapSerialDescriptor(
     keyDescriptor: SerialDescriptor,
     valueDescriptor: SerialDescriptor
@@ -223,7 +214,6 @@ public fun mapSerialDescriptor(
 /**
  * Creates a descriptor for the type `Map<K, V>`.
  */
-@ExperimentalSerializationApi
 public inline fun <reified K, reified V> mapSerialDescriptor(): SerialDescriptor {
     return mapSerialDescriptor(serializer<K>().descriptor, serializer<V>().descriptor)
 }
@@ -231,7 +221,6 @@ public inline fun <reified K, reified V> mapSerialDescriptor(): SerialDescriptor
 /**
  * Creates a descriptor for the type `Set<T>` where `T` is the type associated with [elementDescriptor].
  */
-@ExperimentalSerializationApi
 public fun setSerialDescriptor(elementDescriptor: SerialDescriptor): SerialDescriptor {
     return HashSetClassDesc(elementDescriptor)
 }
@@ -239,7 +228,6 @@ public fun setSerialDescriptor(elementDescriptor: SerialDescriptor): SerialDescr
 /**
  * Creates a descriptor for the type `Set<T>`.
  */
-@ExperimentalSerializationApi
 public inline fun <reified T> setSerialDescriptor(): SerialDescriptor {
     return setSerialDescriptor(serializer<T>().descriptor)
 }
@@ -262,12 +250,12 @@ public val SerialDescriptor.nullable: SerialDescriptor
  * Otherwise, returns `this`.
  *
  * It may return a nullable descriptor
- * if `this` descriptor has been created manually as nullable by directly implementing SerialDescriptor interface.
+ * if `this` descriptor has been created manually as nullable by directly implementing [SerialDescriptor] interface.
+ * However, direct implementations of [SerialDescriptor] are discouraged and should not be encountered in practice.
  *
  * @see SerialDescriptor.nullable
  * @see KSerializer.nullable
  */
-@ExperimentalSerializationApi
 public val SerialDescriptor.nonNullOriginal: SerialDescriptor
     get() = when (this) {
         is SerialDescriptorForNullable -> original
@@ -293,14 +281,12 @@ public class ClassSerialDescriptorBuilder internal constructor(
      * support nullable types, meaning that it should declare nullable type
      * in its [KSerializer] type parameter and handle nulls during encoding and decoding.
      */
-    @ExperimentalSerializationApi
-    @Deprecated("isNullable inside buildSerialDescriptor is deprecated. Please use SerialDescriptor.nullable extension on a builder result.", level = DeprecationLevel.ERROR)
+    @Deprecated("isNullable inside buildSerialDescriptor is deprecated. Please use SerialDescriptor.nullable extension on a builder result.", level = DeprecationLevel.HIDDEN)
     public var isNullable: Boolean = false
 
     /**
      * [Serial][SerialInfo] annotations on a target type.
      */
-    @ExperimentalSerializationApi
     public var annotations: List<Annotation> = emptyList()
 
     internal val elementNames: MutableList<String> = ArrayList()

--- a/core/commonMain/src/kotlinx/serialization/internal/PrimitiveArraysSerializers.kt
+++ b/core/commonMain/src/kotlinx/serialization/internal/PrimitiveArraysSerializers.kt
@@ -419,7 +419,6 @@ internal class BooleanArrayBuilder internal constructor(
  * unless format's Encoder/Decoder have special handling for this serializer.
  */
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal object UByteArraySerializer : KSerializer<UByteArray>,
     PrimitiveArraySerializer<UByte, UByteArray, UByteArrayBuilder>(UByte.serializer()) {
@@ -439,7 +438,6 @@ internal object UByteArraySerializer : KSerializer<UByteArray>,
 }
 
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal class UByteArrayBuilder internal constructor(
     bufferWithData: UByteArray
@@ -473,7 +471,6 @@ internal class UByteArrayBuilder internal constructor(
  * unless format's Encoder/Decoder have special handling for this serializer.
  */
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal object UShortArraySerializer : KSerializer<UShortArray>,
     PrimitiveArraySerializer<UShort, UShortArray, UShortArrayBuilder>(UShort.serializer()) {
@@ -493,7 +490,6 @@ internal object UShortArraySerializer : KSerializer<UShortArray>,
 }
 
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal class UShortArrayBuilder internal constructor(
     bufferWithData: UShortArray
@@ -527,7 +523,6 @@ internal class UShortArrayBuilder internal constructor(
  * unless format's Encoder/Decoder have special handling for this serializer.
  */
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal object UIntArraySerializer : KSerializer<UIntArray>,
     PrimitiveArraySerializer<UInt, UIntArray, UIntArrayBuilder>(UInt.serializer()) {
@@ -547,7 +542,6 @@ internal object UIntArraySerializer : KSerializer<UIntArray>,
 }
 
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal class UIntArrayBuilder internal constructor(
     bufferWithData: UIntArray
@@ -581,7 +575,6 @@ internal class UIntArrayBuilder internal constructor(
  * unless format's Encoder/Decoder have special handling for this serializer.
  */
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal object ULongArraySerializer : KSerializer<ULongArray>,
     PrimitiveArraySerializer<ULong, ULongArray, ULongArrayBuilder>(ULong.serializer()) {
@@ -601,7 +594,6 @@ internal object ULongArraySerializer : KSerializer<ULongArray>,
 }
 
 @PublishedApi
-@ExperimentalSerializationApi
 @ExperimentalUnsignedTypes
 internal class ULongArrayBuilder internal constructor(
     bufferWithData: ULongArray
@@ -627,4 +619,3 @@ internal class ULongArrayBuilder internal constructor(
 
     override fun build() = buffer.copyOf(position)
 }
-

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModule.kt
@@ -25,8 +25,6 @@ import kotlin.reflect.*
  * @see Polymorphic
  */
 public sealed class SerializersModule {
-
-    @ExperimentalSerializationApi
     @Deprecated(
         "Deprecated in favor of overload with default parameter",
         ReplaceWith("getContextual(kclass)"),
@@ -43,7 +41,6 @@ public sealed class SerializersModule {
      *
      * @see SerializersModuleBuilder.contextual
      */
-    @ExperimentalSerializationApi
     public abstract fun <T : Any> getContextual(
         kClass: KClass<T>,
         typeArgumentsSerializers: List<KSerializer<*>> = emptyList()
@@ -52,20 +49,17 @@ public sealed class SerializersModule {
     /**
      * Returns a polymorphic serializer registered for a class of the given [value] in the scope of [baseClass].
      */
-    @ExperimentalSerializationApi
     public abstract fun <T : Any> getPolymorphic(baseClass: KClass<in T>, value: T): SerializationStrategy<T>?
 
     /**
      * Returns a polymorphic deserializer registered for a [serializedClassName] in the scope of [baseClass]
      * or default value constructed from [serializedClassName] if a default serializer provider was registered.
      */
-    @ExperimentalSerializationApi
     public abstract fun <T : Any> getPolymorphic(baseClass: KClass<in T>, serializedClassName: String?): DeserializationStrategy<T>?
 
     /**
      * Copies contents of this module to the given [collector].
      */
-    @ExperimentalSerializationApi
     public abstract fun dumpTo(collector: SerializersModuleCollector)
 
     @InternalSerializationApi

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
@@ -18,7 +18,6 @@ import kotlin.reflect.*
  * `SerializersModuleCollector` interface is not stable for inheritance in 3rd party libraries, as new methods
  * might be added to this interface or contracts of the existing methods can be changed.
  */
-@ExperimentalSerializationApi
 public interface SerializersModuleCollector {
 
     /**

--- a/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
+++ b/core/commonMain/src/kotlinx/serialization/modules/SerializersModuleCollector.kt
@@ -12,11 +12,6 @@ import kotlin.reflect.*
 /**
  * [SerializersModuleCollector] can introspect and accumulate content of any [SerializersModule] via [SerializersModule.dumpTo],
  * using a visitor-like pattern: [contextual] and [polymorphic] functions are invoked for each registered serializer.
- *
- * ### Not stable for inheritance
- *
- * `SerializersModuleCollector` interface is not stable for inheritance in 3rd party libraries, as new methods
- * might be added to this interface or contracts of the existing methods can be changed.
  */
 public interface SerializersModuleCollector {
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -560,7 +560,6 @@ public class JsonBuilder internal constructor(json: Json) {
      *
      * This strategy is applied for all entities that have [StructureKind.CLASS].
      */
-    @ExperimentalSerializationApi
     public var namingStrategy: JsonNamingStrategy? = json.configuration.namingStrategy
 
     /**

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonConfiguration.kt
@@ -29,7 +29,6 @@ public class JsonConfiguration @OptIn(ExperimentalSerializationApi::class) inter
     public val classDiscriminator: String = "type",
     public val allowSpecialFloatingPointValues: Boolean = false,
     public val useAlternativeNames: Boolean = true,
-    @ExperimentalSerializationApi
     public val namingStrategy: JsonNamingStrategy? = null,
     public val decodeEnumsCaseInsensitive: Boolean = false,
     public val allowTrailingComma: Boolean = false,

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonElementBuilders.kt
@@ -150,7 +150,6 @@ public class JsonArrayBuilder @PublishedApi internal constructor() {
      * @return `true` if the list was changed as the result of the operation.
      */
     @IgnorableReturnValue
-    @ExperimentalSerializationApi
     public fun addAll(elements: Collection<JsonElement>): Boolean =
         content.addAll(elements)
 
@@ -216,7 +215,6 @@ public fun JsonArrayBuilder.addJsonArray(builderAction: JsonArrayBuilder.() -> U
  */
 @IgnorableReturnValue
 @JvmName("addAllStrings")
-@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<String?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
@@ -227,7 +225,6 @@ public fun JsonArrayBuilder.addAll(values: Collection<String?>): Boolean =
  */
 @IgnorableReturnValue
 @JvmName("addAllBooleans")
-@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<Boolean?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 
@@ -238,7 +235,6 @@ public fun JsonArrayBuilder.addAll(values: Collection<Boolean?>): Boolean =
  */
 @IgnorableReturnValue
 @JvmName("addAllNumbers")
-@ExperimentalSerializationApi
 public fun JsonArrayBuilder.addAll(values: Collection<Number?>): Boolean =
     addAll(values.map(::JsonPrimitive))
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonNamingStrategy.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonNamingStrategy.kt
@@ -44,7 +44,6 @@ import kotlinx.serialization.descriptors.*
  * However, there are cases where usage of naming strategies is inevitable, such as interop with an existing API or migrating a large codebase.
  * Therefore, one should carefully weigh the pros and cons before considering adding global naming strategies to an application.
  */
-@ExperimentalSerializationApi
 public fun interface JsonNamingStrategy {
     /**
      * Accepts an original [serialName] (defined by property name in the class or [SerialName] annotation) and returns
@@ -66,7 +65,6 @@ public fun interface JsonNamingStrategy {
     /**
      * Contains basic, ready to use naming strategies.
      */
-    @ExperimentalSerializationApi
     public companion object Builtins {
 
         /**
@@ -93,7 +91,6 @@ public fun interface JsonNamingStrategy {
          * and therefore does not support one-to-many and many-to-one character mappings.
          * See the documentation of these functions for details.
          */
-        @ExperimentalSerializationApi
         public val SnakeCase: JsonNamingStrategy = object : JsonNamingStrategy {
             override fun serialNameForJson(
                 descriptor: SerialDescriptor,
@@ -128,7 +125,6 @@ public fun interface JsonNamingStrategy {
          * and therefore does not support one-to-many and many-to-one character mappings.
          * See the documentation of these functions for details.
          */
-        @ExperimentalSerializationApi
         public val KebabCase: JsonNamingStrategy = object : JsonNamingStrategy {
             override fun serialNameForJson(
                 descriptor: SerialDescriptor,


### PR DESCRIPTION
- JsonNamingStrategy: it has no known issues

- .addAll overloads in JsonElementBuilders: no known issues and it does not conflict with potential addition of MutableList<JsonElement> as supertype.

- things around SerializersModule:

Experimental annotation was needed because we did not want anyone to implement it. Since interface is sealed for a long time, this problem does not exist. SerializersModuleCollector is widely used in schema generators, and any change to it would require thinking about compatibility anyway, so no point in keeping it experimental.

- ContextualSerializer: should be public just as PolymorphicSerializer (and Sealed, but that's for later).

- various serial descriptors builders and .nonNullOriginal:

They're widely used in delegating descriptors, so moving them under `buildClassSerialDescriptor` or removing completely does not make sense.

- Unsigned array serializers: they're not going away in any case

- seializer() overloads accepting typeParameterSerializers: no known issues

- @KeepGeneratedSerializer: no known issues