### PR TITLE
Fix integral decoding from property maps

### DIFF
--- a/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
+++ b/formats/properties/commonMain/src/kotlinx/serialization/properties/Properties.kt
@@ -12,6 +12,8 @@ import kotlinx.serialization.encoding.*
 import kotlinx.serialization.internal.*
 import kotlinx.serialization.modules.*
 
+private const val MAX_SAFE_INTEGER: Double = 9007199254740991.0 // 2^53 - 1
+
 /**
  * Transforms a [Serializable] class' properties into a single flat [Map] consisting of
  * string keys and primitive type values, and vice versa.
@@ -147,6 +149,49 @@ public sealed class Properties(
     ) : InMapper<Any>(map, descriptor) {
         override fun structure(descriptor: SerialDescriptor): InAnyMapper =
             InAnyMapper(map, descriptor)
+
+        override fun decodeTaggedByte(tag: String): Byte =
+            decodeTaggedIntegral<Byte>(tag, Byte.MIN_VALUE.toDouble(), Byte.MAX_VALUE.toDouble()).toInt().toByte()
+
+        override fun decodeTaggedShort(tag: String): Short =
+            decodeTaggedIntegral<Short>(tag, Short.MIN_VALUE.toDouble(), Short.MAX_VALUE.toDouble()).toInt().toShort()
+
+        override fun decodeTaggedInt(tag: String): Int =
+            decodeTaggedIntegral<Int>(tag, Int.MIN_VALUE.toDouble(), Int.MAX_VALUE.toDouble()).toInt()
+
+        override fun decodeTaggedLong(tag: String): Long {
+            val value = decodeTaggedValue(tag)
+            if (value is Long) return value
+
+            // Kotlin/JS represents Float and Double as the same JavaScript Number.
+            // Other targets retain distinct runtime types and must not coerce them to Long.
+            val isFloat = value is Float
+            val isDouble = value is Double
+            if (isFloat && isDouble) {
+                val number = (value as Number).toDouble()
+                if (number.isFinite() && number % 1.0 == 0.0 && number in -MAX_SAFE_INTEGER..MAX_SAFE_INTEGER) {
+                    return number.toLong()
+                }
+            }
+
+            throw invalidIntegralValue(tag, value, "Long")
+        }
+
+        private inline fun <reified T : Number> decodeTaggedIntegral(
+            tag: String,
+            min: Double,
+            max: Double
+        ): Double {
+            val value = decodeTaggedValue(tag)
+            val number = (value as? T)?.toDouble() ?: throw invalidIntegralValue(tag, value, T::class.simpleName!!)
+            if (!number.isFinite() || number % 1.0 != 0.0 || number !in min..max) {
+                throw invalidIntegralValue(tag, value, T::class.simpleName!!)
+            }
+            return number
+        }
+
+        private fun invalidIntegralValue(tag: String, value: Any, type: String): SerializationException =
+            SerializationException("Value '$value' for property '$tag' is not a valid $type")
     }
 
     private inner class InStringMapper(

--- a/formats/properties/commonTest/src/kotlinx/serialization/properties/PropertiesNumericTest.kt
+++ b/formats/properties/commonTest/src/kotlinx/serialization/properties/PropertiesNumericTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.properties
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+@Serializable
+internal data class IntegralHolder(
+    val byte: Byte = 0,
+    val short: Short = 0,
+    val int: Int = 0,
+    val long: Long = 0
+)
+
+class PropertiesNumericTest {
+
+    @Test
+    fun testRoundTripsIntegralValues() {
+        val expected = IntegralHolder(Byte.MIN_VALUE, Short.MAX_VALUE, Int.MIN_VALUE, Long.MAX_VALUE)
+        val encoded = Properties.encodeToMap(IntegralHolder.serializer(), expected)
+        assertEquals(expected, Properties.decodeFromMap(IntegralHolder.serializer(), encoded))
+    }
+}

--- a/formats/properties/jsTest/src/kotlinx/serialization/properties/PropertiesNumericTest.kt
+++ b/formats/properties/jsTest/src/kotlinx/serialization/properties/PropertiesNumericTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.properties
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+private const val MAX_SAFE_INTEGER: Double = 9007199254740991.0 // 2^53 - 1
+
+class PropertiesJsNumericTest {
+
+    private fun assertRejected(property: String, value: Any) {
+        assertFailsWith<SerializationException>("Expected $value to be rejected for $property") {
+            Properties.decodeFromMap(IntegralHolder.serializer(), mapOf(property to value))
+        }
+    }
+
+    private fun assertAccepted(property: String, value: Any, expected: IntegralHolder) {
+        assertEquals(
+            expected,
+            Properties.decodeFromMap(IntegralHolder.serializer(), mapOf(property to value))
+        )
+    }
+
+    @Test
+    fun testAcceptsIntegralBoundaries() {
+        assertAccepted("byte", Byte.MIN_VALUE.toDouble(), IntegralHolder(byte = Byte.MIN_VALUE))
+        assertAccepted("byte", Byte.MAX_VALUE.toDouble(), IntegralHolder(byte = Byte.MAX_VALUE))
+        assertAccepted("short", Short.MIN_VALUE.toDouble(), IntegralHolder(short = Short.MIN_VALUE))
+        assertAccepted("short", Short.MAX_VALUE.toDouble(), IntegralHolder(short = Short.MAX_VALUE))
+        assertAccepted("int", Int.MIN_VALUE.toDouble(), IntegralHolder(int = Int.MIN_VALUE))
+        assertAccepted("int", Int.MAX_VALUE.toDouble(), IntegralHolder(int = Int.MAX_VALUE))
+        assertAccepted("long", -MAX_SAFE_INTEGER, IntegralHolder(long = -MAX_SAFE_INTEGER.toLong()))
+        assertAccepted("long", MAX_SAFE_INTEGER, IntegralHolder(long = MAX_SAFE_INTEGER.toLong()))
+    }
+
+    @Test
+    fun testRejectsFractionalIntegralValues() {
+        assertRejected("byte", 1.23)
+        assertRejected("short", 1.23)
+        assertRejected("int", 1.23)
+        assertRejected("long", 1.23)
+    }
+
+    @Test
+    fun testRejectsNonFiniteIntegralValues() {
+        listOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY).forEach { value ->
+            assertRejected("byte", value)
+            assertRejected("short", value)
+            assertRejected("int", value)
+            assertRejected("long", value)
+        }
+    }
+
+    @Test
+    fun testRejectsOutOfRangeIntegralValues() {
+        assertRejected("byte", Byte.MIN_VALUE.toDouble() - 1)
+        assertRejected("byte", Byte.MAX_VALUE.toDouble() + 1)
+        assertRejected("short", Short.MIN_VALUE.toDouble() - 1)
+        assertRejected("short", Short.MAX_VALUE.toDouble() + 1)
+        assertRejected("int", Int.MIN_VALUE.toDouble() - 1)
+        assertRejected("int", Int.MAX_VALUE.toDouble() + 1)
+        assertRejected("long", Long.MIN_VALUE.toDouble())
+        assertRejected("long", Long.MAX_VALUE.toDouble())
+    }
+
+    @Test
+    fun testRejectsUnsafeLongValues() {
+        assertRejected("long", -MAX_SAFE_INTEGER - 1)
+        assertRejected("long", MAX_SAFE_INTEGER + 1)
+    }
+}

--- a/formats/properties/jvmTest/src/kotlinx/serialization/properties/PropertiesNumericTest.kt
+++ b/formats/properties/jvmTest/src/kotlinx/serialization/properties/PropertiesNumericTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.properties
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+class PropertiesJvmNumericTest {
+
+    private fun assertRejected(property: String, value: Any) {
+        assertFailsWith<SerializationException>("Expected ${value::class.simpleName} to be rejected for $property") {
+            Properties.decodeFromMap(IntegralHolder.serializer(), mapOf(property to value))
+        }
+    }
+
+    @Test
+    fun testRejectsMismatchedIntegralRuntimeTypes() {
+        assertRejected("byte", 1.toShort())
+        assertRejected("byte", 1.0)
+        assertRejected("short", 1)
+        assertRejected("short", 1.0)
+        assertRejected("int", 1L)
+        assertRejected("int", 1.0)
+        assertRejected("long", 1)
+        assertRejected("long", 1.0)
+    }
+}


### PR DESCRIPTION
Closes #1208

## Summary

- validate `Byte`, `Short`, and `Int` values from `Any`-backed property maps before converting them
- accept only finite, integral, safe JavaScript numbers when decoding a `Long`
- preserve exact runtime-type behavior on JVM and Native and add focused common, JS, and JVM regression tests

## Validation

- `./gradlew :kotlinx-serialization-properties:jvmTest :kotlinx-serialization-properties:jsNodeTest --tests '*Properties*NumericTest*'`
- `./gradlew :kotlinx-serialization-properties:jvmTest :kotlinx-serialization-properties:jsNodeTest`
- `./gradlew :kotlinx-serialization-properties:check` (passed through JVM, JS, macOS ARM64 Native, ABI/artifact, and cross-target checks; stopped only because the local Xcode installation lacks the tvOS Simulator ARM64 SDK)
- `git diff --check`
