### PR TITLE
Optimize ordered JSON key decoding

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/LookupOverheadBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/LookupOverheadBenchmark.kt
@@ -33,6 +33,7 @@ open class LookupOverheadBenchmark {
     private val data = """{"a":""}"""
     private val doubleData = """{"a":"","b":0}"""
     private val pentaData = """{"a":"","b":0,"c":1,"d":true,"e":" "}"""
+    private val reversedPentaData = """{"e":" ","d":true,"c":1,"b":0,"a":""}"""
 
     @Serializable
     object Object
@@ -60,6 +61,9 @@ open class LookupOverheadBenchmark {
 
     @Benchmark
     fun pentaGenericPlain() = Json.decodeFromString(PentaGeneric.serializer(String.serializer(), Int.serializer(), Long.serializer(), Boolean.serializer(), Char.serializer()), pentaData)
+
+    @Benchmark
+    fun pentaGenericReversed() = Json.decodeFromString(PentaGeneric.serializer(String.serializer(), Int.serializer(), Long.serializer(), Boolean.serializer(), Char.serializer()), reversedPentaData)
 
     @Benchmark
     fun objectReified() = Json.decodeFromString<Object>("{}")

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonNameLookupTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonNameLookupTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JsonNameLookupTest : JsonTestBase() {
+
+    @Serializable
+    data class HashCollision(
+        @SerialName("Aa") val first: Int,
+        @SerialName("BB") val second: Int
+    )
+
+    @Serializable
+    data class EscapedName(@SerialName("quoted\"name") val value: Int)
+
+    @Serializable
+    data class DifferentLengths(val longerName: Int, val x: Int)
+
+    @Serializable
+    data class Recursive(val head: Int, val child: Recursive? = null, val tail: Int)
+
+    @Test
+    fun orderedAndOutOfOrderNames() {
+        assertEquals(
+            HashCollision(1, 2),
+            Json.decodeFromString<HashCollision>("""{"Aa":1,"BB":2}""")
+        )
+        assertEquals(
+            HashCollision(1, 2),
+            Json.decodeFromString<HashCollision>("""{"BB":2,"Aa":1}""")
+        )
+        assertEquals(
+            DifferentLengths(1, 2),
+            Json.decodeFromString<DifferentLengths>("""{"x":2,"longerName":1}""")
+        )
+    }
+
+    @Test
+    fun escapedNameUsesFallback() {
+        assertEquals(
+            EscapedName(42),
+            Json.decodeFromString<EscapedName>("""{"quoted\"name":42}""")
+        )
+    }
+
+    @Test
+    fun nestedSameDescriptorRestoresThroughFallback() {
+        assertEquals(
+            Recursive(1, Recursive(2, tail = 3), 4),
+            Json.decodeFromString<Recursive>("""{"head":1,"child":{"head":2,"tail":3},"tail":4}""")
+        )
+    }
+}

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonPath.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonPath.kt
@@ -61,6 +61,8 @@ internal class JsonPath(private val configuration: JsonConfiguration) {
         indicies[currentDepth] = index
     }
 
+    fun currentDescriptorIndex(): Int = if (currentDepth == -1) -1 else indicies[currentDepth]
+
     /*
      * For maps we cannot use indicies and should use the key as an element of the path instead.
      * The key can be even an object (e.g. in a case of 'allowStructuredMapKeys') where

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -44,6 +44,8 @@ internal open class StreamingJsonDecoder(
     private var currentIndex = -1
     private var discriminatorHolder: DiscriminatorHolder? = discriminatorHolder
     private val configuration = json.configuration
+    private val useKeyNameFastPath =
+        !configuration.isLenient && configuration.namingStrategy == null && lexer.supportsKeyNameMatching
 
     private val elementMarker: JsonElementMarker? = if (configuration.explicitNulls) null else JsonElementMarker(descriptor)
 
@@ -111,6 +113,7 @@ internal open class StreamingJsonDecoder(
                 discriminatorHolder
             )
             else -> if (mode == newMode && json.configuration.explicitNulls) {
+                currentIndex = -1
                 this
             } else {
                 StreamingJsonDecoder(json, newMode, lexer, descriptor, discriminatorHolder)
@@ -130,6 +133,8 @@ internal open class StreamingJsonDecoder(
         lexer.consumeNextToken(mode.end)
         // Then cleanup the path
         lexer.path.popDescriptor()
+        // An object decoder can be reused for a nested object, so restore the outer sequential index.
+        if (mode == WriteMode.OBJ) currentIndex = lexer.path.currentDescriptorIndex()
     }
 
     private fun skipLeftoverElements(descriptor: SerialDescriptor) {
@@ -224,10 +229,26 @@ internal open class StreamingJsonDecoder(
         var hasComma = lexer.tryConsumeComma()
         while (lexer.canConsumeValue()) { // TODO: consider merging comma consumption and this check
             hasComma = false
-            val key = decodeStringKey()
+            // JSON produced by this format writes keys in descriptor order. Compare that expected
+            // name directly against String input, then retain the regular lookup as a full fallback.
+            val nextIndex = currentIndex + 1
+            val fastIndex = if (
+                useKeyNameFastPath && nextIndex < descriptor.elementsCount &&
+                lexer.tryConsumeKeyString(descriptor.getElementName(nextIndex))
+            ) {
+                nextIndex
+            } else {
+                UNKNOWN_NAME
+            }
+            val key = if (fastIndex == UNKNOWN_NAME) {
+                if (configuration.isLenient) decodeStringKey() else lexer.consumeKeyStringAfterMatchFailure()
+            } else {
+                null
+            }
             lexer.consumeNextToken(COLON)
-            val index = descriptor.getJsonNameIndex(json, key)
+            val index = if (fastIndex == UNKNOWN_NAME) descriptor.getJsonNameIndex(json, key!!) else fastIndex
             val isUnknown = if (index != UNKNOWN_NAME) {
+                currentIndex = index
                 if (configuration.coerceInputValues && coerceInputValue(descriptor, index)) {
                     hasComma = lexer.tryConsumeComma()
                     false // Known element, but coerced
@@ -240,7 +261,7 @@ internal open class StreamingJsonDecoder(
             }
 
             if (isUnknown) { // slow-path for unknown keys handling
-                hasComma = handleUnknown(descriptor, key)
+                hasComma = handleUnknown(descriptor, key!!)
             }
         }
         if (hasComma && !json.configuration.allowTrailingComma) lexer.invalidTrailingComma()

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt
@@ -312,6 +312,17 @@ internal abstract class AbstractJsonLexer(internal val configuration: JsonConfig
      */
     abstract fun consumeKeyString(): String
 
+    /** Whether [tryConsumeKeyString] can avoid materializing a matching key. */
+    open val supportsKeyNameMatching: Boolean get() = false
+
+    /**
+     * Consumes a key equal to [expected] without creating a [String]. If the key does not match,
+     * [consumeKeyStringAfterMatchFailure] must return it and leave the lexer after the key.
+     */
+    open fun tryConsumeKeyString(expected: String): Boolean = false
+
+    open fun consumeKeyStringAfterMatchFailure(): String = consumeKeyString()
+
     private fun insideString(isLenient: Boolean, char: Char): Boolean = if (isLenient) {
         charToTokenClass(char) == TC_OTHER
     } else {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/StringJsonLexer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/StringJsonLexer.kt
@@ -18,6 +18,9 @@ internal open class StringJsonLexer(
     configuration: JsonConfiguration
 ) : AbstractJsonLexer(configuration) {
 
+    private var unmatchedKey: String? = null
+    override val supportsKeyNameMatching: Boolean get() = true
+
     override fun prefetchOrEof(position: Int): Int = if (position < source.length) position else -1
 
     override fun consumeNextToken(): Byte {
@@ -108,6 +111,57 @@ internal open class StringJsonLexer(
         }
         this.currentPosition = closingQuote + 1
         return source.substring(current, closingQuote)
+    }
+
+    override fun tryConsumeKeyString(expected: String): Boolean {
+        val positionSnapshot = currentPosition
+        consumeNextToken(STRING)
+        val start = currentPosition
+        val expectedEnd = start + expected.length
+
+        // The common case knows the expected length, so it can avoid scanning the key twice.
+        // expectedEnd >= start also rejects Int overflow for unusually large inputs.
+        if (expectedEnd >= start && expectedEnd < source.length && source[expectedEnd] == STRING) {
+            var matches = true
+            for (i in expected.indices) {
+                val char = source[start + i]
+                // A quote before expectedEnd means the key is shorter. An escape needs full decoding.
+                if (char == STRING || char == STRING_ESC) {
+                    currentPosition = positionSnapshot
+                    return false
+                }
+                if (matches && char != expected[i]) matches = false
+            }
+
+            currentPosition = expectedEnd + 1
+            if (!matches) unmatchedKey = source.substring(start, expectedEnd)
+            return matches
+        }
+
+        // A differently-sized key can still be returned to the regular lookup without rescanning it.
+        val closingQuote = source.indexOf('"', start)
+        if (closingQuote == -1) {
+            currentPosition = positionSnapshot
+            return false
+        }
+
+        for (i in start until closingQuote) {
+            val char = source[i]
+            if (char == STRING_ESC) {
+                currentPosition = positionSnapshot
+                return false
+            }
+        }
+
+        currentPosition = closingQuote + 1
+        unmatchedKey = source.substring(start, closingQuote)
+        return false
+    }
+
+    override fun consumeKeyStringAfterMatchFailure(): String {
+        val key = unmatchedKey ?: return consumeKeyString()
+        unmatchedKey = null
+        return key
     }
 
     override fun consumeStringChunked(isLenient: Boolean, consumeChunk: (stringChunk: String) -> Unit) {


### PR DESCRIPTION
## Summary

- avoid materializing JSON object keys and performing a hash lookup when string input follows descriptor order
- retain the existing lookup path for out-of-order, escaped, unknown, lenient, naming-strategy, and streamed input
- restore the outer sequential index when an object decoder is reused for a nested object
- add regression coverage and a reversed-order JMH control

## Motivation

Object decoding currently allocates a `String` for every field name and then looks it up in the descriptor name map. Profiling showed key parsing and lookup as a significant part of JSON decoding time and allocation.

The new optimistic path compares the next descriptor name directly with the source. A mismatch immediately falls back to the existing behavior, so accepted inputs and public APIs are unchanged.

## Performance

Project JMH, clean `master` versus this change:

| Benchmark | Throughput | Allocation |
|---|---:|---:|
| Five-field generic object | +50.1% | -19.9% |
| One-field integer object | +115.2% | -54.5% |
| Twitter feed | +19.3% | -52.4% |

An external `java-json-benchmark` A/B run on JDK 25 and the dedicated Claws host compared published 1.11.0 with the local candidate across 1/10/100/1000 KB payloads:

- Users deserialization: **+20.37%** geometric mean
- Clients deserialization: **+7.00%** geometric mean
- all deserialization cases: **+13.49%** geometric mean
- serialization control: **+0.52%** geometric mean, with mixed signs and overlapping confidence intervals

The external run used 15 threads, two forks, a fixed seed, and alternated baseline/candidate execution order per workload.

## Compatibility

The regular lookup remains authoritative whenever the optimistic comparison cannot be used or does not match. Tests cover hash-colliding names, different-length and reversed fields, escaped names, and recursive reuse of the same descriptor.

There are no public API changes.

## Validation

- `./gradlew :kotlinx-serialization-json-tests:jvmTest`
- `./gradlew :kotlinx-serialization-json-tests:jsNodeTest`
- `./gradlew :kotlinx-serialization-json-tests:macosArm64Test`
- `./gradlew apiCheck`
- `./gradlew :benchmark:jmhJar`
- full external Claws A/B benchmark matrix
