### PR TITLE
Rename some Json implementation classes

### DIFF
--- a/formats/json-io/commonMain/src/kotlinx/serialization/json/io/IoStreams.kt
+++ b/formats/json-io/commonMain/src/kotlinx/serialization/json/io/IoStreams.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.json.DecodeSequenceMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.internal.*
-import kotlinx.serialization.json.io.internal.JsonToIoStreamWriter
+import kotlinx.serialization.json.io.internal.KxIoJsonWriter
 import kotlinx.serialization.json.internal.decodeToSequenceByReader
 import kotlinx.serialization.json.io.internal.KxIoReader
 import kotlinx.io.*
@@ -25,7 +25,7 @@ public fun <T> Json.encodeToSink(
     value: T,
     sink: Sink
 ) {
-    val writer = JsonToIoStreamWriter(sink)
+    val writer = KxIoJsonWriter(sink)
     try {
         encodeByWriter(this, writer, serializer, value)
     } finally {

--- a/formats/json-io/commonMain/src/kotlinx/serialization/json/io/IoStreams.kt
+++ b/formats/json-io/commonMain/src/kotlinx/serialization/json/io/IoStreams.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.json.io.internal.JsonToIoStreamWriter
 import kotlinx.serialization.json.internal.decodeToSequenceByReader
-import kotlinx.serialization.json.io.internal.IoSerialReader
+import kotlinx.serialization.json.io.internal.KxIoReader
 import kotlinx.io.*
 
 /**
@@ -60,7 +60,7 @@ public fun <T> Json.decodeFromSource(
     deserializer: DeserializationStrategy<T>,
     source: Source
 ): T {
-    return decodeByReader(this, deserializer, IoSerialReader(source))
+    return decodeByReader(this, deserializer, KxIoReader(source))
 }
 
 /**
@@ -99,7 +99,7 @@ public fun <T> Json.decodeSourceToSequence(
     deserializer: DeserializationStrategy<T>,
     format: DecodeSequenceMode = DecodeSequenceMode.AUTO_DETECT
 ): Sequence<T> {
-    return decodeToSequenceByReader(this, IoSerialReader(source), deserializer, format)
+    return decodeToSequenceByReader(this, KxIoReader(source), deserializer, format)
 }
 
 /**

--- a/formats/json-io/commonMain/src/kotlinx/serialization/json/io/internal/IoJsonStreams.kt
+++ b/formats/json-io/commonMain/src/kotlinx/serialization/json/io/internal/IoJsonStreams.kt
@@ -41,7 +41,7 @@ private const val HIGH_SURROGATE_HEADER = 0xd800 - (0x010000 ushr 10)
 private const val LOW_SURROGATE_HEADER = 0xdc00
 
 @OptIn(UnsafeIoApi::class, InternalIoApi::class)
-internal class IoSerialReader(private val source: Source) : InternalJsonReader {
+internal class KxIoReader(private val source: Source) : InternalJsonReader {
     // When the last (count'th) byte is a high surrogate, we save it here and merge with the low one on the next read()
     // \u0000 is a placeholder for "no high surrogate stored"
     private var bufferedChar: Char = '\u0000'

--- a/formats/json-io/commonMain/src/kotlinx/serialization/json/io/internal/IoJsonStreams.kt
+++ b/formats/json-io/commonMain/src/kotlinx/serialization/json/io/internal/IoJsonStreams.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.internal.*
 
 private const val QUOTE_CODE = '"'.code
 
-internal class JsonToIoStreamWriter(private val sink: Sink) : InternalJsonWriter {
+internal class KxIoJsonWriter(private val sink: Sink) : InternalJsonWriter {
 
     override fun writeLong(value: Long) {
         sink.writeDecimalLong(value)

--- a/formats/json-io/commonTest/src/kotlinx/serialization/json/io/IoTests.kt
+++ b/formats/json-io/commonTest/src/kotlinx/serialization/json/io/IoTests.kt
@@ -25,7 +25,7 @@ class IoTests {
 
         val buffer = Buffer()
         buffer.writeString(text)
-        val reader = IoSerialReader(buffer)
+        val reader = KxIoReader(buffer)
 
         val readArray = CharArray(2)
         assertEquals(1, reader.read(readArray, 0, 1) )

--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.json.DecodeSequenceMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.internal.*
-import kotlinx.serialization.json.okio.internal.JsonToOkioStreamWriter
+import kotlinx.serialization.json.okio.internal.OkioJsonWriter
 import kotlinx.serialization.json.internal.decodeToSequenceByReader
 import kotlinx.serialization.json.okio.internal.OkioReader
 import okio.*
@@ -25,7 +25,7 @@ public fun <T> Json.encodeToBufferedSink(
     value: T,
     sink: BufferedSink
 ) {
-    val writer = JsonToOkioStreamWriter(sink)
+    val writer = OkioJsonWriter(sink)
     try {
         encodeByWriter(this, writer, serializer, value)
     } finally {

--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/OkioStreams.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.json.okio.internal.JsonToOkioStreamWriter
 import kotlinx.serialization.json.internal.decodeToSequenceByReader
-import kotlinx.serialization.json.okio.internal.OkioSerialReader
+import kotlinx.serialization.json.okio.internal.OkioReader
 import okio.*
 
 /**
@@ -60,7 +60,7 @@ public fun <T> Json.decodeFromBufferedSource(
     deserializer: DeserializationStrategy<T>,
     source: BufferedSource
 ): T {
-    return decodeByReader(this, deserializer, OkioSerialReader(source))
+    return decodeByReader(this, deserializer, OkioReader(source))
 }
 
 /**
@@ -99,7 +99,7 @@ public fun <T> Json.decodeBufferedSourceToSequence(
     deserializer: DeserializationStrategy<T>,
     format: DecodeSequenceMode = DecodeSequenceMode.AUTO_DETECT
 ): Sequence<T> {
-    return decodeToSequenceByReader(this, OkioSerialReader(source), deserializer, format)
+    return decodeToSequenceByReader(this, OkioReader(source), deserializer, format)
 }
 
 /**

--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/internal/OkioJsonStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/internal/OkioJsonStreams.kt
@@ -9,7 +9,7 @@ import okio.*
 
 private const val QUOTE_CODE = '"'.code
 
-internal class JsonToOkioStreamWriter(private val sink: BufferedSink) : InternalJsonWriter {
+internal class OkioJsonWriter(private val sink: BufferedSink) : InternalJsonWriter {
     override fun writeLong(value: Long) {
         sink.writeDecimalLong(value)
     }

--- a/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/internal/OkioJsonStreams.kt
+++ b/formats/json-okio/commonMain/src/kotlinx/serialization/json/okio/internal/OkioJsonStreams.kt
@@ -38,7 +38,7 @@ private const val HIGH_SURROGATE_HEADER = 0xd800 - (0x010000 ushr 10)
 // Value added to the low UTF-16 surrogate after masking
 private const val LOW_SURROGATE_HEADER = 0xdc00
 
-internal class OkioSerialReader(private val source: BufferedSource) : InternalJsonReader {
+internal class OkioReader(private val source: BufferedSource) : InternalJsonReader {
     private val cursor = Buffer.UnsafeCursor()
     // When the last (count'th) byte is a high surrogate, we save it here and merge with the low one on the next read()
     // \u0000 is a placeholder for "no high surrogate stored"

--- a/formats/json-okio/commonTest/src/kotlinx/serialization/json/okio/internal/OkioTests.kt
+++ b/formats/json-okio/commonTest/src/kotlinx/serialization/json/okio/internal/OkioTests.kt
@@ -25,7 +25,7 @@ class OkioTests {
 
         val buffer = Buffer()
         buffer.writeUtf8(text)
-        val reader = OkioSerialReader(buffer)
+        val reader = OkioReader(buffer)
 
         val readArray = CharArray(2)
         assertEquals(1, reader.read(readArray, 0, 1) )

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/LexerModesTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/LexerModesTest.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.test.*
 import kotlin.test.*
 
-class JsonModesTest : JsonTestBase() {
+class LexerModesTest : JsonTestBase() {
 
     @Test
     fun testNan() = parametrizedTest(lenient) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -145,7 +145,7 @@ public sealed class Json(
      */
     public final override fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, @FormatLanguage("json", "", "") string: String): T {
         val lexer = StringJsonLexer(this, string)
-        val input = StreamingJsonDecoder(this, WriteMode.OBJ, lexer, deserializer.descriptor, null)
+        val input = StreamingJsonDecoder(this, LexerMode.OBJ, lexer, deserializer.descriptor, null)
         val result = input.decodeSerializableValue(deserializer)
         lexer.expectEof()
         return result

--- a/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/Json.kt
@@ -120,7 +120,7 @@ public sealed class Json(
      * @throws [SerializationException] if the given value cannot be serialized to JSON.
      */
     public final override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
-        val result = JsonToStringWriter()
+        val result = StringJsonWriter()
         try {
             encodeByWriter(this@Json, result, serializer, value)
             return result.toString()

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/CharArrayPool.common.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/CharArrayPool.common.kt
@@ -3,7 +3,8 @@
  */
 package kotlinx.serialization.json.internal
 
-internal expect object CharArrayPoolBatchSize {
+// Operates with lexer's batch size
+internal expect object JsonLexerBufferPool {
     fun take(): CharArray
     fun release(array: CharArray)
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonIterator.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonIterator.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.*
 internal fun <T> JsonIterator(
     mode: DecodeSequenceMode,
     json: Json,
-    lexer: ReaderJsonLexer,
+    lexer: BufferedJsonLexer,
     deserializer: DeserializationStrategy<T>
 ): Iterator<T> = when (lexer.determineFormat(mode)) {
     DecodeSequenceMode.WHITESPACE_SEPARATED -> JsonIteratorWsSeparated(
@@ -52,7 +52,7 @@ private fun AbstractJsonLexer.tryConsumeStartArray(): Boolean {
 
 private class JsonIteratorWsSeparated<T>(
     private val json: Json,
-    private val lexer: ReaderJsonLexer,
+    private val lexer: BufferedJsonLexer,
     private val deserializer: DeserializationStrategy<T>
 ) : Iterator<T> {
     override fun next(): T =
@@ -64,7 +64,7 @@ private class JsonIteratorWsSeparated<T>(
 
 private class JsonIteratorArrayWrapped<T>(
     private val json: Json,
-    private val lexer: ReaderJsonLexer,
+    private val lexer: BufferedJsonLexer,
     private val deserializer: DeserializationStrategy<T>
 ) : Iterator<T> {
     private var first = true

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonIterator.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonIterator.kt
@@ -56,7 +56,7 @@ private class JsonIteratorWsSeparated<T>(
     private val deserializer: DeserializationStrategy<T>
 ) : Iterator<T> {
     override fun next(): T =
-        StreamingJsonDecoder(json, WriteMode.OBJ, lexer, deserializer.descriptor, null)
+        StreamingJsonDecoder(json, LexerMode.OBJ, lexer, deserializer.descriptor, null)
             .decodeSerializableValue(deserializer)
 
     override fun hasNext(): Boolean = lexer.isNotEof()
@@ -76,7 +76,7 @@ private class JsonIteratorArrayWrapped<T>(
         } else {
             lexer.consumeNextToken(COMMA)
         }
-        val input = StreamingJsonDecoder(json, WriteMode.OBJ, lexer, deserializer.descriptor, null)
+        val input = StreamingJsonDecoder(json, LexerMode.OBJ, lexer, deserializer.descriptor, null)
         return input.decodeSerializableValue(deserializer)
     }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonStreams.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonStreams.kt
@@ -53,7 +53,7 @@ public fun <T> decodeByReader(
     deserializer: DeserializationStrategy<T>,
     reader: InternalJsonReader
 ): T {
-    val lexer = ReaderJsonLexer(json, reader)
+    val lexer = BufferedJsonLexer(json, reader)
     try {
         val input = StreamingJsonDecoder(json, WriteMode.OBJ, lexer, deserializer.descriptor, null)
         val result = input.decodeSerializableValue(deserializer)
@@ -72,7 +72,7 @@ public fun <T> decodeToSequenceByReader(
     deserializer: DeserializationStrategy<T>,
     format: DecodeSequenceMode = DecodeSequenceMode.AUTO_DETECT
 ): Sequence<T> {
-    val lexer = ReaderJsonLexer(json, reader, CharArray(BATCH_SIZE)) // Unpooled buffer due to lazy nature of sequence
+    val lexer = BufferedJsonLexer(json, reader, CharArray(BATCH_SIZE)) // Unpooled buffer due to lazy nature of sequence
     val iter = JsonIterator(format, json, lexer, deserializer)
     return Sequence { iter }.constrainOnce()
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonStreams.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonStreams.kt
@@ -41,8 +41,8 @@ public interface InternalJsonReader {
 public fun <T> encodeByWriter(json: Json, writer: InternalJsonWriter, serializer: SerializationStrategy<T>, value: T) {
     val encoder = StreamingJsonEncoder(
         writer, json,
-        WriteMode.OBJ,
-        arrayOfNulls(WriteMode.entries.size)
+        LexerMode.OBJ,
+        arrayOfNulls(LexerMode.entries.size)
     )
     encoder.encodeSerializableValue(serializer, value)
 }
@@ -55,7 +55,7 @@ public fun <T> decodeByReader(
 ): T {
     val lexer = BufferedJsonLexer(json, reader)
     try {
-        val input = StreamingJsonDecoder(json, WriteMode.OBJ, lexer, deserializer.descriptor, null)
+        val input = StreamingJsonDecoder(json, LexerMode.OBJ, lexer, deserializer.descriptor, null)
         val result = input.decodeSerializableValue(deserializer)
         lexer.expectEof()
         return result

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/LexerMode.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/LexerMode.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 import kotlin.jvm.*
 
-internal enum class WriteMode(@JvmField val begin: Char, @JvmField val end: Char) {
+internal enum class LexerMode(@JvmField val begin: Char, @JvmField val end: Char) {
     OBJ(BEGIN_OBJ, END_OBJ),
     LIST(BEGIN_LIST, END_LIST),
     MAP(BEGIN_OBJ, END_OBJ),
@@ -19,12 +19,12 @@ internal enum class WriteMode(@JvmField val begin: Char, @JvmField val end: Char
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-internal fun Json.switchMode(desc: SerialDescriptor): WriteMode =
+internal fun Json.modeFor(desc: SerialDescriptor): LexerMode =
     when (desc.kind) {
-        is PolymorphicKind -> WriteMode.POLY_OBJ
-        StructureKind.LIST -> WriteMode.LIST
-        StructureKind.MAP -> selectMapMode(desc, { WriteMode.MAP }, { WriteMode.LIST })
-        else -> WriteMode.OBJ
+        is PolymorphicKind -> LexerMode.POLY_OBJ
+        StructureKind.LIST -> LexerMode.LIST
+        StructureKind.MAP -> selectMapMode(desc, { LexerMode.MAP }, { LexerMode.LIST })
+        else -> LexerMode.OBJ
     }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -20,7 +20,7 @@ import kotlin.jvm.*
 @OptIn(ExperimentalSerializationApi::class)
 internal open class StreamingJsonDecoder(
     final override val json: Json,
-    private val mode: WriteMode,
+    private val mode: LexerMode,
     @JvmField internal val lexer: AbstractJsonLexer,
     descriptor: SerialDescriptor,
     discriminatorHolder: DiscriminatorHolder?
@@ -99,13 +99,13 @@ internal open class StreamingJsonDecoder(
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
-        val newMode = json.switchMode(descriptor)
+        val newMode = json.modeFor(descriptor)
         lexer.path.pushDescriptor(descriptor)
         lexer.consumeNextToken(newMode.begin)
         checkLeadingComma()
         return when (newMode) {
             // In fact resets current index that these modes rely on
-            WriteMode.LIST, WriteMode.MAP, WriteMode.POLY_OBJ -> StreamingJsonDecoder(
+            LexerMode.LIST, LexerMode.MAP, LexerMode.POLY_OBJ -> StreamingJsonDecoder(
                 json,
                 newMode,
                 lexer,
@@ -161,7 +161,7 @@ internal open class StreamingJsonDecoder(
         deserializer: DeserializationStrategy<T>,
         previousValue: T?
     ): T {
-        val isMapKey = mode == WriteMode.MAP && index and 1 == 0
+        val isMapKey = mode == LexerMode.MAP && index and 1 == 0
         // Reset previous key
         if (isMapKey) {
             lexer.path.resetCurrentMapKey()
@@ -177,12 +177,12 @@ internal open class StreamingJsonDecoder(
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         val index = when (mode) {
-            WriteMode.OBJ -> decodeObjectIndex(descriptor)
-            WriteMode.MAP -> decodeMapIndex()
+            LexerMode.OBJ -> decodeObjectIndex(descriptor)
+            LexerMode.MAP -> decodeMapIndex()
             else -> decodeListIndex() // Both for LIST and default polymorphic
         }
         // The element of the next index that will be decoded
-        if (mode != WriteMode.MAP) {
+        if (mode != LexerMode.MAP) {
             lexer.path.updateDescriptorIndex(index)
         }
         return index
@@ -363,7 +363,7 @@ public fun <T> decodeStringToJsonTree(
     source: String
 ): JsonElement {
     val lexer = StringJsonLexer(json, source)
-    val input = StreamingJsonDecoder(json, WriteMode.OBJ, lexer, deserializer.descriptor, null)
+    val input = StreamingJsonDecoder(json, LexerMode.OBJ, lexer, deserializer.descriptor, null)
     val tree = input.decodeJsonElement()
     lexer.expectEof()
     return tree

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonEncoder.kt
@@ -29,12 +29,12 @@ internal val SerialDescriptor.isUnquotedLiteral: Boolean
 internal class StreamingJsonEncoder(
     private val composer: Composer,
     override val json: Json,
-    private val mode: WriteMode,
+    private val mode: LexerMode,
     private val modeReuseCache: Array<JsonEncoder?>?
 ) : JsonEncoder, AbstractEncoder() {
 
     internal constructor(
-        output: InternalJsonWriter, json: Json, mode: WriteMode,
+        output: InternalJsonWriter, json: Json, mode: LexerMode,
         modeReuseCache: Array<JsonEncoder?>
     ) : this(Composer(output, json), json, mode, modeReuseCache)
 
@@ -81,7 +81,7 @@ internal class StreamingJsonEncoder(
     }
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
-        val newMode = json.switchMode(descriptor)
+        val newMode = json.modeFor(descriptor)
         if (newMode.begin != INVALID) { // entry
             composer.print(newMode.begin)
             composer.indent()
@@ -111,12 +111,12 @@ internal class StreamingJsonEncoder(
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         when (mode) {
-            WriteMode.LIST -> {
+            LexerMode.LIST -> {
                 if (!composer.writingFirst)
                     composer.print(COMMA)
                 composer.nextItem()
             }
-            WriteMode.MAP -> {
+            LexerMode.MAP -> {
                 if (!composer.writingFirst) {
                     forceQuoting = if (index % 2 == 0) {
                         composer.print(COMMA)
@@ -132,7 +132,7 @@ internal class StreamingJsonEncoder(
                     composer.nextItem()
                 }
             }
-            WriteMode.POLY_OBJ -> {
+            LexerMode.POLY_OBJ -> {
                 if (index == 0)
                     forceQuoting = true
                 if (index == 1) {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
@@ -1,6 +1,6 @@
 package kotlinx.serialization.json.internal
 
-internal expect class JsonToStringWriter constructor() : InternalJsonWriter {
+internal expect class StringJsonWriter() : InternalJsonWriter {
     override fun writeChar(char: Char)
     override fun writeLong(value: Long)
     override fun write(text: String)

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
@@ -139,7 +139,7 @@ internal fun escapeToChar(c: Int): Char = if (c < ESC2C_MAX) ESCAPE_2_CHAR[c] el
 /**
  * The base class that reads the JSON from the given char sequence source.
  * It has two implementations: one over the raw [String] instance, [StringJsonLexer],
- * and one over an arbitrary stream of data, [ReaderJsonLexer] (JVM-only).
+ * and one over an arbitrary stream of data, [BufferedJsonLexer] (JVM-only).
  *
  * [AbstractJsonLexer] contains base implementation for cold or not performance-sensitive
  * methods on top of [CharSequence], but [StringJsonLexer] overrides some

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/BufferedJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/BufferedJsonLexer.kt
@@ -35,15 +35,15 @@ internal class ArrayAsSequence(internal val buffer: CharArray) : CharSequence {
     override fun toString(): String = substring(0, length)
 }
 
-internal fun ReaderJsonLexer(json: Json, reader: InternalJsonReader, buffer: CharArray = CharArrayPoolBatchSize.take()) =
+internal fun BufferedJsonLexer(json: Json, reader: InternalJsonReader, buffer: CharArray = CharArrayPoolBatchSize.take()) =
     if (!json.configuration.allowComments)
-        ReaderJsonLexer(reader, buffer, json.configuration)
+        BufferedJsonLexer(reader, buffer, json.configuration)
     else
-        ReaderJsonLexerWithComments(reader, buffer, json.configuration)
+        BufferedJsonLexerWithComments(reader, buffer, json.configuration)
 
-internal open class ReaderJsonLexer(
-    val reader: InternalJsonReader,
-    val buffer: CharArray = CharArrayPoolBatchSize.take(),
+internal open class BufferedJsonLexer(
+    private val reader: InternalJsonReader,
+    private val buffer: CharArray = CharArrayPoolBatchSize.take(),
     configuration: JsonConfiguration
 ) : AbstractJsonLexer(configuration) {
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/BufferedJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/BufferedJsonLexer.kt
@@ -12,9 +12,9 @@ private const val DEFAULT_THRESHOLD = 128
 
 /**
  * For some reason this hand-rolled implementation is faster than
- * fun ArrayAsSequence(s: CharArray): CharSequence = java.nio.CharBuffer.wrap(s, 0, length)
+ * fun CharArrayView(s: CharArray): CharSequence = java.nio.CharBuffer.wrap(s, 0, length)
  */
-internal class ArrayAsSequence(internal val buffer: CharArray) : CharSequence {
+internal class CharArrayView(internal val buffer: CharArray) : CharSequence {
     override var length: Int = buffer.size
 
     override fun get(index: Int): Char = buffer[index]
@@ -35,7 +35,7 @@ internal class ArrayAsSequence(internal val buffer: CharArray) : CharSequence {
     override fun toString(): String = substring(0, length)
 }
 
-internal fun BufferedJsonLexer(json: Json, reader: InternalJsonReader, buffer: CharArray = CharArrayPoolBatchSize.take()) =
+internal fun BufferedJsonLexer(json: Json, reader: InternalJsonReader, buffer: CharArray = JsonLexerBufferPool.take()) =
     if (!json.configuration.allowComments)
         BufferedJsonLexer(reader, buffer, json.configuration)
     else
@@ -43,14 +43,14 @@ internal fun BufferedJsonLexer(json: Json, reader: InternalJsonReader, buffer: C
 
 internal open class BufferedJsonLexer(
     private val reader: InternalJsonReader,
-    private val buffer: CharArray = CharArrayPoolBatchSize.take(),
+    private val buffer: CharArray = JsonLexerBufferPool.take(),
     configuration: JsonConfiguration
 ) : AbstractJsonLexer(configuration) {
 
     @JvmField
     protected var threshold: Int = DEFAULT_THRESHOLD // chars
 
-    override val source: ArrayAsSequence = ArrayAsSequence(buffer)
+    override val source: CharArrayView = CharArrayView(buffer)
 
     init {
         preload(0)
@@ -216,6 +216,6 @@ internal open class BufferedJsonLexer(
     override fun peekLeadingMatchingValue(keyToMatch: String, isLenient: Boolean): String? = null
 
     fun release() {
-        CharArrayPoolBatchSize.release(buffer)
+        JsonLexerBufferPool.release(buffer)
     }
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/CommentLexers.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/CommentLexers.kt
@@ -95,7 +95,7 @@ internal class StringJsonLexerWithComments(source: String, configuration: JsonCo
     }
 }
 
-internal class ReaderJsonLexerWithComments(reader: InternalJsonReader, buffer: CharArray, configuration: JsonConfiguration): ReaderJsonLexer(reader, buffer, configuration) {
+internal class BufferedJsonLexerWithComments(reader: InternalJsonReader, buffer: CharArray, configuration: JsonConfiguration): BufferedJsonLexer(reader, buffer, configuration) {
     override fun consumeNextToken(expected: Char) {
         ensureHaveChars()
         val source = source

--- a/formats/json/jsWasmMain/src/kotlinx/serialization/json/internal/CharArrayPool.kt
+++ b/formats/json/jsWasmMain/src/kotlinx/serialization/json/internal/CharArrayPool.kt
@@ -4,7 +4,7 @@
 package kotlinx.serialization.json.internal
 
 
-internal actual object CharArrayPoolBatchSize {
+internal actual object JsonLexerBufferPool {
 
     actual fun take(): CharArray = CharArray(BATCH_SIZE)
 

--- a/formats/json/jsWasmMain/src/kotlinx/serialization/json/internal/JsonToStringWriterJsWasm.kt
+++ b/formats/json/jsWasmMain/src/kotlinx/serialization/json/internal/JsonToStringWriterJsWasm.kt
@@ -1,6 +1,6 @@
 package kotlinx.serialization.json.internal
 
-internal actual open class JsonToStringWriter actual constructor(): InternalJsonWriter {
+internal actual open class StringJsonWriter actual constructor(): InternalJsonWriter {
     private val sb = StringBuilder(128)
 
     actual override fun writeLong(value: Long) {

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/JvmStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/JvmStreams.kt
@@ -20,7 +20,7 @@ public fun <T> Json.encodeToStream(
     value: T,
     stream: OutputStream
 ) {
-    val writer = JsonToJavaStreamWriter(stream)
+    val writer = OutputStreamJsonWriter(stream)
     try {
         encodeByWriter(this, writer, serializer, value)
     } finally {

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/JvmStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/JvmStreams.kt
@@ -56,7 +56,7 @@ public fun <T> Json.decodeFromStream(
     deserializer: DeserializationStrategy<T>,
     stream: InputStream
 ): T {
-    val reader = JavaStreamSerialReader(stream)
+    val reader = Utf8InputStreamReader(stream)
     try {
         return decodeByReader(this, deserializer, reader)
     } finally {
@@ -102,7 +102,7 @@ public fun <T> Json.decodeToSequence(
     deserializer: DeserializationStrategy<T>,
     format: DecodeSequenceMode = DecodeSequenceMode.AUTO_DETECT
 ): Sequence<T> {
-    return decodeToSequenceByReader(this, JavaStreamSerialReader(stream), deserializer, format)
+    return decodeToSequenceByReader(this, Utf8InputStreamReader(stream), deserializer, format)
 }
 
 /**

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/ArrayPools.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/ArrayPools.kt
@@ -41,7 +41,7 @@ internal object CharArrayPool : CharArrayPoolBase() {
 }
 
 // Pools char arrays of size 16K
-internal actual object CharArrayPoolBatchSize : CharArrayPoolBase() {
+internal actual object JsonLexerBufferPool : CharArrayPoolBase() {
 
     actual fun take(): CharArray = super.take(BATCH_SIZE)
 

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
@@ -257,7 +257,7 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : Intern
     }
 }
 
-internal class JavaStreamSerialReader(stream: InputStream) : InternalJsonReader {
+internal class Utf8InputStreamReader(stream: InputStream) : InternalJsonReader {
     // NB: not closed on purpose, it is the responsibility of the caller
     private val reader = CharsetReader(stream, Charsets.UTF_8)
 

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.json.JsonEncodingException
 import java.io.InputStream
 import java.io.OutputStream
 
-internal class JsonToJavaStreamWriter(private val stream: OutputStream) : InternalJsonWriter {
+internal class OutputStreamJsonWriter(private val stream: OutputStream) : InternalJsonWriter {
     private val buffer = ByteArrayPool.take()
     private var charArray = CharArrayPool.take()
     private var indexInBuffer: Int = 0

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
@@ -5,8 +5,8 @@ package kotlinx.serialization.json.internal
  *
  * ## Implementation note
  *
- * In order to encode a single string, it should be processed symbol-per-symbol,
- * in order to detect and escape unicode symbols.
+ * To encode a single string, it should be processed symbol-per-symbol,
+ * so it's possible to properly detect and escape unicode symbols.
  *
  * Doing naively, it drastically slows down strings processing due to factors:
  * * Byte-by-byte copying that does not leverage optimized array copying
@@ -25,7 +25,7 @@ package kotlinx.serialization.json.internal
  * 3) We pool char arrays in order to save excess resizes, allocations
  *    and nulls-out of arrays.
  */
-internal actual class JsonToStringWriter : InternalJsonWriter {
+internal actual class StringJsonWriter : InternalJsonWriter {
     private var array: CharArray = CharArrayPool.take()
     private var size = 0
 

--- a/formats/json/nativeMain/src/kotlinx/serialization/json/internal/CharArrayPool.kt
+++ b/formats/json/nativeMain/src/kotlinx/serialization/json/internal/CharArrayPool.kt
@@ -3,7 +3,7 @@
  */
 package kotlinx.serialization.json.internal
 
-internal actual object CharArrayPoolBatchSize {
+internal actual object JsonLexerBufferPool {
     actual fun take(): CharArray = CharArray(BATCH_SIZE)
     actual fun release(array: CharArray) = Unit
 }

--- a/formats/json/nativeMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
+++ b/formats/json/nativeMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
@@ -1,6 +1,6 @@
 package kotlinx.serialization.json.internal
 
-internal actual open class JsonToStringWriter actual constructor(): InternalJsonWriter {
+internal actual open class StringJsonWriter actual constructor(): InternalJsonWriter {
     private val sb = StringBuilder(128)
 
     actual override fun writeLong(value: Long) {


### PR DESCRIPTION
While working on the trie prototype (and on #3225/#2743), I've generally noticed that it is really hard to follow the current implementation and switch between various types of lexers/readers. 

Its naming is not self-consistent, is partially contradictory, and is slightly confusing. It especially stands out after some time without contributing to the project but still having an understanding of all concepts.

I've tried to keep things self-consistent and conventional, without touching any ABI. One commit -- one self-contained change