### PR TITLE
Suppress LV 2.0 deprecation

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -175,7 +175,7 @@ object Java9Modularity {
 
             val taskKotlinLanguageVersion = compilerOptions.languageVersion.orElse(KotlinVersion.DEFAULT)
             @OptIn(InternalKotlinGradlePluginApi::class)
-            @Suppress("DEPRECATION")
+            @Suppress("DEPRECATION", "DEPRECATION_ERROR")
             if (taskKotlinLanguageVersion.get() < KotlinVersion.KOTLIN_2_0) {
                 // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
                 @Suppress("INVISIBLE_MEMBER")

--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -17,13 +17,9 @@ import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.targets.jvm.*
-import org.jetbrains.kotlin.gradle.tasks.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-import org.jetbrains.kotlin.tooling.core.*
 import java.io.*
-import kotlin.reflect.*
-import kotlin.reflect.full.*
 
 object Java9Modularity {
     private val KotlinProjectExtension.targets: Iterable<KotlinTarget>
@@ -162,30 +158,11 @@ object Java9Modularity {
                 }
             ).withPropertyName("moduleInfosOfLibraries")
             this as KotlinCompile
-            val kotlinPluginVersion = KotlinToolingVersion(kotlinApiPlugin.pluginVersion)
-            if (kotlinPluginVersion <= KotlinToolingVersion("1.9.255")) {
-                // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
-                @Suppress("UNCHECKED_CAST")
-                val ownModuleNameProp = (this::class.superclasses.first() as KClass<AbstractKotlinCompile<*>>)
-                    .declaredMemberProperties
-                    .find { it.name == "ownModuleName" }
-                    ?.get(this) as? Property<String>
-                ownModuleNameProp?.set(compileTask.flatMap { it.compilerOptions.moduleName})
-            }
 
-            val taskKotlinLanguageVersion = compilerOptions.languageVersion.orElse(KotlinVersion.DEFAULT)
             @OptIn(InternalKotlinGradlePluginApi::class)
-            @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-            if (taskKotlinLanguageVersion.get() < KotlinVersion.KOTLIN_2_0) {
-                // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
-                @Suppress("INVISIBLE_MEMBER")
-                commonSourceSet.from(compileTask.map {
-                    @Suppress("INVISIBLE_MEMBER")
-                    it.commonSourceSet
-                })
-            } else {
-                multiplatformStructure.refinesEdges.set(compileTask.flatMap { it.multiplatformStructure.refinesEdges })
-                multiplatformStructure.fragments.set(compileTask.flatMap { it.multiplatformStructure.fragments })
+            multiplatformStructure.apply {
+                refinesEdges.set(compileTask.flatMap { it.multiplatformStructure.refinesEdges })
+                fragments.set(compileTask.flatMap { it.multiplatformStructure.fragments })
             }
             // part of work-around for https://youtrack.jetbrains.com/issue/KT-60541
             // and work-around for https://youtrack.jetbrains.com/issue/KT-60582


### PR DESCRIPTION
Suppress LV 2.0's deprecation with error.

Required for https://github.com/JetBrains/kotlin/pull/7411