### PR TITLE
Speed up TreeJsonDecoder when no alternative names exist

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TreeJsonNamesBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TreeJsonNamesBenchmark.kt
@@ -38,7 +38,7 @@ open class TreeJsonNamesBenchmark {
         val f27: String? = null, val f28: String? = null, val f29: String? = null
     )
 
-    private val default = Json                              // useAlternativeNames = true (default)
+    private val default = Json // useAlternativeNames = true (default)
     private val noAltNames = Json { useAlternativeNames = false }
 
     private val sparse = """{"f00":"a","f07":"b","f13":"c","f21":"d","f29":"e"}"""

--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TreeJsonNamesBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/TreeJsonNamesBenchmark.kt
@@ -1,0 +1,53 @@
+package kotlinx.benchmarks.json
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(2)
+open class TreeJsonNamesBenchmark {
+
+    @Serializable
+    data class Wide(
+        val f00: String? = null, val f01: String? = null, val f02: String? = null,
+        val f03: String? = null, val f04: String? = null, val f05: String? = null,
+        val f06: String? = null, val f07: String? = null, val f08: String? = null,
+        val f09: String? = null, val f10: String? = null, val f11: String? = null,
+        val f12: String? = null, val f13: String? = null, val f14: String? = null,
+        val f15: String? = null, val f16: String? = null, val f17: String? = null,
+        val f18: String? = null, val f19: String? = null, val f20: String? = null,
+        val f21: String? = null, val f22: String? = null, val f23: String? = null,
+        val f24: String? = null, val f25: String? = null, val f26: String? = null,
+        val f27: String? = null, val f28: String? = null, val f29: String? = null
+    )
+
+    private val default = Json                              // useAlternativeNames = true (default)
+    private val noAltNames = Json { useAlternativeNames = false }
+
+    private val sparse = """{"f00":"a","f07":"b","f13":"c","f21":"d","f29":"e"}"""
+    private val element: JsonObject = Json.parseToJsonElement(sparse).jsonObject
+    private val serializer = Wide.serializer()
+
+    @Benchmark
+    fun treeAltNames(): Wide = default.decodeFromJsonElement(serializer, element)
+
+    @Benchmark
+    fun treeNoAltNames(): Wide = noAltNames.decodeFromJsonElement(serializer, element)
+}

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/JsonNamesTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/JsonNamesTest.kt
@@ -35,6 +35,13 @@ class JsonNamesTest : JsonTestBase() {
         @JsonNames("_foo") val foo: String
     )
 
+    @Serializable
+    data class NoAlternativeNames(
+        val a: String? = null,
+        val b: String? = null,
+        val c: String? = null
+    )
+
     private val inputString1 = """{"foo":"foo"}"""
     private val inputString2 = """{"_foo":"foo"}"""
 
@@ -99,6 +106,19 @@ class JsonNamesTest : JsonTestBase() {
                     jsonTestingMode = streaming
                 )
             }
