### PR TITLE
Avoid specifying -Xjdk-release twice

### DIFF
--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -143,8 +143,14 @@ object Java9Modularity {
             multiPlatformEnabled.set(compileTask.get().multiPlatformEnabled)
             compilerOptions {
                 jvmTarget.set(JvmTarget.JVM_9)
-                freeCompilerArgs.addAll(
-                    listOf("-Xjdk-release=9",  "-Xsuppress-version-warnings", "-Xexpect-actual-classes")
+                freeCompilerArgs.set(
+                    compileTask.flatMap { it.compilerOptions.freeCompilerArgs }.map { args ->
+                        args.filterNot { it.startsWith("-Xjdk-release=") } + listOf(
+                            "-Xjdk-release=9",
+                            "-Xsuppress-version-warnings",
+                            "-Xexpect-actual-classes"
+                        )
+                    }
                 )
             }
             // work-around for https://youtrack.jetbrains.com/issue/KT-60583


### PR DESCRIPTION
With recent changes on KGP side (KT-88381) it results in a warning, which fails our builds.