### PR TITLE
IR inliner: Don't use CLI flag that enforces "intra-module" inliner mode

### DIFF
--- a/buildSrc/src/main/kotlin/CompilerOptions.kt
+++ b/buildSrc/src/main/kotlin/CompilerOptions.kt
@@ -14,7 +14,6 @@ val defaultCompilerArgs
         "-Xreport-all-warnings",
         "-Xrender-internal-diagnostic-names",
         "-Xreturn-value-checker=full",
-        "-Xklib-ir-inliner=intra-module",
     )
 
 fun KotlinCommonCompilerOptions.defaultOptions() {


### PR DESCRIPTION
Previously, "intra-module" inliner has been explicitly enabled in kotlinx.serialization runtime libraries when they were built with 2.3.x compiler: a5a3c97a590571de3f6692c21d00de95aa16226c.

In 2.4.x the "intra-module" inliner is enabled by default, and in 2.5.0 the full ("cross-module") inliner is enabled by default.

We need to drop all explicit usages of `-Xklib-ir-inliner` flag from build scripts to not stick with the "intra-module" mode forever.

^KT-88022