### PR TITLE
Workaround watchosArm32 target removal

### DIFF
--- a/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.*
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 
 /*
@@ -7,6 +8,12 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.*
 
 plugins {
     kotlin("multiplatform")
+}
+
+// Temporary workaround for the removed watchosArm32 target
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun KotlinMultiplatformExtension.watchosArm32() {
+    // Do nothing
 }
 
 kotlin {


### PR DESCRIPTION
Added a stub function to invoke instead of the removed `watchosArm32()`.