### PR TITLE
Stop unconditionally dumping serialized data from protobuf tests

### DIFF
--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtoBufNullTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtoBufNullTest.kt
@@ -25,19 +25,19 @@ class ProtoBufNullTest {
     @Test
     fun testReadCompareWithNulls() {
         val data = MessageWithOptionals()
-        assertTrue(readCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(readCompare(data, protoBuf = protoBuf))
     }
 
     @Test
     fun testDumpCompareWithNulls() {
         val data = MessageWithOptionals()
-        assertTrue(dumpCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(dumpCompare(data, protoBuf = protoBuf))
     }
 
     @Test
     fun testReadCompareWithDefaults() {
         val data = MessageWithOptionals(0, "", MessageWithOptionals.Position.FIRST, 99, listOf(1, 2, 3))
-        assertTrue(readCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(readCompare(data, protoBuf = protoBuf))
     }
 
     @Test
@@ -49,13 +49,13 @@ class ProtoBufNullTest {
     @Test
     fun testReadCompareWithValues() {
         val data = MessageWithOptionals(42, "Test", MessageWithOptionals.Position.SECOND, 24, listOf(1, 2, 3))
-        assertTrue(readCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(readCompare(data, protoBuf = protoBuf))
     }
 
     @Test
     fun testDumpCompareWithValues() {
         val data = MessageWithOptionals(42, "Test", MessageWithOptionals.Position.SECOND, 24, listOf(1, 2, 3))
-        assertTrue(dumpCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(dumpCompare(data, protoBuf = protoBuf))
     }
 
     @Test

--- a/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtoBufOptionalTest.kt
+++ b/formats/protobuf/jvmTest/src/kotlinx/serialization/protobuf/ProtoBufOptionalTest.kt
@@ -25,25 +25,25 @@ class ProtoBufOptionalTest {
     @Test
     fun readCompareWithDefaults() {
         val data = MessageWithOptionals()
-        assertTrue(readCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(readCompare(data, protoBuf = protoBuf))
     }
 
     @Test
     fun dumpCompareWithDefaults() {
         val data = MessageWithOptionals()
-        assertTrue(dumpCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(dumpCompare(data, protoBuf = protoBuf))
     }
 
     @Test
     fun readCompareWithValues() {
         val data = MessageWithOptionals(42, "Test", MessageWithOptionals.Position.SECOND, 24, listOf(1, 2, 3))
-        assertTrue(readCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(readCompare(data, protoBuf = protoBuf))
     }
 
     @Test
     fun dumpCompareWithValues() {
         val data = MessageWithOptionals(42, "Test", MessageWithOptionals.Position.SECOND, 24, listOf(1, 2, 3))
-        assertTrue(dumpCompare(data, alwaysPrint = true, protoBuf = protoBuf))
+        assertTrue(dumpCompare(data, protoBuf = protoBuf))
     }
 
     @Test


### PR DESCRIPTION
Some protobuf tests are adding additional noise to build logs and there are no reasons to print all the info unconditionally, so let's make then silent.