### PR TITLE
Reduce JSON encodeToStream write calls

### DIFF
--- a/formats/json-tests/jvmTest/src/kotlinx/serialization/features/JsonJvmStreamsTest.kt
+++ b/formats/json-tests/jvmTest/src/kotlinx/serialization/features/JsonJvmStreamsTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.serialization.features
 
 import kotlinx.serialization.*
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
@@ -12,6 +13,8 @@ import kotlinx.serialization.test.*
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
@@ -85,6 +88,45 @@ class JsonJvmStreamsTest {
         }
     }
 
+    @Test
+    fun testEncodeBuffersSmallWrites() {
+        val serializer = ListSerializer(String.serializer())
+        val value = List(20) { "value-$it" }
+        val stream = CountingOutputStream()
+
+        Json.encodeToStream(serializer, value, stream)
+
+        assertEquals(Json.encodeToString(serializer, value), stream.content())
+        assertEquals(1, stream.writeCalls)
+        assertEquals(0, stream.flushCalls)
+    }
+
+    @Test
+    fun testStreamUtf8EncodingMatchesStringEncoding() {
+        val values = listOf(
+            "",
+            "plain ASCII",
+            "\"\\\b\u000c\n\r\t\u0000\u001f",
+            "\u007f\u0080\u07ff\u0800\uffff",
+            "Привет, мир",
+            "😀",
+            "\ud800",
+            "\udc00",
+            "\ud800x\udc00",
+            "é".repeat(BATCH_SIZE),
+            "😀".repeat(BATCH_SIZE)
+        )
+
+        for (value in values) {
+            val expected = Json.encodeToString(String.serializer(), value).encodeToByteArray()
+            val output = ByteArrayOutputStream()
+
+            Json.encodeToStream(String.serializer(), value, output)
+
+            assertContentEquals(expected, output.toByteArray(), "Failed to encode ${value.take(32)}")
+        }
+    }
+
     interface Poly
 
     @Serializable
@@ -125,5 +167,30 @@ class JsonJvmStreamsTest {
 
         val deserialized = json.decodeViaStream(serializer<Poly>(), string)
         assertEquals(golden, deserialized as Impl)
+    }
+
+    private class CountingOutputStream : OutputStream() {
+        private val output = ByteArrayOutputStream()
+
+        var writeCalls: Int = 0
+            private set
+        var flushCalls: Int = 0
+            private set
+
+        override fun write(b: Int) {
+            writeCalls++
+            output.write(b)
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            writeCalls++
+            output.write(b, off, len)
+        }
+
+        override fun flush() {
+            flushCalls++
+        }
+
+        fun content(): String = output.toByteArray().decodeToString()
     }
 }

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
@@ -45,7 +45,6 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : Intern
         arr[length + 1] = '"'
 
         writeUtf8(arr, length + 2)
-        flush()
     }
 
     private fun appendStringSlowPath(currentSize: Int, string: String) {
@@ -90,7 +89,6 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : Intern
         ensureTotalCapacity(sz, 1)
         charArray[sz++] = '"'
         writeUtf8(charArray, sz)
-        flush()
     }
 
     @IgnorableReturnValue
@@ -109,10 +107,10 @@ internal class JsonToJavaStreamWriter(private val stream: OutputStream) : Intern
     }
 
     private fun flush() {
+        if (indexInBuffer == 0) return
         stream.write(buffer, 0, indexInBuffer)
         indexInBuffer = 0
     }
-
 
     @Suppress("NOTHING_TO_INLINE")
     // ! you should never ask for more than the buffer size


### PR DESCRIPTION
## Summary

- retain encoded UTF-8 bytes in the existing pooled buffer across quoted JSON values
- write buffered bytes only when the buffer is full or the writer is released, and skip zero-length writes
- cover write batching and byte-for-byte UTF-8 compatibility, including escapes, buffer boundaries, Unicode, and malformed surrogate pairs

## Why

`JsonToJavaStreamWriter.writeQuoted` and its slow path flushed the byte buffer after every JSON string. Object and collection workloads therefore issued many small `OutputStream.write` calls even when the 512-byte buffer still had capacity.

The writer is scoped to one `encodeToStream` call and is released in `finally`, so retaining bytes until capacity is needed preserves output and exception behavior while making the existing buffer effective across tokens. This does not call `OutputStream.flush`; ownership of the destination stream remains with the caller.

## Benchmark

Measured with java-json-benchmark on Claws (Ryzen 7 7700X, Linux, JDK 25), using the stream serialization category, one 100 KiB payload, one thread, seed `20260811`, CPU affinity to one core, 3 forks, 3 × 2 s warmup, and 5 × 2 s measurement.

| Payload | 1.11.0 | This change | Difference |
| --- | ---: | ---: | ---: |
| Users | 3,203.8 ops/s | 3,482.9 ops/s | +8.7% |
| Clients | 3,244.7 ops/s | 3,357.3 ops/s | +3.5% |

In a JFR run on the Users payload, `ByteArrayOutputStream.write` fell from 9.51% to 0.51% of sampled CPU. Allocation was unchanged (15,256.7 B/op vs 15,256.4 B/op); this optimization removes calls rather than objects.

## Validation

- `./gradlew :kotlinx-serialization-json-tests:jvmTest`
- java-json-benchmark tests and shadow JAR builds for both 1.11.0 and the local snapshot
