### PR TITLE
Temporarily set `-Xallow-pre-17-runtime-jdk`

### DIFF
--- a/buildSrc/src/main/kotlin/CompilerOptions.kt
+++ b/buildSrc/src/main/kotlin/CompilerOptions.kt
@@ -22,7 +22,7 @@ fun KotlinCommonCompilerOptions.defaultOptions() {
 
 fun KotlinJvmCompilerOptions.setJava8Compatible() {
     jvmTarget = JvmTarget.JVM_1_8
-    freeCompilerArgs.addAll("-Xjdk-release=1.8")
+    freeCompilerArgs.addAll("-Xjdk-release=1.8", "-Xallow-pre-17-runtime-jdk")
 }
 
 fun KotlinCommonCompilerOptions.languageVersion(overriddenLanguageVersion: String?) {

--- a/buildSrc/src/main/kotlin/Java9Modularity.kt
+++ b/buildSrc/src/main/kotlin/Java9Modularity.kt
@@ -143,8 +143,14 @@ object Java9Modularity {
             multiPlatformEnabled.set(compileTask.get().multiPlatformEnabled)
             compilerOptions {
                 jvmTarget.set(JvmTarget.JVM_9)
-                freeCompilerArgs.addAll(
-                    listOf("-Xjdk-release=9",  "-Xsuppress-version-warnings", "-Xexpect-actual-classes")
+                freeCompilerArgs.set(
+                    compileTask.flatMap { it.compilerOptions.freeCompilerArgs }.map { args ->
+                        args.filterNot { it.startsWith("-Xjdk-release=") } + listOf(
+                            "-Xjdk-release=9",
+                            "-Xsuppress-version-warnings",
+                            "-Xexpect-actual-classes"
+                        )
+                    }
                 )
             }
             // work-around for https://youtrack.jetbrains.com/issue/KT-60583

--- a/buildSrc/src/main/kotlin/cli-compiler-options.gradle.kts
+++ b/buildSrc/src/main/kotlin/cli-compiler-options.gradle.kts
@@ -43,10 +43,10 @@ tasks.withType(KotlinCompilationTask::class).configureEach {
 }
 
 tasks.withType<Kotlin2JsCompile>().configureEach {
-    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=error") }
 }
 tasks.withType<KotlinNativeCompile>().configureEach {
-    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=error") }
 }
 
 tasks.withType<KotlinCompilationTask<*>>().configureEach {


### PR DESCRIPTION
Main PR to Kotlin: https://github.com/JetBrains/kotlin/pull/7833
Alternative PR: https://github.com/Kotlin/kotlinx.serialization/pull/3252

^[KT-88174](https://youtrack.jetbrains.com/issue/KT-88174)

