### PR TITLE
Use lowercase level for partial-linkage-loglevel option

### DIFF
--- a/buildSrc/src/main/kotlin/cli-compiler-options.gradle.kts
+++ b/buildSrc/src/main/kotlin/cli-compiler-options.gradle.kts
@@ -43,10 +43,10 @@ tasks.withType(KotlinCompilationTask::class).configureEach {
 }
 
 tasks.withType<Kotlin2JsCompile>().configureEach {
-    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=error") }
 }
 tasks.withType<KotlinNativeCompile>().configureEach {
-    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=error") }
 }
 
 tasks.withType<KotlinCompilationTask<*>>().configureEach {


### PR DESCRIPTION
Using "ERROR" insead of "error" will become an error on its own soon (see KT-86059).