### PR TITLE
TreeJsonDecoder rewrite: make it tagless, JsonPath-friendly and faster

### DIFF
--- a/formats/json-tests/commonTest/src/kotlinx/serialization/DeserializerExceptionsTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/DeserializerExceptionsTest.kt
@@ -55,7 +55,7 @@ class DeserializerExceptionsTest: JsonTestBase() {
     @Test
     fun testConstructorExceptionIsCause() = parametrizedTest { mode ->
         val string = """{"r":256,"g":256,"b":256}"""
-        checkDecodingException(mode, { Json.decodeFromString<Rgb>(string) }) {
+        checkDecodingException(mode, { Json.decodeFromString<Rgb>(string, mode) }) {
             message("Deserialization failed because of 'r is out of range: 256' exception in the decoder")
             path("$")
             input(string)
@@ -66,7 +66,7 @@ class DeserializerExceptionsTest: JsonTestBase() {
     @Test
     fun testDecodingExceptionSwallowed() = parametrizedTest { mode ->
         val string = """{"i":1}"""
-        checkDecodingException(mode, { Json.decodeFromString<Box>(string) }) {
+        checkDecodingException(mode, { Json.decodeFromString<Box>(string, mode) }) {
             message("Deserialization failed because of an exception in the decoder")
             path("$")
             input(string)

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/JsonPathTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/JsonPathTest.kt
@@ -4,6 +4,8 @@
 
 package kotlinx.serialization
 
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlin.test.*
 
@@ -19,74 +21,73 @@ class JsonPathTest : JsonTestBase() {
     class Box(val s: String)
 
     @Test
-    fun testBasicError() {
-        expectPath("$.a") { Json.decodeFromString<Outer>("""{"a":foo}""") }
-        expectPath("$.i") { Json.decodeFromString<Outer>("""{"a":42, "i":[]}""") }
-        expectPath("$.i.b") { Json.decodeFromString<Outer>("""{"a":42, "i":{"a":43, "b":42}""") }
-        expectPath("$.i.b") { Json.decodeFromString<Outer>("""{"a":42, "i":{"b":42}""") }
+    fun testBasicError() = parametrizedTest { mode ->
+        expectPath("$.a") { Json.decodeFromString<Outer>("""{"a":foo}""", mode) }
+        expectPath("$.i") { Json.decodeFromString<Outer>("""{"a":42, "i":[]}""", mode) }
+        expectPath("$.i.b") { Json.decodeFromString<Outer>("""{"a":42, "i":{"a":43, "b":42}}""", mode) }
+        expectPath("$.i.b") { Json.decodeFromString<Outer>("""{"a":42, "i":{"b":42}}""", mode) }
     }
 
     @Test
-    fun testMissingKey() {
-        expectPath("$.i.d['1']") { Json.decodeFromString<Outer>("""{"a":42, "i":{"d":{1:{}}""") }
+    fun testMissingKey() = parametrizedTest { mode ->
+        expectPath("$.i.d['1']") { Json.decodeFromString<Outer>("""{"a":42, "i":{"d":{"1":{}}}}""", mode) }
     }
 
     @Test
-    fun testUnknownKeyIsProperlyReported() {
-        expectPath("$.i") { Json.decodeFromString<Outer>("""{"a":42, "i":{"foo":42}""") }
-        expectPath("$") { Json.decodeFromString<Outer>("""{"x":{}, "a": 42}""") }
+    fun testUnknownKeyIsProperlyReported() = parametrizedTest { mode ->
+        expectPath("$.i") { Json.decodeFromString<Outer>("""{"a":42, "i":{"foo":42}}""", mode) }
+        expectPath("$") { Json.decodeFromString<Outer>("""{"x":{}, "a": 42}""", mode) }
         expectPath("$") { Json.decodeFromString<Outer>("""{"a":42, "x":{}}""") }
     }
 
     @Test
-    fun testMalformedRootObject() {
-        expectPath("$") { Json.decodeFromString<Outer>("""{{""") }
+    fun testMalformedRootObject() = parametrizedTest { mode ->
+        expectPath("$") { Json.decodeFromString<Outer>("""{{""", mode) }
     }
 
     @Test
-    fun testArrayIndex() {
-        expectPath("$.i.c[1]") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "c": ["a", 2]}""") }
-        expectPath("$[2]") { Json.decodeFromString<List<String>>("""["a", "2", 3]""") }
+    fun testArrayIndex() = parametrizedTest { mode ->
+        expectPath("$.i.c[1]") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "c": ["a", 2]}}""", mode) }
+        expectPath("$[2]") { Json.decodeFromString<List<String>>("""["a", "2", 3]""", mode) }
     }
 
     @Test
-    fun testArrayIndexMalformedArray() {
-        // Also zeroes as we cannot distinguish what exactly wen wrong is such cases
-        expectPath("$.i.c[0]") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "c": [[""") }
-        expectPath("$[0]") { Json.decodeFromString<List<String>>("""[[""") }
+    fun testArrayIndexMalformedArray() = parametrizedTest { mode ->
+        expectPath("$.i.c[0]") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "c": [[]]}}""", mode) }
+        expectPath("$[0]") { Json.decodeFromString<List<String>>("""[[]]""", mode) }
         // But we can here
-        expectPath("$.i.c\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "c": {}}}""") }
-        expectPath("$\n") { Json.decodeFromString<List<String>>("""{""") }
+        expectPath("$.i.c\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "c": {}}}""", mode) }
+        expectPath("$\n") { Json.decodeFromString<List<String>>("""{""", mode) }
     }
 
     @Test
-    fun testMapKey() {
-        expectPath("$.i.d\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {"foo": {}}""") }
-        expectPath("$.i.d\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {42: {"s":"s"}, 42.0:{}}""") }
-        expectPath("$\n") { Json.decodeFromString<Map<Int, String>>("""{"foo":"bar"}""") }
-        expectPath("$\n") { Json.decodeFromString<Map<Int, String>>("""{42:"bar", "foo":"bar"}""") }
-        expectPath("$['42']['foo']") { Json.decodeFromString<Map<Int, Map<String, Int>>>("""{42: {"foo":"bar"}""") }
+    fun testMapKey() = parametrizedTest { mode ->
+        expectPath("$.i.d\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {"foo": {}}}}""", mode) }
+        expectPath("$.i.d\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {"42": {"s":"s"}, "42.0":{}}}}""", mode) }
+        expectPath("$\n") { Json.decodeFromString<Map<Int, String>>("""{"foo":"bar"}""", mode) }
+        expectPath("$\n") { Json.decodeFromString<Map<Int, String>>("""{"42":"bar", "foo":"bar"}""", mode) }
+        expectPath("$['42']['foo']") { Json.decodeFromString<Map<Int, Map<String, Int>>>("""{"42": {"foo":"bar"}}""", mode) }
     }
 
     @Test
-    fun testMalformedMap() {
-        expectPath("$.i.d\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": []""") }
-        expectPath("$\n") { Json.decodeFromString<Map<Int, String>>("""[]""") }
+    fun testMalformedMap() = parametrizedTest { mode ->
+        expectPath("$.i.d\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": []}}""", mode) }
+        expectPath("$\n") { Json.decodeFromString<Map<Int, String>>("""[]""", mode) }
     }
 
     @Test
-    fun testMapValue() {
-        expectPath("$.i.d['42']\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {42: {"xx":"bar"}}""") }
-        expectPath("$.i.d['43']\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {42: {"s":"s"}, 43: {"xx":"bar"}}}""") }
-        expectPath("$['239']") { Json.decodeFromString<Map<Int, String>>("""{239:bar}""") }
+    fun testMapValue() = parametrizedTest { mode ->
+        expectPath("$.i.d['42']\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {"42": {"xx":"bar"}}}}""", mode) }
+        expectPath("$.i.d['43']\n") { Json.decodeFromString<Outer>("""{"a":42, "i":{ "d": {"42": {"s":"s"}, "43": {"xx":"bar"}}}}""", mode) }
+        expectPath("$['239']") { Json.decodeFromString<Map<Int, String>>("""{"239":bar}""", mode) }
     }
 
     @Serializable
     class Fp(val d: Double)
 
     @Test
-    fun testInvalidFp() {
-        expectPath("$.d") { Json.decodeFromString<Fp>("""{"d": NaN}""") }
+    fun testInvalidFp() = parametrizedTest { mode ->
+        expectPath("$.d") { Json.decodeFromString<Fp>("""{"d": NaN}""", mode) }
     }
 
     @Serializable
@@ -94,8 +95,8 @@ class JsonPathTest : JsonTestBase() {
     enum class E
 
     @Test
-    fun testUnknownEnum() {
-        expectPath("$.e") { Json.decodeFromString<EH>("""{"e": "foo"}""") }
+    fun testUnknownEnum() = parametrizedTest { mode ->
+        expectPath("$.e") { Json.decodeFromString<EH>("""{"e": "foo"}""", mode) }
     }
 
     @Serializable
@@ -117,41 +118,45 @@ class JsonPathTest : JsonTestBase() {
 
     @Test
     fun testHugeNestingToCheckResize() {
-        val json = Json { useArrayPolymorphism = true }
-        var outer = Sealed.Nesting(Sealed.Box("value"))
-        repeat(100) {
-            outer = Sealed.Nesting(outer)
-        }
-        val str = json.encodeToString(Sealed.serializer(), outer)
-        // check that data is correctly formed
-        assertEquals(outer, json.decodeFromString(Sealed.serializer(), str))
+        parametrizedTest { mode ->
+            val json = Json { useArrayPolymorphism = true }
+            var outer = Sealed.Nesting(Sealed.Box("value"))
+            repeat(100) {
+                outer = Sealed.Nesting(outer)
+            }
+            val str = json.encodeToString(Sealed.serializer(), outer)
+            // check that data is correctly formed
+            assertEquals(outer, json.decodeFromString(Sealed.serializer(), str, mode))
 
-        val malformed = str.replace("\"value\"", "42")
-        val expectedPath = "$" + ".value.f".repeat(101) + ".value.s"
-        expectPath(expectedPath) { json.decodeFromString(Sealed.serializer(), malformed) }
+            val malformed = str.replace("\"value\"", "42")
+            val expectedPath = "$" + ".value.f".repeat(101) + ".value.s"
+            expectPath(expectedPath) { json.decodeFromString(Sealed.serializer(), malformed, mode) }
+        }
     }
 
     @Test
     fun testDoubleNestingNoArrayPoly() {
-        val json = Json { useArrayPolymorphism = false }
-        var outer1 = Sealed.Nesting(Sealed.Box("correct"))
-        repeat(64) {
-            outer1 = Sealed.Nesting(outer1)
+        parametrizedTest { mode ->
+            val json = Json { useArrayPolymorphism = false }
+            var outer1 = Sealed.Nesting(Sealed.Box("correct"))
+            repeat(64) {
+                outer1 = Sealed.Nesting(outer1)
+            }
+
+            var outer2 = Sealed.Nesting(Sealed.Box("incorrect"))
+            repeat(33) {
+                outer2 = Sealed.Nesting(outer2)
+            }
+
+            val value = Sealed.DoubleNesting(outer1, outer2)
+            val str = json.encodeToString(Sealed.serializer(), value)
+            // check that data is correctly formed
+            assertEquals(value, json.decodeFromString(Sealed.serializer(), str, mode))
+
+            val malformed = str.replace("\"incorrect\"", "42")
+            val expectedPath = "$.f2" + ".f".repeat(34) + ".s"
+            expectPath(expectedPath) { json.decodeFromString(Sealed.serializer(), malformed, mode) }
         }
-
-        var outer2 = Sealed.Nesting(Sealed.Box("incorrect"))
-        repeat(33) {
-            outer2 = Sealed.Nesting(outer2)
-        }
-
-        val value = Sealed.DoubleNesting(outer1, outer2)
-        val str = json.encodeToString(Sealed.serializer(), value)
-        // check that data is correctly formed
-        assertEquals(value, json.decodeFromString(Sealed.serializer(), str))
-
-        val malformed = str.replace("\"incorrect\"", "42")
-        val expectedPath = "$.f2" + ".f".repeat(34) + ".s"
-        expectPath(expectedPath) { json.decodeFromString(Sealed.serializer(), malformed) }
     }
 
     @Serializable
@@ -161,18 +166,18 @@ class JsonPathTest : JsonTestBase() {
     data object DataObject
 
     @Test
-    fun testMalformedDataObjectInDeeplyNestedStructure() {
+    fun testMalformedDataObjectInDeeplyNestedStructure() = parametrizedTest { mode ->
         var outer = SimpleNested(t = DataObject)
         repeat(20) {
             outer = SimpleNested(n = outer)
         }
         val str = Json.encodeToString(SimpleNested.serializer(), outer)
         // check that data is correctly formed
-        assertEquals(outer, Json.decodeFromString(SimpleNested.serializer(), str))
+        assertEquals(outer, Json.decodeFromString(SimpleNested.serializer(), str, mode))
 
         val malformed = str.replace("{}", "42")
         val expectedPath = "$" + ".n".repeat(20) + ".t\n"
-        expectPath(expectedPath) { Json.decodeFromString(SimpleNested.serializer(), malformed) }
+        expectPath(expectedPath) { Json.decodeFromString(SimpleNested.serializer(), malformed, mode) }
     }
 
     private inline fun expectPath(path: String, block: () -> Any?) {

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/LongAsStringTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/LongAsStringTest.kt
@@ -36,7 +36,7 @@ class LongAsStringTest : JsonTestBase() {
                 // NumberFormatException messages vary by platform
                 assertContains(exception.message, "exception in the decoder")
                 assertContains(exception.message, exception.shortMessage)
-                if (jsonTestingMode == JsonTestingMode.TREE) path("$") else path("$.l")
+                path("$.l")
                 input(str)
                 cause<NumberFormatException>()
             })
@@ -49,7 +49,7 @@ class LongAsStringTest : JsonTestBase() {
                 // NumberFormatException messages vary by platform
                 assertContains(exception.message, "exception in the decoder")
                 assertContains(exception.message, exception.shortMessage)
-                if (jsonTestingMode == JsonTestingMode.TREE) path("$") else path("$.l")
+                path("$.l")
                 input(str2)
                 cause<NumberFormatException>()
             })

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/features/PolymorphicErrorMessagesTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/features/PolymorphicErrorMessagesTest.kt
@@ -24,7 +24,7 @@ class PolymorphicErrorMessagesTest : JsonTestBase() {
             default.decodeFromString<Holder>(input, mode)
         }) {
             message("Serializer for subclass 'my.Class' is not found in the polymorphic scope of 'Any'")
-            if (mode != JsonTestingMode.TREE) path("$.d.a") else path("$.a") // #3170
+            path("$.d.a")
             hint("Check if class with serial name 'my.Class' exists and serializer is registered in a corresponding SerializersModule.")
             // ReaderJsonLexer.peekLeadingMatchingValue is not implemented (#2626), so first-key optimization is not working for non-streaming yet.
             if (mode == JsonTestingMode.STREAMING) {
@@ -44,7 +44,7 @@ class PolymorphicErrorMessagesTest : JsonTestBase() {
         }) {
             // Always slow path when discriminator is missing, so no position
             message("Class discriminator was missing and no default serializers were registered in the polymorphic scope of 'Any'")
-            if (mode != JsonTestingMode.TREE) path("$.d.a") else path("$.a") // #3170
+            path("$.d.a")
             input("{\"value\":42}")
         }
     }
@@ -57,7 +57,7 @@ class PolymorphicErrorMessagesTest : JsonTestBase() {
         }) {
             // Always slow path when discriminator is missing, so no position
             message("Class discriminator was missing and no default serializers were registered in the polymorphic scope of 'Any'")
-            if (mode != JsonTestingMode.TREE) path("$.d.a") else path("$.a") // #3170
+            path("$.d.a")
             input("{\"type\":null,\"value\":42}")
         }
     }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonDecodingRedactedErrorMessagesTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonDecodingRedactedErrorMessagesTest.kt
@@ -40,7 +40,7 @@ class JsonDecodingRedactedErrorMessagesTest : JsonTestBase() {
                 "Failed to parse literal '\"y\"' as an int value",
             )
             offset(17)
-            if (mode != JsonTestingMode.TREE) path("$.boxed[<debug info disabled>]") else path("$.x") // #3170
+            path("$.boxed[<debug info disabled>]")
             noInput()
         })
     }

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonTransformingSerializerTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/JsonTransformingSerializerTest.kt
@@ -100,6 +100,14 @@ class JsonTransformingSerializerTest : JsonTestBase() {
         assertEquals(correctExample, json.decodeFromString(DocExample.serializer(), """{"data":"str1"}""", streaming))
     }
 
+    @Test
+    fun testTransformingSerializerPreservesPath() = parametrizedTest { mode ->
+        val exception = assertFailsWith<SerializationException> {
+            json.decodeFromString<Example>("""{"name":"test","data":{"data":42}}""", mode)
+        }
+        assertContains(exception.message!!, "at path: $.data.data")
+    }
+
     // Wraps/unwraps {"data":null} to just `null`, because StringData.data is not nullable
     object NullableStringDataSerializer : JsonTransformingSerializer<StringData?>(StringData.serializer().nullable) {
         override fun transformDeserialize(element: JsonElement): JsonElement {

--- a/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonContentPolymorphicSerializerTest.kt
+++ b/formats/json-tests/commonTest/src/kotlinx/serialization/json/polymorphic/JsonContentPolymorphicSerializerTest.kt
@@ -62,6 +62,14 @@ class JsonContentPolymorphicSerializerTest : JsonTestBase() {
     }
 
     @Test
+    fun testPathIsPreservedAfterSelectingDeserializer() = parametrizedTest { mode ->
+        val exception = assertFailsWith<SerializationException> {
+            json.decodeFromString<WithChoices>("""{"response":{"b":"not an int"}}""", mode)
+        }
+        assertContains(exception.message!!, "at path: $.response.b")
+    }
+
+    @Test
     fun testSerializesParametrically() = parametrizedTest { streaming ->
         for (i in testDataOutput.indices) {
             assertEquals(

--- a/formats/json/commonMain/src/kotlinx/serialization/json/JsonContentPolymorphicSerializer.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/JsonContentPolymorphicSerializer.kt
@@ -7,6 +7,7 @@ package kotlinx.serialization.json
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.internal.*
 import kotlinx.serialization.modules.*
 import kotlin.reflect.*
 
@@ -91,7 +92,8 @@ public abstract class JsonContentPolymorphicSerializer<T : Any>(private val base
 
         @Suppress("UNCHECKED_CAST")
         val actualSerializer = selectDeserializer(tree) as KSerializer<T>
-        return input.json.decodeFromJsonElement(actualSerializer, tree)
+        // Note: use internal readJson so we can pass `input` further and link json path
+        return readJson(input.json, tree, actualSerializer, input)
     }
 
     /**

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonExceptions.kt
@@ -27,7 +27,7 @@ internal fun decodingExceptionOf(shortMessage: String, hint: String? = null): Js
 
 @OptIn(ExperimentalSerializationApi::class)
 internal inline fun <T> JsonDecoder.withExceptionHandling(
-    path: () -> String,
+    path: JsonPath,
     input: () -> CharSequence,
     block: () -> T
 ): T {
@@ -37,11 +37,11 @@ internal inline fun <T> JsonDecoder.withExceptionHandling(
         // Add "at path" if and only if we've just caught an exception and it hasn't been augmented yet
         if (e.message!!.contains("at path")) throw e
         // NB: we could've use some additional flag marker or augment the stacktrace, but it seemed to be as too much of a burden
-        throw missingFieldExceptionWithNewMessage(e, e.message + " at path: " + path())
+        throw missingFieldExceptionWithNewMessage(e, e.message + " at path: " + path.getPath())
     } catch (e: SerializationException) {
         throw e
     } catch (e: Exception) {
-        throw errorFromDeserializer(e, path(), input)
+        throw errorFromDeserializer(e, path.getPath(), input)
     }
 }
 
@@ -186,7 +186,7 @@ internal fun InvalidFloatingPointEncoded(value: Number, key: String? = null) =
 internal inline fun JsonDecoder.InvalidFloatingPointDecoded(value: Number, key: String, input: () -> CharSequence) =
     decodingExceptionOf(nonFiniteFpMessage(value, key), hint = specialFlowingValuesHint, input = input)
 
-private fun nonFiniteFpMessage(value: Number, key: String?): String =
+internal fun nonFiniteFpMessage(value: Number, key: String?): String =
     "Unexpected special floating-point value $value" + (if (key != null) " with key $key. " else ". ") + "By default, " +
         "non-finite floating point values are prohibited because they do not conform JSON specification."
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonNamesMap.kt
@@ -112,11 +112,12 @@ internal fun SerialDescriptor.getJsonNameIndex(json: Json, name: String): Int {
 /**
  * Throws on [CompositeDecoder.UNKNOWN_NAME]
  */
-@OptIn(ExperimentalSerializationApi::class)
-internal fun SerialDescriptor.getJsonNameIndexOrThrow(json: Json, name: String, suffix: String = ""): Int {
+internal fun SerialDescriptor.getJsonNameIndexOrThrow(json: Json, name: String, jsonPath: JsonPath?): Int {
     val index = getJsonNameIndex(json, name)
-    if (index == CompositeDecoder.UNKNOWN_NAME)
-        throw SerializationException("$serialName does not contain element with name '$name'$suffix")
+    if (index == CompositeDecoder.UNKNOWN_NAME) {
+        val path = if (jsonPath == null) "" else " at path ${jsonPath.getPath()}"
+        throw SerializationException("$serialName does not contain element with name '$name'${path}")
+    }
     return index
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonPath.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonPath.kt
@@ -104,7 +104,6 @@ internal class JsonPath(configuration: JsonConfiguration) {
         }
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
     fun getPath(): String {
         return buildString {
             append("$")
@@ -141,10 +140,6 @@ internal class JsonPath(configuration: JsonConfiguration) {
         }
     }
 
-
-    @OptIn(ExperimentalSerializationApi::class)
-    private fun prettyString(it: Any?) = (it as? SerialDescriptor)?.serialName ?: it.toString()
-
     private fun resize() {
         val newSize = currentDepth * 2
         currentObjectPath = currentObjectPath.copyOf(newSize)
@@ -154,4 +149,13 @@ internal class JsonPath(configuration: JsonConfiguration) {
     }
 
     override fun toString(): String = getPath()
+}
+
+// Updates JsonPath if we are currently decoding map key and not a regular object
+// (because map keys are not indices in the descriptor, but actual strings/objects)
+internal inline fun <T> withMapKeyTracking(path: JsonPath, isMapKey: Boolean, block: () -> T): T {
+    if (isMapKey) path.resetCurrentMapKey()
+    val result = block()
+    if (isMapKey) path.updateCurrentMapKey(result)
+    return result
 }

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonPolymorphicHelpers.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/JsonPolymorphicHelpers.kt
@@ -80,17 +80,26 @@ internal fun checkKind(kind: SerialKind) {
     if (kind is PolymorphicKind) error("Actual serializer for polymorphic cannot be polymorphic itself")
 }
 
-internal inline fun <T> JsonDecoder.decodeSerializableValuePolymorphic(
+
+internal fun <T> PolymorphicJsonDecoder.decodeSerializableValuePolymorphic(deserializer: DeserializationStrategy<T>): T =
+    decodeSerializableValuePolymorphic(deserializer, path, null)
+
+internal fun <T> JsonDecoder.decodeSerializableValuePolymorphic(
     deserializer: DeserializationStrategy<T>,
-    path: () -> String
+    path: JsonPath,
+    // Kludge for 'decodeDynamic' that does not track JsonPath
+    alternativePath: (() -> String)?
 ): T {
+
+    fun renderPath(): String = (alternativePath ?: path::getPath).invoke()
+
     // NB: changes in this method should be reflected in StreamingJsonDecoder#decodeSerializableValue
     if (deserializer !is AbstractPolymorphicSerializer<*> || json.configuration.useArrayPolymorphism) {
         return deserializer.deserialize(this)
     }
     val discriminator = deserializer.descriptor.classDiscriminator(json)
 
-    val jsonTree = cast<JsonObject>(decodeJsonElement(), deserializer.descriptor.serialName, path)
+    val jsonTree = cast<JsonObject>(decodeJsonElement(), deserializer.descriptor.serialName, ::renderPath)
     val type =
         jsonTree[discriminator]?.jsonPrimitive?.contentOrNull // differentiate between `"type":"null"` and `"type":null`.
 
@@ -99,9 +108,9 @@ internal inline fun <T> JsonDecoder.decodeSerializableValuePolymorphic(
         deserializer.findPolymorphicSerializerOrNull(this, type) as? DeserializationStrategy<T>
     if (actualSerializer == null) {
         val (message, hint) = subtypeNotRegisteredMessageJson(type, deserializer.baseClass)
-        throw decodingExceptionOf(message, path(), hint) { jsonTree.toString() }
+        throw decodingExceptionOf(message, renderPath(), hint) { jsonTree.toString() }
     }
-    return json.readPolymorphicJson(discriminator, jsonTree, actualSerializer)
+    return json.readPolymorphicJson(discriminator, jsonTree, actualSerializer, path)
 }
 
 internal fun SerialDescriptor.classDiscriminator(json: Json): String {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphicJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphicJsonDecoder.kt
@@ -4,15 +4,22 @@
 
 package kotlinx.serialization.json.internal
 
-import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.*
+
 
 /**
- * An internal extension of [JsonDecoder] that exposes the polymorphic discriminator.
- * This interface is used during the transformation process to ensure that the
- * class discriminator (e.g., the "type" field) is correctly propagated between
- * decoders, especially when using [JsonTransformingSerializer].
+ * An internal extension of [JsonDecoder] that exposes the state shared between nested decoders:
+ * the polymorphic discriminator and the current [path][JsonPath].
+ * This interface is used when decoding switches to another decoder (e.g. from streaming to tree decoding
+ * in [JsonTransformingSerializer] or for polymorphic values) to ensure that things like the class discriminator
+ * (i.e., the "type" field) is correctly propagated and that errors are reported with the full path.
  */
 internal interface PolymorphicJsonDecoder : JsonDecoder {
+    /**
+     * The path shared by all decoders participating in the current decoding
+     */
+    val path: JsonPath
+
     /**
      * A discriminator of the current [JsonDecoder].
      */

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphicJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/PolymorphicJsonDecoder.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.*
  * the polymorphic discriminator and the current [path][JsonPath].
  * This interface is used when decoding switches to another decoder (e.g. from streaming to tree decoding
  * in [JsonTransformingSerializer] or for polymorphic values) to ensure that things like the class discriminator
- * (i.e., the "type" field) is correctly propagated and that errors are reported with the full path.
+ * (i.e., the "type" field) are correctly propagated and that errors are reported with the full path.
  */
 internal interface PolymorphicJsonDecoder : JsonDecoder {
     /**

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -346,7 +346,7 @@ internal open class StreamingJsonDecoder(
         else super.decodeInline(descriptor)
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
-        return enumDescriptor.getJsonNameIndexOrThrow(json, decodeString(), " at path " + lexer.path.getPath())
+        return enumDescriptor.getJsonNameIndexOrThrow(json, decodeString(), lexer.path)
     }
 }
 

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -53,7 +53,7 @@ internal open class StreamingJsonDecoder(
     override fun decodeJsonElement(): JsonElement = JsonTreeReader(json.configuration, lexer).read()
 
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
-        return withExceptionHandling(path = lexer.path::getPath, input = lexer::source) {
+        return withExceptionHandling(path = lexer.path, input = lexer::source) {
             /*
              * This is an optimized path over decodeSerializableValuePolymorphic(deserializer):
              * dSVP reads the very next JSON tree into a memory as JsonElement and then runs TreeJsonDecoder over it
@@ -155,17 +155,9 @@ internal open class StreamingJsonDecoder(
         previousValue: T?
     ): T {
         val isMapKey = mode == LexerMode.MAP && index and 1 == 0
-        // Reset previous key
-        if (isMapKey) {
-            lexer.path.resetCurrentMapKey()
+        return withMapKeyTracking(lexer.path, isMapKey) {
+            super.decodeSerializableElement(descriptor, index, deserializer, previousValue)
         }
-        // Deserialize the key
-        val value = super.decodeSerializableElement(descriptor, index, deserializer, previousValue)
-        // Put the key to the path
-        if (isMapKey) {
-            lexer.path.updateCurrentMapKey(value)
-        }
-        return value
     }
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt
@@ -41,6 +41,8 @@ internal open class StreamingJsonDecoder(
 
 
     override val serializersModule: SerializersModule = json.serializersModule
+    override val path: JsonPath
+        get() = lexer.path
     override val discriminator: String?
         get() = discriminatorHolder?.discriminatorToSkip
     private var currentIndex = -1
@@ -75,7 +77,7 @@ internal open class StreamingJsonDecoder(
             val discriminator = deserializer.descriptor.classDiscriminator(json)
             val type = lexer.peekLeadingMatchingValue(discriminator, configuration.isLenient)
                 ?: // Fallback to slow path if we haven't found discriminator on first try
-                return decodeSerializableValuePolymorphic<T>(deserializer as DeserializationStrategy<T>) { lexer.path.getPath() }
+                return decodeSerializableValuePolymorphic<T>(deserializer as DeserializationStrategy<T>)
 
             @Suppress("UNCHECKED_CAST")
             val actualSerializer = deserializer.findPolymorphicSerializerOrNull(this, type) as? DeserializationStrategy<T>

--- a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
+++ b/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt
@@ -10,7 +10,6 @@ package kotlinx.serialization.json.internal
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
-import kotlinx.serialization.internal.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 import kotlin.jvm.*
@@ -22,11 +21,13 @@ public fun <T> readJson(
     deserializer: DeserializationStrategy<T>,
     previousDecoder: JsonDecoder? = null
 ): T {
-    val discriminator = (previousDecoder as? PolymorphicJsonDecoder)?.discriminator
+    val parent = previousDecoder as? PolymorphicJsonDecoder
+    val discriminator = parent?.discriminator
+    val path = parent?.path ?: JsonPath(json.configuration)
     val input = when (element) {
-        is JsonObject -> JsonTreeDecoder(json, element, deserializer.descriptor, discriminator)
-        is JsonArray -> JsonTreeListDecoder(json, element)
-        is JsonLiteral, JsonNull -> JsonPrimitiveDecoder(json, element as JsonPrimitive)
+        is JsonObject -> JsonTreeDecoder(json, element, deserializer.descriptor, path, discriminator)
+        is JsonArray -> JsonTreeListDecoder(json, element, path)
+        is JsonLiteral, JsonNull -> JsonPrimitiveDecoder(json, element as JsonPrimitive, path)
     }
     return input.decodeSerializableValue(deserializer)
 }
@@ -35,19 +36,21 @@ internal fun <T> Json.readPolymorphicJson(
     discriminator: String,
     element: JsonObject,
     // Note: this is an actual deserializer, not a polymorphic one
-    deserializer: DeserializationStrategy<T>
+    deserializer: DeserializationStrategy<T>,
+    path: JsonPath
 ): T {
     val descriptor = deserializer.descriptor
     return JsonTreeDecoder(
-        this, element, descriptor, discriminator, descriptor
+        this, element, descriptor, path, discriminator, descriptor
     ).decodeSerializableValue(deserializer)
 }
 
 private sealed class AbstractJsonTreeDecoder(
     override val json: Json,
     open val value: JsonElement,
+    final override val path: JsonPath,
     protected val polymorphicDiscriminator: String? = null
-) : NamedValueDecoder(), PolymorphicJsonDecoder {
+) : AbstractDecoder(), PolymorphicJsonDecoder {
 
     override val serializersModule: SerializersModule
         get() = json.serializersModule
@@ -58,161 +61,146 @@ private sealed class AbstractJsonTreeDecoder(
     @JvmField
     protected val configuration = json.configuration
 
-    protected fun currentObject() = currentTagOrNull?.let { currentElement(it) } ?: value
-
-    fun renderTagStack(currentTag: String) = renderTagStack() + ".$currentTag"
-
-    override fun decodeJsonElement(): JsonElement = currentObject()
+    override fun decodeJsonElement(): JsonElement = currentElement()
 
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
-        return withExceptionHandling(path = ::renderTagStack, input = currentObject()::toString) { decodeSerializableValuePolymorphic(deserializer, ::renderTagStack) }
+        return withExceptionHandling(path = path, input = currentElement()::toString) {
+            decodeSerializableValuePolymorphic(deserializer)
+        }
     }
-
-    final override fun composeName(parentName: String, childName: String): String = childName
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
-        val currentObject = currentObject()
+        val element = currentElement()
+        path.pushDescriptor(descriptor)
         return when (descriptor.kind) {
-            StructureKind.LIST, is PolymorphicKind -> JsonTreeListDecoder(json, cast(currentObject, descriptor))
+            StructureKind.LIST, is PolymorphicKind -> JsonTreeListDecoder(json, cast(element, descriptor), path)
             StructureKind.MAP -> json.selectMapMode(
                 descriptor,
-                { JsonTreeMapDecoder(json, cast(currentObject, descriptor), descriptor) },
-                { JsonTreeListDecoder(json, cast(currentObject, descriptor)) }
+                { JsonTreeMapDecoder(json, cast(element, descriptor), descriptor, path) },
+                { JsonTreeListDecoder(json, cast(element, descriptor), path) }
             )
-            else -> JsonTreeDecoder(json, cast(currentObject, descriptor), descriptor, polymorphicDiscriminator)
+            else -> JsonTreeDecoder(json, cast(element, descriptor), descriptor, path, polymorphicDiscriminator)
         }
     }
 
-    inline fun <reified T : JsonElement> cast(value: JsonElement, descriptor: SerialDescriptor): T = cast(value, descriptor.serialName) { renderTagStack() }
-    inline fun <reified T : JsonElement> cast(value: JsonElement, serialName: String, tag: String): T = cast(value, serialName) { renderTagStack(tag) }
+    inline fun <reified T : JsonElement> cast(value: JsonElement, descriptor: SerialDescriptor): T =
+        cast(value, descriptor.serialName, path::getPath)
 
     override fun endStructure(descriptor: SerialDescriptor) {
-        // Nothing
+        path.popDescriptor()
     }
 
-    override fun decodeNotNullMark(): Boolean = currentObject() !is JsonNull
+    override fun decodeNotNullMark(): Boolean = currentElement() !is JsonNull
 
     @Suppress("NOTHING_TO_INLINE")
-    protected inline fun getPrimitiveValue(tag: String, descriptor: SerialDescriptor): JsonPrimitive =
-        cast(currentElement(tag), descriptor.serialName, tag)
+    protected inline fun getPrimitiveValue(descriptor: SerialDescriptor): JsonPrimitive =
+        cast(currentElement(), descriptor.serialName, path::getPath)
 
-    private inline fun <T : Any> getPrimitiveValue(tag: String, primitiveName: String, convert: JsonPrimitive.() -> T?): T {
-        val literal = cast<JsonPrimitive>(currentElement(tag), primitiveName, tag)
+    private inline fun <T : Any> getPrimitiveValue(primitiveName: String, convert: JsonPrimitive.() -> T?): T {
+        val literal = cast<JsonPrimitive>(currentElement(), primitiveName, path::getPath)
         try {
-            return literal.convert() ?: unparsedPrimitive(literal, primitiveName, tag)
+            return literal.convert() ?: unparsedPrimitive(literal, primitiveName)
         } catch (e: IllegalArgumentException) {
             // TODO: pass e as cause? (may conflict with #2590)
-            unparsedPrimitive(literal, primitiveName, tag)
+            unparsedPrimitive(literal, primitiveName)
         }
     }
 
-    private fun unparsedPrimitive(literal: JsonPrimitive, primitive: String, tag: String): Nothing {
+    private fun unparsedPrimitive(literal: JsonPrimitive, primitive: String): Nothing {
         val type = if (primitive.startsWith("i")) "an $primitive" else "a $primitive"
-        throw decodingExceptionOf("Failed to parse literal '$literal' as $type value", path = renderTagStack(tag)) {
-            currentObject().toString()
+        throw decodingExceptionOf("Failed to parse literal '$literal' as $type value", path = path.getPath()) {
+            currentElement().toString()
         }
     }
 
-    protected abstract fun currentElement(tag: String): JsonElement
+    // The element being decoded
+    protected open fun currentElement(): JsonElement = value
 
-    override fun decodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor): Int =
-        enumDescriptor.getJsonNameIndexOrThrow(json, getPrimitiveValue(tag, enumDescriptor).content)
+    // The name of the element being decoded, used in error messages only
+    protected open fun currentTag(): String = PRIMITIVE_TAG
 
-    override fun decodeTaggedNull(tag: String): Nothing? = null
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int =
+        enumDescriptor.getJsonNameIndexOrThrow(json, getPrimitiveValue(enumDescriptor).content, path)
 
-    override fun decodeTaggedNotNullMark(tag: String): Boolean = currentElement(tag) !== JsonNull
+    override fun decodeBoolean(): Boolean =
+        getPrimitiveValue("boolean", JsonPrimitive::booleanOrNull)
 
-    override fun decodeTaggedBoolean(tag: String): Boolean =
-        getPrimitiveValue(tag, "boolean", JsonPrimitive::booleanOrNull)
-
-    override fun decodeTaggedByte(tag: String) = getPrimitiveValue(tag, "byte") {
+    override fun decodeByte() = getPrimitiveValue("byte") {
         val result = parseLongImpl()
         if (result in Byte.MIN_VALUE..Byte.MAX_VALUE) result.toByte()
         else null
     }
 
-    override fun decodeTaggedShort(tag: String) = getPrimitiveValue(tag, "short") {
+    override fun decodeShort() = getPrimitiveValue("short") {
         val result = parseLongImpl()
         if (result in Short.MIN_VALUE..Short.MAX_VALUE) result.toShort()
         else null
     }
 
-    override fun decodeTaggedInt(tag: String) = getPrimitiveValue(tag, "int") {
+    override fun decodeInt() = getPrimitiveValue("int") {
         val result = parseLongImpl()
         if (result in Int.MIN_VALUE..Int.MAX_VALUE) result.toInt()
         else null
     }
 
-    override fun decodeTaggedLong(tag: String) = getPrimitiveValue(tag, "long") { parseLongImpl() }
+    override fun decodeLong() = getPrimitiveValue("long") { parseLongImpl() }
 
-    override fun decodeTaggedFloat(tag: String): Float {
-        val result = getPrimitiveValue(tag, "float") { float }
+    override fun decodeFloat(): Float {
+        val result = getPrimitiveValue("float") { float }
         val specialFp = json.configuration.allowSpecialFloatingPointValues
         if (specialFp || result.isFinite()) return result
-        throw InvalidFloatingPointDecoded(result, tag) { currentObject().toString() }
+        throw decodingExceptionOf(nonFiniteFpMessage(result, null), path.getPath(), specialFlowingValuesHint) { currentElement().toString() }
     }
 
-    override fun decodeTaggedDouble(tag: String): Double {
-        val result = getPrimitiveValue(tag, "double") { double }
+    override fun decodeDouble(): Double {
+        val result = getPrimitiveValue("double") { double }
         val specialFp = json.configuration.allowSpecialFloatingPointValues
         if (specialFp || result.isFinite()) return result
-        throw InvalidFloatingPointDecoded(result, tag) { currentObject().toString() }
+        throw decodingExceptionOf(nonFiniteFpMessage(result, null), path.getPath(), specialFlowingValuesHint) { currentElement().toString() }
     }
 
-    override fun decodeTaggedChar(tag: String): Char = getPrimitiveValue(tag, "char") { content.single() }
+    override fun decodeChar(): Char = getPrimitiveValue("char") { content.single() }
 
-    override fun decodeTaggedString(tag: String): String {
-        val value = cast<JsonPrimitive>(currentElement(tag), "string", tag)
+    override fun decodeString(): String {
+        val tag = currentTag()
+        val value = cast<JsonPrimitive>(currentElement(), "string", path::getPath)
         if (value !is JsonLiteral)
-            throw decodingExceptionOf("Expected string value for a non-null key '$tag', got null literal instead", renderTagStack(tag), coerceInputValuesHint) {
-                currentObject().toString()
+            throw decodingExceptionOf("Expected string value for a non-null key '$tag', got null literal instead", path.getPath(), coerceInputValuesHint) {
+                currentElement().toString()
             }
         if (!value.isString && !json.configuration.isLenient) {
-            throw decodingExceptionOf("String literal for value of key '$tag' should be quoted", renderTagStack(tag), lenientHint) {
-                currentObject().toString()
+            throw decodingExceptionOf("String literal for value of key '$tag' should be quoted", path.getPath(), lenientHint) {
+                currentElement().toString()
             }
         }
         return value.content
     }
 
-    override fun decodeTaggedInline(tag: String, inlineDescriptor: SerialDescriptor): Decoder {
-        return if (inlineDescriptor.isUnsignedNumber) {
-            val lexer = StringJsonLexer(json, getPrimitiveValue(tag, inlineDescriptor).content)
-            JsonDecoderForUnsignedTypes(lexer, json)
-        } else super.decodeTaggedInline(tag, inlineDescriptor)
-    }
-
     override fun decodeInline(descriptor: SerialDescriptor): Decoder {
-        return if (currentTagOrNull != null) super.decodeInline(descriptor)
-        else JsonPrimitiveDecoder(json, value, polymorphicDiscriminator).decodeInline(descriptor)
+        return if (descriptor.isUnsignedNumber) {
+            val lexer = StringJsonLexer(json, getPrimitiveValue(descriptor).content)
+            JsonDecoderForUnsignedTypes(lexer, json)
+        } else this
     }
 }
 
 private class JsonPrimitiveDecoder(
     json: Json,
     override val value: JsonElement,
-    polymorphicDiscriminator: String? = null
-) : AbstractJsonTreeDecoder(json, value, polymorphicDiscriminator) {
-
-    init {
-        pushTag(PRIMITIVE_TAG)
-    }
+    path: JsonPath,
+) : AbstractJsonTreeDecoder(json, value, path) {
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int = 0
-
-    override fun currentElement(tag: String): JsonElement {
-        require(tag == PRIMITIVE_TAG) { "This input can only handle primitives with '$PRIMITIVE_TAG' tag" }
-        return value
-    }
 }
 
 private open class JsonTreeDecoder(
     json: Json,
     override val value: JsonObject,
     descriptor: SerialDescriptor,
+    path: JsonPath,
     polymorphicDiscriminator: String? = null,
     private val polyDescriptor: SerialDescriptor? = null
-) : AbstractJsonTreeDecoder(json, value, polymorphicDiscriminator) {
+) : AbstractJsonTreeDecoder(json, value, path, polymorphicDiscriminator) {
 
     // Pointer to the current entry of JsonObject that is being decoded
     // NB: do not `override val value` in JsonTreeMapDecoder, otherwise this field won't be
@@ -221,7 +209,7 @@ private open class JsonTreeDecoder(
 
     private val elementMarker: JsonElementMarker? = if (configuration.explicitNulls) null else JsonElementMarker(descriptor)
 
-    // Cached results of entries.next() to be used in tagged protocol
+    // Cached results of entries.next() used directly by primitive and nested decoders
     private var currentName: String? = null
     private var currentValue: JsonElement? = null
 
@@ -238,9 +226,11 @@ private open class JsonTreeDecoder(
                 elementMarker?.mark(index)
                 currentName = key
                 currentValue = entry.value
+                path.updateDescriptorIndex(index)
                 return index
             }
             if (key != polymorphicDiscriminator && !descriptor.ignoreUnknownKeys(json)) {
+                path.updateDescriptorIndex(CompositeDecoder.UNKNOWN_NAME)
                 throwUnknownKey(key)
             }
         }
@@ -249,6 +239,7 @@ private open class JsonTreeDecoder(
             currentName = descriptor.getElementName(markerIndex)
             currentValue = null
         }
+        path.updateDescriptorIndex(markerIndex)
         return markerIndex
     }
 
@@ -263,16 +254,17 @@ private open class JsonTreeDecoder(
         return !(elementMarker?.isUnmarkedNull ?: false) && super.decodeNotNullMark()
     }
 
-    override fun elementName(descriptor: SerialDescriptor, index: Int): String =
-        currentName ?: descriptor.getElementName(index)
+    override fun currentElement(): JsonElement =
+        currentValue ?: currentName?.let(value::getValue) ?: value
 
-    override fun currentElement(tag: String): JsonElement = currentValue ?: value.getValue(tag)
+    override fun currentTag(): String = currentName ?: PRIMITIVE_TAG
 
     override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
         // polyDiscriminator needs to be preserved so the discriminator key can be filtered out.
         if (descriptor === polyDescriptor) {
+            path.pushDescriptor(descriptor)
             return JsonTreeDecoder(
-                json, cast(currentObject(), polyDescriptor), descriptor, polymorphicDiscriminator, polyDescriptor
+                json, cast(currentElement(), polyDescriptor), descriptor, path, polymorphicDiscriminator, polyDescriptor
             )
         }
 
@@ -282,7 +274,7 @@ private open class JsonTreeDecoder(
     private fun throwUnknownKey(key: String): Nothing {
         throw decodingExceptionOf(
             "Encountered an unknown key '$key'",
-            renderTagStack(),
+            path.getPath(),
             ignoreUnknownKeysHint
         ) { value.toString() }
     }
@@ -291,16 +283,12 @@ private open class JsonTreeDecoder(
 private class JsonTreeMapDecoder(
     json: Json,
     value: JsonObject,
-    descriptor: SerialDescriptor
-) : JsonTreeDecoder(json, value, descriptor) {
+    descriptor: SerialDescriptor,
+    path: JsonPath,
+) : JsonTreeDecoder(json, value, descriptor, path) {
     private val keys = value.keys.toList()
     private val size: Int = keys.size * 2
     private var position = -1
-
-    override fun elementName(descriptor: SerialDescriptor, index: Int): String {
-        val i = index / 2
-        return keys[i]
-    }
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         while (position < size - 1) {
@@ -310,30 +298,46 @@ private class JsonTreeMapDecoder(
         return CompositeDecoder.DECODE_DONE
     }
 
-    override fun currentElement(tag: String): JsonElement {
-        return if (position % 2 == 0) JsonPrimitive(tag) else value.getValue(tag)
+    override fun <T> decodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T>,
+        previousValue: T?
+    ): T {
+        val isMapKey = index and 1 == 0
+        return withMapKeyTracking(path, isMapKey) {
+            super.decodeSerializableElement(descriptor, index, deserializer, previousValue)
+        }
     }
 
-    override fun endStructure(descriptor: SerialDescriptor) {
-        // do nothing, maps do not have strict keys, so strict mode check is omitted
+    override fun currentElement(): JsonElement {
+        if (position < 0) return value
+        val key = keys[position / 2]
+        return if (position % 2 == 0) JsonPrimitive(key) else value.getValue(key)
     }
+
+    override fun currentTag(): String = if (position < 0) PRIMITIVE_TAG else keys[position / 2]
 }
 
-private class JsonTreeListDecoder(json: Json, override val value: JsonArray) : AbstractJsonTreeDecoder(json, value) {
+private class JsonTreeListDecoder(
+    json: Json,
+    override val value: JsonArray,
+    path: JsonPath,
+) : AbstractJsonTreeDecoder(json, value, path) {
     private val size = value.size
     private var currentIndex = -1
 
-    override fun elementName(descriptor: SerialDescriptor, index: Int): String = index.toString()
+    override fun currentElement(): JsonElement = if (currentIndex < 0) value else value[currentIndex]
 
-    override fun currentElement(tag: String): JsonElement {
-        return value[tag.toInt()]
-    }
+    override fun currentTag(): String = if (currentIndex < 0) PRIMITIVE_TAG else currentIndex.toString()
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         while (currentIndex < size - 1) {
             currentIndex++
+            path.updateDescriptorIndex(currentIndex)
             return currentIndex
         }
+        path.updateDescriptorIndex(CompositeDecoder.DECODE_DONE)
         return CompositeDecoder.DECODE_DONE
     }
 }

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
@@ -68,7 +68,7 @@ private open class DynamicInput(
     }
 
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
-        return decodeSerializableValuePolymorphic(deserializer, ::renderTagStack)
+        return decodeSerializableValuePolymorphic(deserializer, JsonPath(json.configuration)) { renderTagStack() }
     }
 
     private fun coerceInputValue(descriptor: SerialDescriptor, index: Int, tag: String): Boolean =

--- a/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
+++ b/formats/json/jsMain/src/kotlinx/serialization/json/internal/DynamicDecoders.kt
@@ -141,7 +141,7 @@ private open class DynamicInput(
     override fun decodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor): Int {
         val byTag = getByTag(tag)
         val enumValue = byTag as? String ?: throw SerializationException("Enum value must be a string, got '$byTag'")
-        return enumDescriptor.getJsonNameIndexOrThrow(json, enumValue)
+        return enumDescriptor.getJsonNameIndexOrThrow(json, enumValue, null)
     }
 
     protected open fun getByTag(tag: String): dynamic = value[tag]


### PR DESCRIPTION
Make `AbstractJsonTreeDecoder` to extend `AbstractDecoder` decoder directly.

It gets rid of a slow-for-no-reason tag stack system and uses more straightforward, faster decoding.
Apart from performance, it also comes with nice benefits along the way:

* Easy and non-duplicating JsonPath integration, so proper paths in exceptions
* Shared code with the streaming mode, so less duplication
* More consistent exception messages
* A random performance improvement in enum decoding

Performance gain is around ~30%

Fixes #3249
Fixes #3170