+        }
+    }
+
+    @Test
+    fun testDecodesSparseObjectWithoutAlternativeNames() = parametrizedTest { mode ->
+        val decoded = Json.decodeFromString(NoAlternativeNames.serializer(), """{"b":"x"}""", mode)
+        assertEquals(NoAlternativeNames(a = null, b = "x", c = null), decoded)
+    }
+
+    @Test
+    fun testRejectsUnknownKeyWithoutAlternativeNames() = parametrizedTest { mode ->
+        assertFailsWithMessage<SerializationException>("Encountered an unknown key 'z'") {
+            Json.decodeFromString(NoAlternativeNames.serializer(), """{"b":"x","z":1}""", mode)
         }
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -210,6 +210,19 @@ private open class JsonTreeDecoder(
 ) : AbstractJsonTreeDecoder(json, value, polymorphicDiscriminator) {
     private var position = 0
     private var forceNull: Boolean = false
+    private var alternativeNamesResolved = false
+    private var hasAlternativeNames = false
+
+    private fun hasAlternativeNames(descriptor: SerialDescriptor): Boolean {
+        if (!alternativeNamesResolved) {
+            // Read the cache directly. deserializationNamesMap() makes a throwaway object on every
+            // call, even when the answer is already cached (#3193)
+            hasAlternativeNames = (json.schemaCache[descriptor, JsonDeserializationNamesKey]
+                ?: json.deserializationNamesMap(descriptor)).isNotEmpty()
+            alternativeNamesResolved = true
+        }
+        return hasAlternativeNames
+    }
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         while (position < descriptor.elementsCount) {
@@ -252,7 +265,7 @@ private open class JsonTreeDecoder(
         val strategy = descriptor.namingStrategy(json)
         val baseName = descriptor.getElementName(index)
         if (strategy == null) {
-            if (!configuration.useAlternativeNames) return baseName
+            if (!configuration.useAlternativeNames || !hasAlternativeNames(descriptor)) return baseName
             // Fast path, do not go through ConcurrentHashMap.get
             // Note, it blocks ability to detect collisions between the primary name and alternate,
             // but it eliminates a significant performance penalty (about -15% without this optimization)
@@ -295,9 +308,9 @@ private open class JsonTreeDecoder(
 
         @Suppress("DEPRECATION_ERROR")
         val names: Set<String> = when {
-            strategy == null && !configuration.useAlternativeNames -> descriptor.jsonCachedSerialNames()
             strategy != null -> json.deserializationNamesMap(descriptor).keys
-            else -> descriptor.jsonCachedSerialNames() + json.schemaCache[descriptor, JsonDeserializationNamesKey]?.keys.orEmpty()
+            !configuration.useAlternativeNames || !hasAlternativeNames(descriptor) -> descriptor.jsonCachedSerialNames()
+            else -> descriptor.jsonCachedSerialNames() + json.deserializationNamesMap(descriptor).keys
         }
 
         for (key in value.keys) {


### PR DESCRIPTION
## Problem

When you decode from a `JsonElement` and `useAlternativeNames` is on (the default), it's 2-4x slower and uses about 5x more memory than when it's off, even for classes that have no `@JsonNames` on them at all.

Two things cause it, and both only matter when a class actually has alternative names:
- `endStructure` builds a new set of allowed key names every time it checks for unknown keys.
- `elementName` searches the keys to find fields that aren't present under their own name.

## Fix

Check once per object whether the class has any alternative names. If it doesn't, just do what `useAlternativeNames = false` already does, use the field's own name in `elementName`, and reuse the set of names we already have in `endStructure` instead of building a new one. Classes that do use alternative names aren't affected.

One detail I want to mention: I read the cache directly here to avoid the `getOrPut` allocation in [deserializationNamesMap()](https://github.com/Kotlin/kotlinx.serialization/blob/25c2a75/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt#L53-L54) because it was the only thing keeping memory above the `false` number even though its a small difference. Happy to move that read into `deserializationNamesMap()` itself if you'd rather me fix it at the source.

## Testing

30 field class, 5 of the 30 fields present, decoded from a `JsonElement`:

|                                       | memory per decode |
|---------------------------------------|-------------------|
| useAlternativeNames = false           | 336 bytes         |
| useAlternativeNames = true (before)   | 1872 bytes         |
| useAlternativeNames = true (with fix) | 336 bytes         |

To run it yourself:

```
./gradlew jmhJar
java -jar benchmarks.jar TreeJsonNamesBenchmark -prof gc
```

Attached are before and after logs and profiling artifacts:

[flame-alloc-after.html](https://github.com/user-attachments/files/29932585/flame-alloc-after.html)
[flame-alloc-before.html](https://github.com/user-attachments/files/29932586/flame-alloc-before.html)
[jmh-after-fix.log](https://github.com/user-attachments/files/29932587/jmh-after-fix.log)
[jmh-before-fix.log](https://github.com/user-attachments/files/29932588/jmh-before-fix.log)

Fixes #3193