### PR TITLE
Use the hand-rolled function for checking if a character needs escapi…

### DIFF
--- a/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/RoundtripStringEncodingBenchmark.kt
+++ b/benchmark/src/jmh/kotlin/kotlinx/benchmarks/json/RoundtripStringEncodingBenchmark.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.benchmarks.json
+
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+import kotlin.io.encoding.Base64
+import kotlin.random.Random
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class RoundtripStringEncodingBenchmark {
+    private val serializer = String.serializer()
+    private val value = Base64.encode(
+        ByteArray(8 * 1024).also { Random(239).nextBytes(it) }
+    )
+
+    @Benchmark
+    fun roundTrip(): String {
+        val encoded = Json.encodeToString(serializer, value)
+        return Json.decodeFromString(serializer, encoded)
+    }
+}

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StringOps.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StringOps.kt
@@ -30,7 +30,11 @@ public val ESCAPE_STRINGS: Array<String?> = arrayOfNulls<String>(93).apply {
     this[0x0c] = "\\f"
 }
 
-internal val ESCAPE_MARKERS: ByteArray = ByteArray(93).apply {
+internal fun isCodePointRequiringEscapeSequence(charCode: Int): Boolean =
+    charCode <= 0x1f || charCode == 0x22 || charCode == 0x5c
+
+// Note: it is 128 so Hotspot successfully eliminates all range checks
+internal val ESCAPE_MARKERS: ByteArray = ByteArray(128).apply {
     for (c in 0..0x1f) {
         this[c] = 1.toByte()
     }

--- a/formats/json/commonTest/src/kotlinx/serialization/json/internal/EscapeMarkersTest.kt
+++ b/formats/json/commonTest/src/kotlinx/serialization/json/internal/EscapeMarkersTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.serialization.json.internal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EscapeMarkersTest {
+    @Test
+    fun isCodePointRequiringEscapeSequenceTest() {
+        for (charCode in ESCAPE_MARKERS.indices) {
+            if (ESCAPE_MARKERS[charCode] == 0.toByte()) {
+                assertFalse(isCodePointRequiringEscapeSequence(charCode), "Unexpected escape marker for $charCode")
+            } else {
+                assertTrue(isCodePointRequiringEscapeSequence(charCode), "No escape marker for $charCode")
+            }
+        }
+    }
+}

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/JvmJsonStreams.kt
@@ -34,7 +34,7 @@ internal class OutputStreamJsonWriter(private val stream: OutputStream) : Intern
         for (i in 1 until 1 + length) {
             val ch = arr[i].code
             // Do we have unescaped symbols?
-            if (ch < ESCAPE_MARKERS.size && ESCAPE_MARKERS[ch] != 0.toByte()) {
+            if (isCodePointRequiringEscapeSequence(ch)) {
                 // Go to slow path
                 return appendStringSlowPath(i, text)
             }

--- a/formats/json/jvmMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
+++ b/formats/json/jvmMain/src/kotlinx/serialization/json/internal/StringJsonWriter.kt
@@ -57,7 +57,7 @@ internal actual class StringJsonWriter : InternalJsonWriter {
         for (i in sz until sz + length) {
             val ch = arr[i].code
             // Do we have unescaped symbols?
-            if (ch < ESCAPE_MARKERS.size && ESCAPE_MARKERS[ch] != 0.toByte()) {
+            if (isCodePointRequiringEscapeSequence(ch)) {
                 // Go to slow path
                 return appendStringSlowPath(i - sz, i, text)
             }


### PR DESCRIPTION
…ng when writing quoted strings

Rationale:

For large enough strings (notably: https://github.com/ej-technologies/serialization-comparison), copying and iterating over a string is fast enough, but range checks to see if we hit a slow path to escape Unicode symbols dominate the execution time.

Replacing it with a hand-rolled check produces up to 30%+ better throughput (e.g. on the benchmark from the linked repo).


**UPD**:
https://github.com/ej-technologies/serialization-comparison/pull/1 is merged.

Before this change:
```
Benchmark                             Mode  Cnt   Score   Error  Units
JsonRoundTripBenchmark.jacksonJava    avgt    5  21.126 ± 1.944  us/op
JsonRoundTripBenchmark.jacksonKotlin  avgt    5  24.521 ± 0.143  us/op
JsonRoundTripBenchmark.kotlinxStream  avgt    5  33.423 ± 0.376  us/op
JsonRoundTripBenchmark.kotlinxString  avgt    5  33.453 ± 1.762  us/op
JsonRoundTripBenchmark.moshiJava      avgt    5  32.571 ± 0.328  us/op
JsonRoundTripBenchmark.moshiKotlin    avgt    5  29.875 ± 0.156  us/op
```


After:
```
Benchmark                             Mode  Cnt   Score   Error  Units
JsonRoundTripBenchmark.jacksonJava    avgt    5  20.888 ± 0.301  us/op
JsonRoundTripBenchmark.jacksonKotlin  avgt    5  24.647 ± 0.196  us/op
JsonRoundTripBenchmark.kotlinxStream  avgt    5  24.156 ± 0.831  us/op
JsonRoundTripBenchmark.kotlinxString  avgt    5  25.656 ± 0.150  us/op
JsonRoundTripBenchmark.moshiJava      avgt    5  32.848 ± 0.180  us/op
JsonRoundTripBenchmark.moshiKotlin    avgt    5  30.142 ± 0.247  us/op
```