### PR TITLE
Fix: preserve polymorphic discriminator for a root value class wrapping a class

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/inline/ValueClassesInSealedHierarchyTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/inline/ValueClassesInSealedHierarchyTest.kt
@@ -10,7 +10,23 @@ import kotlinx.serialization.test.*
 import kotlin.jvm.*
 import kotlin.test.*
 
+@Serializable
+sealed interface A
+
+@JvmInline
+@Serializable
+@SerialName("C")
+value class C(val b: B) : A
+
+@Serializable
+data class B(val foo: String)
+
 class ValueClassesInSealedHierarchyTest : JsonTestBase() {
+    @Test
+    fun testBareValueClassWithObject() {
+        assertJsonFormAndRestored(A.serializer(), C(B("1")), """{"type":"C","foo":"1"}""")
+    }
+
     @Test
     fun testSingle() {
         val single = "foo"

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonEncoder.kt
@@ -121,6 +121,14 @@ private sealed class AbstractJsonTreeEncoder(
         return if (currentTagOrNull != null) {
             if (polymorphicDiscriminator != null) polymorphicSerialName = descriptor.serialName
             super.encodeInline(descriptor)
+        } else if (polymorphicDiscriminator != null && descriptor.getElementDescriptor(0).kind is StructureKind) {
+            // A pending polymorphic discriminator can only be attached to the JsonObject
+            // produced by beginStructure(), so a root-level value class wrapping a
+            // structured type must keep encoding through this tree encoder; delegating to
+            // JsonPrimitiveEncoder here would drop the discriminator (issue #3039). Value
+            // classes wrapping primitives/unsigned numbers keep the JsonPrimitiveEncoder path.
+            polymorphicSerialName = descriptor.serialName
+            this
         } else {
             JsonPrimitiveEncoder(json, nodeConsumer).encodeInline(descriptor)
         }


### PR DESCRIPTION
## Summary

Fixes #3039: `Json.encodeToJsonElement` drops the polymorphic `type` discriminator when serializing a bare value class that wraps a non-primitive at the root of a sealed hierarchy, while `Json.encodeToString` emits it correctly. This restores parity between the two encoding paths.

## Background

For `@Serializable @JvmInline value class C(val b: B) : A` where `A` is a sealed interface and `B` is a `@Serializable` class, `encodeToString(C(B("1")) as A)` yields `{"type":"C","foo":"1"}`, but `encodeToJsonElement(...).toString()` yields `{"foo":"1"}` — the discriminator is lost. The same value class encodes correctly when nested inside another class or a collection; only the bare top-level case is affected. The missing discriminator then propagates into `JsonTransformingSerializer.transformSerialize`, which receives a `JsonObject` with no `type` key.

The divergence is in `AbstractJsonTreeEncoder.encodeInline` (`TreeJsonEncoder.kt`). `encodePolymorphically` sets the pending discriminator before the value-class serializer runs, but at root level (`currentTagOrNull == null`) `encodeInline` unconditionally delegated to a fresh `JsonPrimitiveEncoder`, which does not carry the pending discriminator, so the wrapped class's `beginStructure` never attached it.

## Fix

When a discriminator is pending and the value class wraps a **structured** type (`descriptor.getElementDescriptor(0).kind is StructureKind`), keep encoding through the tree encoder (as the tagged branch already does) instead of delegating to `JsonPrimitiveEncoder`, so the discriminator survives to `beginStructure` and is written onto the resulting `JsonObject`. This mirrors the streaming encoder, which returns the same encoder (`apply { polymorphicSerialName = descriptor.serialName }`) for a pending discriminator, and it honors a custom `@JsonClassDiscriminator` key rather than hard-coding `type`.

Value classes wrapping primitives, unsigned numbers, and unquoted literals keep the existing `JsonPrimitiveEncoder` path unchanged, so those scalar-root cases are unaffected.

## Testing

Added a regression test to `ValueClassesInSealedHierarchyTest` asserting `encodeToJsonElement`/`encodeToString` agree (`{"type":"C","foo":"1"}`) for the bare value-class-wrapping-a-class case, via the existing `JsonTestBase` streaming/tree parametrization. The test passes with the fix and fails against the unpatched code. The `features.inline`, `features.sealed`, polymorphic, and JSON discriminator JVM test suites all pass, confirming no regression to the primitive/nested/collection cases.

Fixes #3039

AI was used for assistance.
