### PR TITLE
KT-87873: suppress warning on android native target family (#3229)

### DIFF
--- a/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
@@ -33,11 +33,21 @@ kotlin {
     mingwX64()
     iosX64()
     watchosDeviceArm64()
+
+    // Deprecated
     // https://github.com/square/okio/issues/1242#issuecomment-1759357336
     if (doesNotDependOnOkio(project)) {
+        // Deprecated for removal: see KT-86581
+        // kotlin 2.5.0 - deprecated warning
+        // kotlin 2.5.20 - deprecated error
+        // kotlin 2.6.0 - removed
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         androidNativeArm32()
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         androidNativeArm64()
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         androidNativeX86()
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         androidNativeX64()
 
         // Deprecated, but not removed
@@ -45,7 +55,8 @@ kotlin {
         linuxArm32Hfp()
     }
 
-    // Deprecated
+    // Deprecated for removal: see KT-78660
+    // timeline: unknown, for additional information see the ticket 
     @Suppress("DEPRECATION", "DEPRECATION_ERROR")
     macosX64()
     @Suppress("DEPRECATION", "DEPRECATION_ERROR")


### PR DESCRIPTION
(cherry picked from commit 355e9b2bcd17d740c579bc3899f9a715a20b5167)